### PR TITLE
ClientSocket `on_disconnect` public method

### DIFF
--- a/spec/amber/websockets/client_socket_spec.cr
+++ b/spec/amber/websockets/client_socket_spec.cr
@@ -106,6 +106,21 @@ module Amber
       end
     end
 
+    describe "#on_disconnect" do
+      it "should get called on socket disconnect" do
+        chan = Channel(String).new
+        http_server, ws = create_socket_server
+        client_socket = Amber::WebSockets::ClientSockets.client_sockets.values.first
+        ws.on_close &->(msg : String) { chan.send("closed") }
+        ws.close
+
+        chan.receive
+        client_socket.as(UserSocket).test_field[0].should eq "on close #{client_socket.id}"
+        client_socket.disconnect!
+        http_server.close
+      end
+    end
+
     context "#on_message" do
       describe "join event" do
         it "should add a subscription" do

--- a/spec/support/factories.cr
+++ b/spec/support/factories.cr
@@ -84,7 +84,13 @@ class TestController < Amber::Controller::Base
 end
 
 struct UserSocket < Amber::WebSockets::ClientSocket
+  property test_field = Array(String).new
+
   channel "user_room:*", UserChannel
+
+  def on_disconnect(**args)
+    test_field.push("on close #{self.id}")
+  end
 end
 
 class UserChannel < Amber::WebSockets::Channel

--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -73,17 +73,20 @@ module Amber
         end
       end
 
-      def session
-        @session ||= @context.session
-      end
-
-      def cookies
-        @cookies ||= @context.cookies
-      end
-
       # Authentication and authorization can happen here
       def on_connect : Bool
         true
+      end
+
+      # On socket disconnect functionality
+      def on_disconnect; end
+
+      protected def session
+        @session ||= @context.session
+      end
+
+      protected def cookies
+        @cookies ||= @context.cookies
       end
 
       # Sends ping opcode to client : https://tools.ietf.org/html/rfc6455#section-5.5.2

--- a/src/amber/websockets/server.cr
+++ b/src/amber/websockets/server.cr
@@ -16,6 +16,7 @@ module Amber
           end
 
           socket.on_close do
+            instance.on_disconnect
             ClientSockets.remove_client_socket(instance)
           end
         end


### PR DESCRIPTION
closes #288 

### Description of the Change

A method doesn't exist for handling `ClientSocket` disconnects within the application.  There was already an `on_connect` public method, this adds a public `on_disconnect` method that can be optionally overritten for functionality when the client disconnects.
