### PR TITLE
Render Refactor [Breaking Change] - Also fixes some things

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -80,6 +80,28 @@ module Amber::Controller
         request = HTTP::Request.new("GET", "/?test=test")
         context = create_context(request)
         html_output = <<-HTML
+        <html>
+          <body>
+            <h1>
+              <h1>Hello World</h1>
+        <p>I am glad you came</p>
+            </h1>
+            <h2>
+              <p>second partial</p>
+            </h2>
+            <h1>Hello World</h1>
+        <p>I am glad you came</p>
+          </body>
+        </html>
+        HTML
+
+        TestController.new(context).render_multiple_partials_in_layout.should eq html_output
+      end
+
+      it "renders html and layout from slang template" do
+        request = HTTP::Request.new("GET", "/?test=test")
+        context = create_context(request)
+        html_output = <<-HTML
         <html>\n  <body>\n    <h1>Hello World</h1>\n<p>I am glad you came</p>\n  </body>\n</html>
         HTML
 

--- a/spec/amber/router/pipe/flash_spec.cr
+++ b/spec/amber/router/pipe/flash_spec.cr
@@ -9,13 +9,12 @@ module Amber
 
   module Router
     describe Flash::FlashStore do
-      
       describe ".from_session" do
         it "creates a flash store from json" do
           flashes = {"some_key" => "some_value"}
           json = flashes.to_json
           flash_store = Flash::FlashStore.from_session json
-          
+
           flash_store.has_key?("some_key").should be_true
           flash_store["some_key"].should eq "some_value"
         end
@@ -33,7 +32,7 @@ module Amber
           flashes = {"some_key" => "some_value"}
           json = flashes.to_json
           flash_store = Flash::FlashStore.from_session json
-          
+
           flash_store.fetch("some_key").should eq "some_value"
         end
 
@@ -41,7 +40,7 @@ module Amber
           flashes = {"some_key" => "some_value"}
           json = flashes.to_json
           flash_store = Flash::FlashStore.from_session json
-          
+
           flash_store.fetch(:some_key).should eq "some_value"
         end
 
@@ -62,7 +61,7 @@ module Amber
           json = flashes.to_json
           flash_store = Flash::FlashStore.from_session json
           test = Hash(String, String).new
-          flash_store.each {|k,v| test[k] = v}
+          flash_store.each { |k, v| test[k] = v }
           test.size.should eq 2
         end
 
@@ -71,7 +70,7 @@ module Amber
           json = flashes.to_json
           flash_store = Flash::FlashStore.from_session json
           test = Hash(String, String).new
-          flash_store.each {|k,v| test[k] = v}
+          flash_store.each { |k, v| test[k] = v }
           flash_store = Flash::FlashStore.from_session flash_store.to_session
 
           flash_store.has_key?("some_key").should be_false
@@ -137,7 +136,6 @@ module Amber
 
           flash_store["some_key"].should eq "some_value"
         end
-        
       end
     end
   end

--- a/spec/amber/server/environment_spec.cr
+++ b/spec/amber/server/environment_spec.cr
@@ -3,22 +3,21 @@ require "../../../spec_helper"
 describe Amber::Server do
   describe "environment" do
     it "should load expected output" do
-
-expected = <<-EXP
+      expected = <<-EXP
       @@name = "amber_test_app"
       @@port_reuse = true
       @@process_count = (ENV[%(AMBER_PROCESS_COUNT)]? || 1).to_i
       @@log = ::Logger.new(STDOUT)
       @@log.level = ::Logger::INFO
       @@color = true
-      @@redis_url = "\#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
+      @@redis_url = "#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
       @@port = 3000
       @@host = "0.0.0.0"
-      @@secret_key_base = \"mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
+      @@secret_key_base = "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
       @@session = {
-      :key => "amber.session",
-      :store => :signed_cookie,
-      :expires => 0,
+        :key => "amber.session",
+        :store => :signed_cookie,
+        :expires => 0, 
       }
       class_getter secrets = {"description": "Store your test secrets credentials and settings here.", "database": "mysql://root@localhost:3306/amber_test_app_test"}
 

--- a/spec/amber/server/environment_spec.cr
+++ b/spec/amber/server/environment_spec.cr
@@ -10,7 +10,7 @@ describe Amber::Server do
       @@log = ::Logger.new(STDOUT)
       @@log.level = ::Logger::INFO
       @@color = true
-      @@redis_url = "#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
+      @@redis_url = "\#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
       @@port = 3000
       @@host = "0.0.0.0"
       @@secret_key_base = "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -62,20 +62,24 @@ class TestController < Amber::Controller::Base
   end
 
   def render_partial
-    render("spec/support/sample/views/test/_test.slang")
+    render(partial: "spec/support/sample/views/test/_test.slang")
   end
 
   def render_with_layout
