### PR TITLE
Fix typo on html code

### DIFF
--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -6,5 +6,5 @@
     <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>
     <a class="list-group-item list-group-item-action" target="_blank" href="https://github.com/veelenga/awesome-crystal">List of Awesome Crystal projects and shards</a>
     <a class="list-group-item list-group-item-action" target="_blank" href="https://crystalshards.xyz">What's hot in Crystal right now</a>
-  </div?
+  </div>
 </div>


### PR DESCRIPTION
### Description of the Change

- Replace ? by >
- Close tag correctly

Discovered by @mixflame :

> on default setup, views/home/index.cr has a bug in the template, unclosed tag

### Alternate Designs

Nil

### Benefits

Nil

### Possible Drawbacks

Nil
