### PR TITLE
Fixed an issue I found with render if we use namespaces.

### DIFF
--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -29,7 +29,7 @@ module Amber::Controller
     end
 
     private macro render_template(filename, path = "src/views")
-      {% if filename.id.split("/").size > 3 %}
+      {% if filename.id.split("/").size > 2 %}
         Kilt.render("{{filename.id}}")
       {% else %}
         Kilt.render("#{{{path}}}/{{filename.id}}")

--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -7,28 +7,29 @@ module Amber::Controller
         raise "Template or partial required!"
       {% end %}
 
-      {{filename = template || partial}}
+      {{ filename = template || partial }}
 
       {% if filename.id.split("/").size > 1 %}
         %content = render_template("#{{{filename}}}", {{path}})
       {% else %}
+        {{ short_path = folder.gsub(/^.+?(?:controllers|views)\//, "") }}
         {% if folder.id.ends_with?(".ecr") %}
-          %content = render_template("#{{{folder.split("/")[-2]}}}/#{{{filename}}}", {{path}})
+          %content = render_template("#{{{path}}}/#{{{short_path.gsub(/\/[^\.\/]+\.ecr/, "")}}}/#{{{filename}}}")
         {% else %}
-          %content = render_template("#{{{folder.split("/").last.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}", {{path}})
+          %content = render_template("#{{{path}}}/#{{{short_path.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}")
         {% end %}
       {% end %}
 
       {% if layout && !partial %}
         content = %content
-        render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
+        render_template("#{{{path}}}/layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}")
       {% else %}
         %content
       {% end %}
     end
 
     private macro render_template(filename, path = "src/views")
-      {% if filename.id.split("/").size > 2 %}
+      {% if filename.id.split("/").size > 3 %}
         Kilt.render("{{filename.id}}")
       {% else %}
         Kilt.render("#{{{path}}}/{{filename.id}}")
@@ -36,3 +37,4 @@ module Amber::Controller
     end
   end
 end
+

--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -37,4 +37,3 @@ module Amber::Controller
     end
   end
 end
-

--- a/src/amber/controller/render.cr
+++ b/src/amber/controller/render.cr
@@ -8,7 +8,8 @@ module Amber::Controller
       {% end %}
 
       {{ filename = template || partial }}
-
+       
+      # Render Template and return content
       {% if filename.id.split("/").size > 1 %}
         %content = render_template("#{{{filename}}}", {{path}})
       {% else %}
@@ -19,7 +20,8 @@ module Amber::Controller
           %content = render_template("#{{{path}}}/#{{{short_path.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}")
         {% end %}
       {% end %}
-
+      
+      # Render Layout
       {% if layout && !partial %}
         content = %content
         render_template("#{{{path}}}/layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}")


### PR DESCRIPTION
### Description of the Change

While thinking about https://github.com/amberframework/amber/issues/324 I realized we would have an issue if we we use namespaces. So I've modified render to allow for this. Layouts an also be defined in folders now. `LAYOUT = "some/folder/application.slang"`