### PR TITLE
Updates docs url

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Amber Crystal borrows concepts that already have been battle tested, successful,
 
 ## Read the Docs
 
-Documentation https://docs.ambercr.io
+Documentation https://docs.amberframework.org
 
 
 ## Benchmark


### PR DESCRIPTION
This change removes doc.sambercr.io in favor of docs.amberframework.org