### PR TITLE
Prevent lower case request methods (i.e. put)

### DIFF
--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -39,6 +39,15 @@ describe HTTP::Server::Context do
           context.request.method.should eq "PATCH"
         end
       end
+
+      it "overrides form request method only by upper case value" do
+        header = HTTP::Headers.new
+        header["content-type"] = "application/x-www-form-urlencoded"
+        request = HTTP::Request.new("GET", "/?test=test", header, "_method=put")
+
+        context = create_context(request)
+        context.request.method.should eq "PUT"
+      end
     end
 
     it "overrides form POST method to PUT, PATCH, DELETE" do

--- a/spec/amber/router/pipe/csrf_spec.cr
+++ b/spec/amber/router/pipe/csrf_spec.cr
@@ -5,7 +5,7 @@ module Amber
     describe CSRF do
       context "when requests have HTTP methods" do
         CSRF::CHECK_METHODS.each do |method|
-          it "raises forbbiden error for PUT request" do
+          it "raises forbidden error for #{method} request" do
             csrf = CSRF.new
 
             request = HTTP::Request.new(method, "/")


### PR DESCRIPTION
### Description of the Change

`a href="/path?_method=PUT` fails because of CSRF, but `a href="/path?_method=put` doesn't, which opens a hole for cross site forgery attack. This change is about to fix it.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
