### PR TITLE
rewrite flash

### DIFF
--- a/spec/amber/router/pipe/flash_spec.cr
+++ b/spec/amber/router/pipe/flash_spec.cr
@@ -9,17 +9,135 @@ module Amber
 
   module Router
     describe Flash::FlashStore do
-      describe ".from_session_value" do
-        it "sweeps the flash store when accessed" do
-          discard = ["some_key"].to_set
+      
+      describe ".from_session" do
+        it "creates a flash store from json" do
           flashes = {"some_key" => "some_value"}
-          json = {"flashes" => flashes, "discard" => discard}.to_json
-          flash_store = Flash::FlashStore.from_session_value json
-
-          flash_store["some_key"].should be_nil
-          flash_store[:some_key].should be_nil
-          flash_store.has_key?("some_key").should be_falsey
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+          
+          flash_store.has_key?("some_key").should be_true
+          flash_store["some_key"].should eq "some_value"
         end
+
+        it "returns an empty flash store if json is invalid" do
+          json = "some_key=some_value"
+          flash_store = Flash::FlashStore.from_session json
+
+          flash_store.has_key?("some_key").should be_false
+        end
+      end
+
+      describe "#fetch" do
+        it "returns the value" do
+          flashes = {"some_key" => "some_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+          
+          flash_store.fetch("some_key").should eq "some_value"
+        end
+
+        it "supports symbols" do
+          flashes = {"some_key" => "some_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+          
+          flash_store.fetch(:some_key).should eq "some_value"
+        end
+
+        it "marks the value as read" do
+          flashes = {"some_key" => "some_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+          flash_store.fetch("some_key")
+          flash_store = Flash::FlashStore.from_session flash_store.to_session
+
+          flash_store.has_key?("some_key").should be_false
+        end
+      end
+
+      describe "#each" do
+        it "returns the list of key/value pairs" do
+          flashes = {"some_key" => "some_value", "other_key" => "other_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+          test = Hash(String, String).new
+          flash_store.each {|k,v| test[k] = v}
+          test.size.should eq 2
+        end
+
+        it "marks the keys as read" do
+          flashes = {"some_key" => "some_value", "other_key" => "other_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+          test = Hash(String, String).new
+          flash_store.each {|k,v| test[k] = v}
+          flash_store = Flash::FlashStore.from_session flash_store.to_session
+
+          flash_store.has_key?("some_key").should be_false
+        end
+      end
+
+      describe "#now" do
+        it "does not keep key even if never read" do
+          flash_store = Flash::FlashStore.new
+          flash_store.now("some_key", "some_value")
+          flash_store = Flash::FlashStore.from_session flash_store.to_session
+          flash_store.has_key?("some_key").should be_false
+        end
+      end
+
+      describe "#keep" do
+        it "keeps the key after being read" do
+          flashes = {"some_key" => "some_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+          flash_store.fetch("some_key")
+          flash_store.keep("some_key")
+          flash_store = Flash::FlashStore.from_session flash_store.to_session
+
+          flash_store.has_key?("some_key").should be_true
+        end
+      end
+
+      describe "<< Hash" do
+        it "supports [] with String" do
+          flashes = {"some_key" => "some_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+
+          flash_store["some_key"].should eq "some_value"
+        end
+
+        it "supports [] with Symbol" do
+          flashes = {"some_key" => "some_value"}
+          json = flashes.to_json
+          flash_store = Flash::FlashStore.from_session json
+
+          flash_store[:some_key].should eq "some_value"
+        end
+
+        it "supports []= with String" do
+          flash_store = Flash::FlashStore.new
+          flash_store["some_key"] = "some_value"
+
+          flash_store["some_key"].should eq "some_value"
+        end
+
+        it "supports []= with Symbol" do
+          flash_store = Flash::FlashStore.new
+          flash_store[:some_key] = "some_value"
+
+          flash_store[:some_key].should eq "some_value"
+        end
+
+        it "supports []= with Symbol but reading with String" do
+          flash_store = Flash::FlashStore.new
+          flash_store[:some_key] = "some_value"
+
+          flash_store["some_key"].should eq "some_value"
+        end
+        
       end
     end
   end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -49,7 +49,7 @@ class HTTP::Server::Context
   end
 
   def flash
-    @flash ||= Amber::Router::Flash.from_session_value(session.fetch(Amber::Pipe::Flash::PARAM_KEY, "{}"))
+    @flash ||= Amber::Router::Flash.from_session(session.fetch(Amber::Pipe::Flash::PARAM_KEY, "{}"))
   end
 
   def websocket?

--- a/src/amber/router/pipe/flash.cr
+++ b/src/amber/router/pipe/flash.cr
@@ -70,6 +70,7 @@ module Amber
 
         def keep(key = nil)
           @read.delete key
+          @now.delete key
         end
 
         def alert

--- a/src/amber/router/pipe/flash.cr
+++ b/src/amber/router/pipe/flash.cr
@@ -19,132 +19,57 @@ module Amber
 
   module Router
     module Flash
-      def self.from_session_value(flash_content)
-        FlashStore.from_session_value(flash_content)
+
+      def self.from_session(flash_content)
+        FlashStore.from_session(flash_content)
       end
 
-      class FlashNow
-        property :flash
-
-        def initialize(flash)
-          @flash = flash
-        end
-
-        def []=(key, value)
-          @flash[key] = value
-          @flash.discard(key)
-          value
-        end
-
-        def [](k)
-          @flash[k.to_s]
-        end
-
-        # Convenience accessor for <tt>flash.now["alert"]=</tt>.
-        def alert=(message)
-          self["alert"] = message
-        end
-
-        # Convenience accessor for <tt>flash.now["notice"]=</tt>.
-        def notice=(message)
-          self["notice"] = message
-        end
-      end
-
-      class FlashStore
-        include Enumerable(String)
-
-        JSON.mapping({
-          flashes: Hash(String | Symbol, String),
-          discard: Set(String),
-        })
-
-        def self.from_session_value(json)
-          from_json(json).tap(&.sweep)
+      class FlashStore < Hash(String, String)
+        def self.from_session(json)
+          flash = new
+          values = JSON.parse(json)
+          values.each {|k,v| flash[k.to_s] = v.to_s}
+          flash
         rescue e : JSON::ParseException
           new
         end
 
-        delegate :each, to: :flashes
-
         def initialize
-          @flashes = Hash(String | Symbol, String).new
-          @discard = Set(String).new
+          @read = [] of String
+          @now = [] of String
+          super
         end
 
-        def discard=(value : Array(String))
-          @discard = value.to_set
+        def fetch(key : String)
+          @read << key
+          super
         end
 
-        def []=(key, value)
-          k = key.to_s
-          @discard.delete k
-          @flashes[k] = value
+        def fetch(key : Symbol)
+          fetch key.to_s
         end
 
-        def [](key)
-          @flashes[key.to_s]?
+        def []=(key : Symbol, value : String)
+          self[key.to_s] = value
         end
 
-        def update(hash : Hash(String, String)) # :nodoc:
-          @discard.subtract hash.keys
-          @flashes.update hash
-          self
-        end
-
-        def keys
-          @flashes.keys
-        end
-
-        def has_key?(key)
-          @flashes.has_key?(key.to_s)
-        end
-
-        def delete(key)
-          @discard.delete key.to_s
-          @flashes.delete key.to_s
-          self
-        end
-
-        def merge!(other : Hash(String, String))
-          other.each do |k, v|
-            @flashes[k.to_s] = v
+        def each
+          current = @first
+          while current
+            yield({current.key, current.value})
+            @read << current.key
+            current = current.fore
           end
           self
         end
 
-        def to_hash
-          @flashes.dup
-        end
-
-        def empty?
-          @flashes.empty?
-        end
-
-        def clear
-          @discard.clear
-          @flashes.clear
-        end
-
-        def now
-          @now ||= FlashNow.new(self)
+        def now(key, value)
+          @now << key
+          self[key] = value
         end
 
         def keep(key = nil)
-          k = key.to_s if key
-          @discard.subtract k
-          k ? self[k] : self
-        end
-
-        def discard(key = nil)
-          k = key ? [key.to_s] : self.keys.map(&.to_s)
-          @discard.concat k.to_set
-          k ? self[k] : self
-        end
-
-        def sweep
-          @discard.each { |k| @flashes.delete k }
-          @discard = @discard.map(&.to_s).to_set | @flashes.keys.map(&.to_s).to_set
+          @read.delete key
         end
 
         def alert
@@ -164,7 +89,7 @@ module Amber
         end
 
         def to_session
-          {"flashes": @flashes, "discard": @discard}.to_json
+          reject { |key, _| @read.includes? key }.reject { |key, _| @now.includes? key }.to_json
         end
       end
     end


### PR DESCRIPTION
### Description of the Change

This change rewrites the Flash to avoid storing both `flashes` and `discards` in the session.  This simplifies the `to_session` and `from_session` by only storing flash messages that need to be maintained between request cycles.

This also includes full test coverage which was missing.

This also goes back to using an inheritance design pattern instead of the delegate pattern.  This avoids needing to delegate all the methods a Hash provides and instead leverage them and only overwriting the methods needed.

This also simplifies the `now` method by always rejecting it from the `to_session` method.

This also adds support for accessing the flash with either a Symbol or a String.

### Alternate Designs

Using a delegate pattern instead of an inheritance pattern. I would argue that the FlashStore is a Hash and extends the functionality to allow for remembering if a key should be included in the serialization for storing in the session.

### Benefits

This simplifies the Flash capabilities and removes some of the complexity.

### Possible Drawbacks

none I can think of