### PR TITLE
Removed spinner fork from shard after getting it merged into upstream project.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -57,7 +57,7 @@ dependencies:
     version: ~> 0.9.1
 
   spinner:
-    github: elorest/spinner 
+    github: askn/spinner
 
   pg:
     github: will/crystal-pg


### PR DESCRIPTION
### Description of the Change

Partially resolves https://github.com/amberframework/amber/issues/261.

I got the fix to spinner merged into the upstream branch, so shard.yml has been modified to point to it instead of the fork.

The following forks still need resolved.

* https://github.com/TechMagister/crystal-icr by @TechMagister
* https://github.com/TechMagister/sentry by @TechMagister