### PR TITLE
Add X-Content-Type-Options = "nosniff"

### DIFF
--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -83,6 +83,7 @@ module Amber
         mime_type ||= mime_type(file_path)
         env.response.content_type = mime_type
         env.response.headers["Accept-Ranges"] = "bytes"
+        env.response.headers["X-Content-Type-Options"] = "nosniff"
         minsize = 860 # http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits ??
         request_headers = env.request.headers
         filesize = File.size(file_path)


### PR DESCRIPTION
### Description of the Change

Add security header for older browsers to prevent content sniffing. Inspired by https://github.com/kemalcr/kemal/issues/379

### Alternate Designs

Nop

### Benefits

Zap, Owasps pen testing tool suggests adding X-Content-Type-Options: nosniff header to static files.

### Possible Drawbacks

Nop
