### PR TITLE
Fix #262 and #245

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ OUT_DIR=bin
 
 all: build force_link
 
+install: build
+	sudo cp `pwd`/bin/amber /usr/local/bin/amber
+
 build:
 	@echo "Building amber in $(shell pwd)"
 	@mkdir -p $(OUT_DIR)

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ clean:
 	rm -rf  $(OUT_DIR) .crystal .shards libs lib
 
 link:
-	sudo ln -s `pwd`/bin/amber /usr/local/bin/amber
+	@ln -s `pwd`/bin/amber /usr/local/bin/amber
 
 force_link:
 	@echo "Symlinking `pwd`/bin/amber to /usr/local/bin/amber"
-	sudo ln -sf `pwd`/bin/amber /usr/local/bin/amber
+	@ln -sf `pwd`/bin/amber /usr/local/bin/amber

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Once you have these dependencies, You can build the `amber` tool from source:
 $ git clone git@github.com:amberframework/amber.git
 $ cd amber/
 $ shards install
-$ make
+$ make install
 ```
 
 ##### For ArchLinux & derivates


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Currently we are using `make` for both deploy and local install on Linux, but `sudo make` is insecure (see: #245 ) and `sudo` isn't available in docker containers (see: #262 ) so this PR adds a `make install` option for install in local machines asking for password when needed and keep `make` for docker containers.

Also `make install` copy amber instead of linking because we are using the same behavior [here](https://github.com/amberframework/amber-aur/blob/master/PKGBUILD#L21)

### Alternate Designs

Nop

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Truly Fix #245 and #262 

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Nop

<!-- What are the possible side-effects or negative impacts of the code change? -->
