### PR TITLE
Fixes bug with release being undefined and adds --no-debug to production run

### DIFF
--- a/src/amber/cli/commands/run.cr
+++ b/src/amber/cli/commands/run.cr
@@ -19,9 +19,13 @@ module Amber::CLI
       end
 
       def run
-        release = "--release" if options.e.downcase == "production"
+        build_options = Array(String)
+        build_options << "--release" if options.e.downcase == "production"
+        build_options << "--no-debug" if options.e.downcase == "production"
+        build_options << " " if build_options.size > 0
+
         puts colorize("💎  Crystalizing...", :dark_gray)
-        `crystal build #{release} $(ls ./src/*.cr | sort -n | head -1) -o app`
+        `crystal build #{build_options.join(" ")}$(ls ./src/*.cr | sort -n | head -1) -o app`
         puts colorize("💎  Crystalization complete!", :dark_gray)
         Process.run(
           "PORT=#{options.p} AMBER_ENV=#{options.e} ./app",

--- a/src/amber/cli/commands/run.cr
+++ b/src/amber/cli/commands/run.cr
@@ -19,7 +19,7 @@ module Amber::CLI
       end
 
       def run
-        build_options = Array(String)
+        build_options = Array(String).new
         build_options << "--release" if options.e.downcase == "production"
         build_options << "--no-debug" if options.e.downcase == "production"
         build_options << " " if build_options.size > 0

--- a/src/amber/cli/commands/run.cr
+++ b/src/amber/cli/commands/run.cr
@@ -19,13 +19,10 @@ module Amber::CLI
       end
 
       def run
-        build_options = Array(String).new
-        build_options << "--release" if options.e.downcase == "production"
-        build_options << "--no-debug" if options.e.downcase == "production"
-        build_options << " " if build_options.size > 0
-
         puts colorize("💎  Crystalizing...", :dark_gray)
-        `crystal build #{build_options.join(" ")}$(ls ./src/*.cr | sort -n | head -1) -o app`
+        compile_command = "crystal build $(ls ./src/*.cr | sort -n | head -1) -o app"
+        compile_command += " --release --no-debug" if %w(development test).includes?(options.e.downcase)
+        system(compile_command)
         puts colorize("💎  Crystalization complete!", :dark_gray)
         Process.run(
           "PORT=#{options.p} AMBER_ENV=#{options.e} ./app",


### PR DESCRIPTION
### Description of the Change

This allows it to work with LLVM 4.0 on linux.
Also saves a bit of time on compiling.
Fixes bug where if run command was used for development or test it would error because #{release} didn't exist.
Fixes issue https://github.com/amberframework/amber/issues/308