### PR TITLE
Ensures method missing returns Bool Type

### DIFF
--- a/spec/amber/server/environment_spec.cr
+++ b/spec/amber/server/environment_spec.cr
@@ -12,6 +12,16 @@ describe Amber do
         amber_env = Amber::Environment.new "invalid environment"
         amber_env.{{env.id}}?.should be_falsey
       end
+
+      it "returns false when environment name does not have `?` at the end" do
+        amber_env = Amber::Environment.new "invalid environment"
+        amber_env.{{env.id}}.should be_falsey
+      end
+
+      it "does not return Nil type" do
+        amber_env = Amber::Environment.new "invalid environment"
+        amber_env.{{env.id}}.should_not be_nil
+      end
     end
   {% end %}
 

--- a/src/amber/server/environment.cr
+++ b/src/amber/server/environment.cr
@@ -26,8 +26,8 @@ module Amber
     end
 
     macro method_missing(call)
-      env2 = {{call.name.id.stringify}}
-      self == env2[0..-2] if env2.ends_with? '?'
+      env_name = {{call.name.id.stringify}}
+      (env_name.ends_with?('?') && self == env_name[0..-2])
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

Currently, the when calling missing methods on `Amber.env` causes to
return `nil` values in some cases.

The changes presented here ensures that it always returns `bool` instead
of `nil` and avoid the following `Amber.env.development?.not_nil!`