-    render("test/test.slang", "layout.slang", "spec/support/sample/views", "./")
+    render("test/test.slang", layout: "layout.slang", path: "spec/support/sample/views", folder: "./")
+  end
+
+  def render_multiple_partials_in_layout
+    render("test/test.slang", layout: "layout_with_partials.slang", path: "spec/support/sample/views", folder: "./")
   end
 
   def render_with_csrf
-    render("spec/support/sample/views/test/_form.slang", layout: false)
+    render(partial: "spec/support/sample/views/test/_form.slang")
   end
 
   def render_with_flash
     flash["error"] = "Displays error Message!"
-    render("spec/support/sample/views/test/flash.slang", false)
+    render("spec/support/sample/views/test/flash.slang", layout: false)
   end
 end
 

--- a/spec/support/sample/views/layouts/layout.slang
+++ b/spec/support/sample/views/layouts/layout.slang
@@ -1,4 +1,3 @@
 html
   body
     == content
- 

--- a/spec/support/sample/views/layouts/layout_with_partials.slang
+++ b/spec/support/sample/views/layouts/layout_with_partials.slang
@@ -1,0 +1,7 @@
+html
+  body
+    h1
+      == render(partial: "spec/support/sample/views/test/_test.slang")
+    h2
+      == render(partial: "spec/support/sample/views/test/_test2.slang")
+    == content

--- a/spec/support/sample/views/test/_test2.slang
+++ b/spec/support/sample/views/test/_test2.slang
@@ -1,0 +1,1 @@
+p second partial

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -11,7 +11,7 @@
     <div class="masthead">
       <div class="container">
         <nav class="nav">
-          <%="<"%>%= render_template "layouts/_nav.<%= @language %>" %>
+          <%="<"%>%= render(partial: "layouts/_nav.<%= @language %>") %>
         </nav>
       </div>
     </div>

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -11,7 +11,7 @@ html
     div.masthead
       div.container
         nav.nav
-          == render_template "layouts/_nav.slang"
+          == render(partial: "layouts/_nav.slang")
     div.container
       div.row
       - flash.each do |key, value|
@@ -24,5 +24,3 @@ html
     script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"
     script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"
     script src="/dist/main.bundle.js"
-
-

--- a/src/amber/cli/templates/scaffold.cr
+++ b/src/amber/cli/templates/scaffold.cr
@@ -63,7 +63,7 @@ module Amber::CLI
     end
 
     def visible_fields
-      @fields.reject{|f|f.hidden}.map do |f|
+      @fields.reject { |f| f.hidden }.map do |f|
         f.reference? ? "#{f.name}_id" : f.name
       end
     end

--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -2,7 +2,7 @@ module Amber::Controller
   module Render
     LAYOUT = "application.slang"
 
-    macro render_template(filename, path = "src/views")
+    private macro render_template(filename, path = "src/views")
       {% if filename.id.split("/").size > 2 %}
         Kilt.render("{{filename.id}}")
       {% else %}
@@ -10,22 +10,29 @@ module Amber::Controller
       {% end %}
     end
 
-    macro render(filename, layout = true, path = "src/views", folder = __FILE__)
-      # NOTE: content is basically yield rails layouts.
-      {% if filename.id.split("/").size > 1 %}
-        content = render_template("#{{{filename}}}", {{path}})
-      {% else %}
-        {% if folder.id.ends_with?(".ecr") %}
-          content = render_template("#{{{folder.split("/")[-2]}}}/#{{{filename}}}", {{path}})
-        {% else %}
-          content = render_template("#{{{folder.split("/").last.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}", {{path}})
-        {% end %}
-      {% end %}
+    macro render(template = nil, partial = nil, layout = true, path = "src/views", folder = __FILE__)
+      {% if template || partial %}
+        {{filename = template || partial}}
 
-      {% if layout && !filename.id.split("/").last.starts_with?("_") %}
-        content = render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
+        {% if filename.id.split("/").size > 1 %}
+          %content = render_template("#{{{filename}}}", {{path}})
+        {% else %}
+          {% if folder.id.ends_with?(".ecr") %}
+            %content = render_template("#{{{folder.split("/")[-2]}}}/#{{{filename}}}", {{path}})
+          {% else %}
+            %content = render_template("#{{{folder.split("/").last.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}", {{path}})
+          {% end %}
+        {% end %}
+
+        {% if layout && !partial %}
+          content = %content
+          %content = render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
+        {% else %}
+          %content
+        {% end %}
+      {% else %}
+        raise "Template or partial required!"
       {% end %}
-      content
     end
   end
 end

--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -2,14 +2,6 @@ module Amber::Controller
   module Render
     LAYOUT = "application.slang"
 
-    private macro render_template(filename, path = "src/views")
-      {% if filename.id.split("/").size > 2 %}
-        Kilt.render("{{filename.id}}")
-      {% else %}
-        Kilt.render("#{{{path}}}/{{filename.id}}")
-      {% end %}
-    end
-
     macro render(template = nil, partial = nil, layout = true, path = "src/views", folder = __FILE__)
       {% if !(template || partial) %}
         raise "Template or partial required!"
