### PR TITLE
Fix for video in safari

### DIFF
--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -135,7 +135,7 @@ module Amber
           env.response.status_code = 206
           env.response.content_length = endb - startb
           env.response.headers["Accept-Ranges"] = "bytes"
-          env.response.headers["Content-Range"] = "bytes #{startb}-#{endb - 1}/#{fileb}" # MUST
+          env.response.headers["Content-Range"] = "bytes #{startb}-#{endb}/#{fileb}" # MUST
 
           if startb > 1024
             skipped = 0

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -133,7 +133,7 @@ module Amber
 
         if startb < endb && endb <= fileb
           env.response.status_code = 206
-          env.response.content_length = endb - startb
+          env.response.content_length = (endb - startb) + 1
           env.response.headers["Accept-Ranges"] = "bytes"
           env.response.headers["Content-Range"] = "bytes #{startb}-#{endb}/#{fileb}" # MUST
 

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -128,7 +128,7 @@ module Amber
         end
 
         if endb == 0
-          endb = fileb
+          endb = fileb - 1
         end
 
         if startb < endb && endb <= fileb


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

> Video doesn't work in safari.

> It seem to be to do with the content-range header. Safari initially asked for the first byte.
> However with a single byte request, the header outputs
> bytes 0-0/1000 (if this file is 1000 bytes in size)

> It does work however if we make the end value 1. But removing the -1 it breaks it in chrome. So I suggest this change, which means the end can't be smaller than 1.

Following https://github.com/kemalcr/kemal/pull/405 by @crisward 

### Alternate Designs

Nop

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits


Video works on safari

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Nop

<!-- What are the possible side-effects or negative impacts of the code change? -->