@@ -32,6 +24,14 @@ module Amber::Controller
         render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
       {% else %}
         %content
+      {% end %}
+    end
+
+    private macro render_template(filename, path = "src/views")
+      {% if filename.id.split("/").size > 2 %}
+        Kilt.render("{{filename.id}}")
+      {% else %}
+        Kilt.render("#{{{path}}}/{{filename.id}}")
       {% end %}
     end
   end

--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -11,27 +11,27 @@ module Amber::Controller
     end
 
     macro render(template = nil, partial = nil, layout = true, path = "src/views", folder = __FILE__)
-      {% if template || partial %}
-        {{filename = template || partial}}
-
-        {% if filename.id.split("/").size > 1 %}
-          %content = render_template("#{{{filename}}}", {{path}})
-        {% else %}
-          {% if folder.id.ends_with?(".ecr") %}
-            %content = render_template("#{{{folder.split("/")[-2]}}}/#{{{filename}}}", {{path}})
-          {% else %}
-            %content = render_template("#{{{folder.split("/").last.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}", {{path}})
-          {% end %}
-        {% end %}
-
-        {% if layout && !partial %}
-          content = %content
-          %content = render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
-        {% else %}
-          %content
-        {% end %}
-      {% else %}
+      {% if !(template || partial) %}
         raise "Template or partial required!"
+      {% end %}
+
+      {{filename = template || partial}}
+
+      {% if filename.id.split("/").size > 1 %}
+        %content = render_template("#{{{filename}}}", {{path}})
+      {% else %}
+        {% if folder.id.ends_with?(".ecr") %}
+          %content = render_template("#{{{folder.split("/")[-2]}}}/#{{{filename}}}", {{path}})
+        {% else %}
+          %content = render_template("#{{{folder.split("/").last.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}", {{path}})
+        {% end %}
+      {% end %}
+
+      {% if layout && !partial %}
+        content = %content
+        render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
+      {% else %}
+        %content
       {% end %}
     end
   end

--- a/src/amber/router/cookies.cr
+++ b/src/amber/router/cookies.cr
@@ -227,7 +227,7 @@ module Amber::Router
       end
     end
 
-    class EncryptedStore 
+    class EncryptedStore
       include ChainedStore
       include SerializedStore
 

--- a/src/amber/router/pipe/flash.cr
+++ b/src/amber/router/pipe/flash.cr
@@ -19,7 +19,6 @@ module Amber
 
   module Router
     module Flash
-
       def self.from_session(flash_content)
         FlashStore.from_session(flash_content)
       end
@@ -28,7 +27,7 @@ module Amber
         def self.from_session(json)
           flash = new
           values = JSON.parse(json)
-          values.each {|k,v| flash[k.to_s] = v.to_s}
+          values.each { |k, v| flash[k.to_s] = v.to_s }
           flash
         rescue e : JSON::ParseException
           new

--- a/src/amber/server/environment.cr
+++ b/src/amber/server/environment.cr
@@ -54,11 +54,13 @@ str = String.build do |s|
   end
 
   if settings["session"]? && settings["session"].raw.is_a?(Hash(YAML::Type, YAML::Type))
-    s.puts %(@@session = {)
-      s.puts %(:key => "#{settings["session"]["key"]? ? settings["session"]["key"] : "amber.session"}",)
-      s.puts %(:store => #{settings["session"]["store"]? ? settings["session"]["store"] : :signed_cookie},)
-      s.puts %(:expires => #{settings["session"]["expires"]? ? settings["session"]["expires"] : 0},) 
-    s.puts %(})
+    s.puts <<-SESSION
+    @@session = {
+      :key => "#{settings["session"]["key"]? ? settings["session"]["key"] : "amber.session"}",
+      :store => #{settings["session"]["store"]? ? settings["session"]["store"] : ":signed_cookie"},
+      :expires => #{settings["session"]["expires"]? ? settings["session"]["expires"] : 0}, 
+    }
+    SESSION
   else
     s.puts %(@@session = {:key => "amber.session", :store => :signed_cookie, :expires => 0})
   end


### PR DESCRIPTION
### Description of the Change

Fixes bug that @eliasjpr found where you couldn't use render multiple times in the same project as content would overwrite the previous content.

Adds `partial` and `template` as  named params to render, this makes render closer to rails so it should be familiar to more people.

1. `render(partial: "_form.slang")` will render supplied file without layout.
2. `render("show.slang", layout: false)` will render template without layout.
3. `render("show.slang")` will render supplied file with default layout.

### Possible issues.

Breaking change as `render("template", false)` has been replaced with the more verbose  `render("template", layout: false)`.
`render_template` is an internal helper macro and shouldn't be use. It is now private.
