### PR TITLE
Have generators handle multi-word names (#316)

### DIFF
--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -17,13 +17,88 @@ module Amber::CLI
 
           Amber::CLI::Spec.cleanup
         end
+
+        it "follows naming conventions for all files and class names" do
+          ENV["AMBER_ENV"] = "test"
+          Amber::CLI::MainCommand.run ["new", TESTING_APP]
+          Dir.cd(TESTING_APP)
+
+          camel_case = "PostComment"
+          snake_case = "post_comment"
+          class_definition_prefix = "class #{camel_case}"
+          spec_definition_prefix = "describe #{camel_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "scaffold", arg, "name:string"]
+
+            File.exists?("./spec/models/#{snake_case}_spec.cr").should be_true
+            File.exists?("./src/models/#{snake_case}.cr").should be_true
+            File.exists?("./spec/controllers/#{snake_case}_controller_spec.cr").should be_true
+            File.exists?("./src/controllers/#{snake_case}_controller.cr").should be_true
+            File.exists?("./src/views/#{snake_case}/_form.slang").should be_true
+            File.exists?("./src/views/#{snake_case}/edit.slang").should be_true
+            File.exists?("./src/views/#{snake_case}/index.slang").should be_true
+            File.exists?("./src/views/#{snake_case}/new.slang").should be_true
+            File.exists?("./src/views/#{snake_case}/show.slang").should be_true
+
+            File.read("./spec/models/#{snake_case}_spec.cr").should contain spec_definition_prefix
+            File.read("./src/models/#{snake_case}.cr").should contain class_definition_prefix
+            File.read("./spec/controllers/#{snake_case}_controller_spec.cr").should contain spec_definition_prefix
+            File.read("./src/controllers/#{snake_case}_controller.cr").should contain class_definition_prefix
+            File.read("./src/views/#{snake_case}/_form.slang").should contain snake_case
+            File.read("./src/views/#{snake_case}/edit.slang").should contain camel_case
+            File.read("./src/views/#{snake_case}/index.slang").should contain camel_case
+            File.read("./src/views/#{snake_case}/new.slang").should contain camel_case
+            File.read("./src/views/#{snake_case}/show.slang").should contain snake_case
+
+            File.delete("./spec/models/#{snake_case}_spec.cr")
+            File.delete("./src/models/#{snake_case}.cr")
+            File.delete("./spec/controllers/#{snake_case}_controller_spec.cr")
+            File.delete("./src/controllers/#{snake_case}_controller.cr")
+            File.delete("./src/views/#{snake_case}/_form.slang")
+            File.delete("./src/views/#{snake_case}/edit.slang")
+            File.delete("./src/views/#{snake_case}/index.slang")
+            File.delete("./src/views/#{snake_case}/new.slang")
+            File.delete("./src/views/#{snake_case}/show.slang")
+          end
+          Amber::CLI::Spec.cleanup
+        end
       end
 
-      context "controllers" do
+      context "model" do
+        ENV["AMBER_ENV"] = "test"
+        Amber::CLI::MainCommand.run ["new", TESTING_APP]
+        Dir.cd(TESTING_APP)
+
+        it "follows naming conventions for all files and class names" do
+          camel_case = "PostComment"
+          snake_case = "post_comment"
+          class_definition_prefix = "class #{camel_case}"
+          spec_definition_prefix = "describe #{camel_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "model", arg]
+            filename = snake_case
+            src_filepath = "./src/models/#{filename}.cr"
+            spec_filepath = "./spec/models/#{filename}_spec.cr"
+
+            File.exists?(src_filepath).should be_true
+            File.exists?(spec_filepath).should be_true
+            File.read(src_filepath).should contain class_definition_prefix
+            File.read(spec_filepath).should contain spec_definition_prefix
+            File.delete(src_filepath)
+            File.delete(spec_filepath)
+          end
+        end
+        Amber::CLI::Spec.cleanup
+      end
+
+      context "controller" do
+        ENV["AMBER_ENV"] = "test"
+        Amber::CLI::MainCommand.run ["new", TESTING_APP]
+        Dir.cd(TESTING_APP)
+
         it "generates controller with correct verbs and actions" do
-          ENV["AMBER_ENV"] = "test"
-          MainCommand.run ["new", TESTING_APP]
-          Dir.cd(TESTING_APP)
           MainCommand.run ["generate", "controller", "Animal", "add:post", "list:get", "remove:delete"]
           routes_post = %(post "/animal/add", AnimalController, :add)
           routes_get = %(get "/animal/list", AnimalController, :list)
@@ -46,13 +121,184 @@ module Amber::CLI
 
           CONT
 
-          File.read("./config/routes.cr").includes?(routes_post).should be_true
-          File.read("./config/routes.cr").includes?(routes_get).should be_true
-          File.read("./config/routes.cr").includes?(routes_delete).should be_true
+          File.read("./config/routes.cr").should contain routes_post
+          File.read("./config/routes.cr").should contain routes_get
+          File.read("./config/routes.cr").should contain routes_delete
           File.read("./src/controllers/animal_controller.cr").should eq output_class
 
           Amber::CLI::Spec.cleanup
         end
+
+        it "follows naming conventions for all files and class names" do
+          ENV["AMBER_ENV"] = "test"
+          Amber::CLI::MainCommand.run ["new", TESTING_APP]
+          Dir.cd(TESTING_APP)
+          camel_case = "PostComment"
+          snake_case = "post_comment"
+          class_definition_prefix = "class #{camel_case}"
+          spec_definition_prefix = "describe #{camel_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "controller", arg]
+            filename = snake_case
+            src_filepath = "./src/controllers/#{filename}_controller.cr"
+            spec_filepath = "./spec/controllers/#{filename}_controller_spec.cr"
+
+            File.exists?(src_filepath).should be_true
+            File.exists?(spec_filepath).should be_true
+            File.read(src_filepath).should contain class_definition_prefix
+            File.read(spec_filepath).should contain spec_definition_prefix
+            File.delete(src_filepath)
+            File.delete(spec_filepath)
+          end
+        end
+        Amber::CLI::Spec.cleanup
+      end
+
+      context "migration" do
+        ENV["AMBER_ENV"] = "test"
+        Amber::CLI::MainCommand.run ["new", TESTING_APP]
+        Dir.cd(TESTING_APP)
+
+        it "follows naming conventions for all files" do
+          camel_case = "PostComment"
+          snake_case = "post_comment"
+          migration_definition_prefix = "CREATE TABLE #{snake_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "migration", arg]
+
+            migration_filename = Dir.entries("./db/migrations").sort.last
+            migration_filename.should contain snake_case
+            File.delete("./db/migrations/#{migration_filename}")
+          end
+        end
+        Amber::CLI::Spec.cleanup
+      end
+
+      context "mailer" do
+        ENV["AMBER_ENV"] = "test"
+        Amber::CLI::MainCommand.run ["new", TESTING_APP]
+        Dir.cd(TESTING_APP)
+
+        it "follows naming conventions for all files and class names" do
+          camel_case = "PostComment"
+          snake_case = "post_comment"
+          class_definition_prefix = "class #{camel_case}"
+          spec_definition_prefix = "describe #{camel_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "mailer", arg]
+            filename = snake_case
+            src_filepath = "./src/mailers/#{filename}_mailer.cr"
+
+            File.exists?(src_filepath).should be_true
+            File.read(src_filepath).should contain class_definition_prefix
+            File.delete(src_filepath)
+          end
+        end
+        Amber::CLI::Spec.cleanup
+      end
+
+      context "socket" do
+        ENV["AMBER_ENV"] = "test"
+        Amber::CLI::MainCommand.run ["new", TESTING_APP]
+        Dir.cd(TESTING_APP)
+
+        it "follows naming conventions for all files and class names" do
+          camel_case = "PostComment"
+          snake_case = "post_comment"
+          struct_definition_prefix = "struct #{camel_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "socket", arg]
+            filename = snake_case
+            src_filepath = "./src/sockets/#{filename}_socket.cr"
+
+            File.exists?(src_filepath).should be_true
+            File.read(src_filepath).should contain struct_definition_prefix
+            File.delete(src_filepath)
+          end
+        end
+        Amber::CLI::Spec.cleanup
+      end
+
+      context "channel" do
+        ENV["AMBER_ENV"] = "test"
+        Amber::CLI::MainCommand.run ["new", TESTING_APP]
+        Dir.cd(TESTING_APP)
+
+        it "follows naming conventions for all files and class names" do
+          camel_case = "PostComment"
+          snake_case = "post_comment"
+          class_definition_prefix = "class #{camel_case}"
+          spec_definition_prefix = "describe #{camel_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "channel", arg]
+            filename = snake_case
+            src_filepath = "./src/channels/#{filename}_channel.cr"
+
+            File.exists?(src_filepath).should be_true
+            File.read(src_filepath).should contain class_definition_prefix
+            File.delete(src_filepath)
+          end
+        end
+        Amber::CLI::Spec.cleanup
+      end
+
+      context "auth" do
+        ENV["AMBER_ENV"] = "test"
+        Amber::CLI::MainCommand.run ["new", TESTING_APP]
+        Dir.cd(TESTING_APP)
+
+        it "follows naming conventions for all files and class names" do
+          camel_case = "AdminUser"
+          snake_case = "admin_user"
+          class_definition_prefix = "class #{camel_case}"
+          spec_definition_prefix = "describe #{camel_case}"
+          migration_definition_prefix = "CREATE TABLE #{snake_case}"
+
+          [camel_case, snake_case].each do |arg|
+            MainCommand.run ["generate", "auth", arg]
+
+            File.exists?("./db/seeds.cr").should be_true
+            File.exists?("./spec/models/admin_user_spec.cr").should be_true
+            File.exists?("./src/controllers/registration_controller.cr").should be_true
+            File.exists?("./src/controllers/session_controller.cr").should be_true
+            File.exists?("./src/handlers/authenticate.cr").should be_true
+            File.exists?("./src/models/admin_user.cr").should be_true
+            File.exists?("./src/views/registration/new.slang").should be_true
+            File.exists?("./src/views/session/new.slang").should be_true
+
+            migration_filename = Dir.entries("./db/migrations").sort.last
+            File.read("./db/migrations/#{migration_filename}").should contain migration_definition_prefix
+            File.read("./db/seeds.cr").should contain camel_case
+            File.read("./db/seeds.cr").should contain snake_case
+            File.read("./spec/models/admin_user_spec.cr").should contain spec_definition_prefix
+            File.read("./src/controllers/registration_controller.cr").should contain camel_case
+            File.read("./src/controllers/registration_controller.cr").should contain snake_case
+            File.read("./src/controllers/session_controller.cr").should contain camel_case
+            File.read("./src/controllers/session_controller.cr").should contain snake_case
+            File.read("./src/handlers/authenticate.cr").should contain camel_case
+            File.read("./src/handlers/authenticate.cr").should contain snake_case
+            File.read("./src/models/admin_user.cr").should contain class_definition_prefix
+            File.read("./src/models/admin_user.cr").should contain snake_case
+            File.read("./src/views/registration/new.slang").should contain snake_case
+            File.read("./src/views/session/new.slang").should contain snake_case
+
+            File.delete("./db/migrations/#{migration_filename}")
+            File.delete("./db/seeds.cr")
+            File.delete("./spec/models/admin_user_spec.cr")
+            File.delete("./src/controllers/registration_controller.cr")
+            File.delete("./src/controllers/session_controller.cr")
+            File.delete("./src/handlers/authenticate.cr")
+            File.delete("./src/models/admin_user.cr")
+            File.delete("./src/views/registration/new.slang")
+            File.delete("./src/views/session/new.slang")
+          end
+        end
+        Amber::CLI::Spec.cleanup
       end
     end
   ensure

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -71,31 +71,60 @@ module Amber::CLI
       end
 
       context "model" do
-        ENV["AMBER_ENV"] = "test"
-        Amber::CLI::MainCommand.run ["new", TESTING_APP]
-        Dir.cd(TESTING_APP)
+        context "granite" do
+          ENV["AMBER_ENV"] = "test"
+          MainCommand.run ["new", TESTING_APP]
+          Dir.cd(TESTING_APP)
 
-        it "follows naming conventions for all files and class names" do
-          camel_case = "PostComment"
-          snake_case = "post_comment"
-          class_definition_prefix = "class #{camel_case}"
-          spec_definition_prefix = "describe #{camel_case}"
+          it "follows naming conventions for all files and class names" do
+            camel_case = "PostComment"
+            snake_case = "post_comment"
+            class_definition_prefix = "class #{camel_case}"
+            spec_definition_prefix = "describe #{camel_case}"
 
-          [camel_case, snake_case].each do |arg|
-            MainCommand.run ["generate", "model", arg]
-            filename = snake_case
-            src_filepath = "./src/models/#{filename}.cr"
-            spec_filepath = "./spec/models/#{filename}_spec.cr"
+            [camel_case, snake_case].each do |arg|
+              MainCommand.run ["generate", "model", arg]
+              filename = snake_case
+              granite_table_name = "table_name #{snake_case}s"
+              src_filepath = "./src/models/#{filename}.cr"
+              spec_filepath = "./spec/models/#{filename}_spec.cr"
 
-            File.exists?(src_filepath).should be_true
-            File.exists?(spec_filepath).should be_true
-            File.read(src_filepath).should contain class_definition_prefix
-            File.read(spec_filepath).should contain spec_definition_prefix
-            File.delete(src_filepath)
-            File.delete(spec_filepath)
+              File.exists?(src_filepath).should be_true
+              File.exists?(spec_filepath).should be_true
+              File.read(src_filepath).should contain class_definition_prefix
+              File.read(src_filepath).should contain granite_table_name
+              File.read(spec_filepath).should contain spec_definition_prefix
+              File.delete(src_filepath)
+              File.delete(spec_filepath)
+            end
           end
+          Amber::CLI::Spec.cleanup
         end
-        Amber::CLI::Spec.cleanup
+
+        context "crecto" do
+          ENV["AMBER_ENV"] = "test"
+          MainCommand.run ["new", TESTING_APP, "-m", "crecto"]
+          Dir.cd(TESTING_APP)
+
+          it "follows naming conventions for all files and class names" do
+            camel_case = "PostComment"
+            snake_case = "post_comment"
+            class_definition_prefix = "class #{camel_case}"
+
+            [camel_case, snake_case].each do |arg|
+              MainCommand.run ["generate", "model", arg]
+              filename = snake_case
+              crecto_table_name = %(schema "#{snake_case}s")
+              src_filepath = "./src/models/#{filename}.cr"
+
+              File.exists?(src_filepath).should be_true
+              File.read(src_filepath).should contain class_definition_prefix
+              File.read(src_filepath).should contain crecto_table_name
+              File.delete(src_filepath)
+            end
+          end
+          Amber::CLI::Spec.cleanup
+        end
       end
 
       context "controller" do

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -25,6 +25,7 @@ module Amber::CLI
 
           camel_case = "PostComment"
           snake_case = "post_comment"
+          display = "Post Comment"
           class_definition_prefix = "class #{camel_case}"
           spec_definition_prefix = "describe #{camel_case}"
 
@@ -46,9 +47,9 @@ module Amber::CLI
             File.read("./spec/controllers/#{snake_case}_controller_spec.cr").should contain spec_definition_prefix
             File.read("./src/controllers/#{snake_case}_controller.cr").should contain class_definition_prefix
             File.read("./src/views/#{snake_case}/_form.slang").should contain snake_case
-            File.read("./src/views/#{snake_case}/edit.slang").should contain camel_case
-            File.read("./src/views/#{snake_case}/index.slang").should contain camel_case
-            File.read("./src/views/#{snake_case}/new.slang").should contain camel_case
+            File.read("./src/views/#{snake_case}/edit.slang").should contain display
+            File.read("./src/views/#{snake_case}/index.slang").should contain display
+            File.read("./src/views/#{snake_case}/new.slang").should contain display
             File.read("./src/views/#{snake_case}/show.slang").should contain snake_case
 
             File.delete("./spec/models/#{snake_case}_spec.cr")

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -19,10 +19,6 @@ module Amber::CLI
         end
 
         it "follows naming conventions for all files and class names" do
-          ENV["AMBER_ENV"] = "test"
-          Amber::CLI::MainCommand.run ["new", TESTING_APP]
-          Dir.cd(TESTING_APP)
-
           camel_case = "PostComment"
           snake_case = "post_comment"
           incorrect_case = "Post_comment"
@@ -31,6 +27,10 @@ module Amber::CLI
           spec_definition_prefix = "describe #{camel_case}"
 
           [camel_case, snake_case].each do |arg|
+            ENV["AMBER_ENV"] = "test"
+            Amber::CLI::MainCommand.run ["new", TESTING_APP]
+            Dir.cd(TESTING_APP)
+
             MainCommand.run ["generate", "scaffold", arg, "name:string"]
 
             File.exists?("./spec/models/#{snake_case}_spec.cr").should be_true
@@ -56,17 +56,9 @@ module Amber::CLI
             File.read("./config/routes.cr").should contain "#{camel_case}Controller"
             File.read("./config/routes.cr").should_not contain "#{incorrect_case}Controller"
 
-            File.delete("./spec/models/#{snake_case}_spec.cr")
-            File.delete("./src/models/#{snake_case}.cr")
-            File.delete("./spec/controllers/#{snake_case}_controller_spec.cr")
-            File.delete("./src/controllers/#{snake_case}_controller.cr")
-            File.delete("./src/views/#{snake_case}/_form.slang")
-            File.delete("./src/views/#{snake_case}/edit.slang")
-            File.delete("./src/views/#{snake_case}/index.slang")
-            File.delete("./src/views/#{snake_case}/new.slang")
-            File.delete("./src/views/#{snake_case}/show.slang")
+            Amber::CLI::Spec.cleanup
           end
-          Amber::CLI::Spec.cleanup
+
         end
       end
 
@@ -321,15 +313,9 @@ module Amber::CLI
             File.read("./src/views/registration/new.slang").should contain snake_case
             File.read("./src/views/session/new.slang").should contain snake_case
 
-            File.delete("./db/migrations/#{migration_filename}")
-            File.delete("./db/seeds.cr")
-            File.delete("./spec/models/admin_user_spec.cr")
-            File.delete("./src/controllers/registration_controller.cr")
-            File.delete("./src/controllers/session_controller.cr")
-            File.delete("./src/handlers/authenticate.cr")
-            File.delete("./src/models/admin_user.cr")
-            File.delete("./src/views/registration/new.slang")
-            File.delete("./src/views/session/new.slang")
+            `rm -rf ./db/*`
+            `rm -rf ./src/*`
+            `rm -rf ./spec/*`
           end
         end
         Amber::CLI::Spec.cleanup

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -25,6 +25,7 @@ module Amber::CLI
 
           camel_case = "PostComment"
           snake_case = "post_comment"
+          incorrect_case = "Post_comment"
           display = "Post Comment"
           class_definition_prefix = "class #{camel_case}"
           spec_definition_prefix = "describe #{camel_case}"
@@ -51,6 +52,9 @@ module Amber::CLI
             File.read("./src/views/#{snake_case}/index.slang").should contain display
             File.read("./src/views/#{snake_case}/new.slang").should contain display
             File.read("./src/views/#{snake_case}/show.slang").should contain snake_case
+
+            File.read("./config/routes.cr").should contain "#{camel_case}Controller"
+            File.read("./config/routes.cr").should_not contain "#{incorrect_case}Controller"
 
             File.delete("./spec/models/#{snake_case}_spec.cr")
             File.delete("./src/models/#{snake_case}.cr")

--- a/src/amber/cli/commands/generate.cr
+++ b/src/amber/cli/commands/generate.cr
@@ -13,7 +13,7 @@ module Amber::CLI
       end
 
       def run
-        template = Template.new(args.name.downcase, ".", args.fields)
+        template = Template.new(args.name, ".", args.fields)
         template.generate args.type
       end
 

--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -9,7 +9,7 @@ require "../src/controllers/**"
 # Anything here will overwrite all environments.
 Amber::Server.configure do |setting|
   # Server options
-  # setting.name = "<%= @name.camelcase %> web application."
+  # setting.name = "<%= class_name %> web application."
   # setting.port = 80 # Port you wish your app to run
   # setting.log = ::Logger.new(STDOUT)
   # setting.log.level = ::Logger::INFO

--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -9,7 +9,7 @@ require "../src/controllers/**"
 # Anything here will overwrite all environments.
 Amber::Server.configure do |setting|
   # Server options
-  # setting.name = "<%= @name.capitalize %> web application."
+  # setting.name = "<%= @name.camelcase %> web application."
   # setting.port = 80 # Port you wish your app to run
   # setting.log = ::Logger.new(STDOUT)
   # setting.log.level = ::Logger::INFO

--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -9,7 +9,7 @@ require "../src/controllers/**"
 # Anything here will overwrite all environments.
 Amber::Server.configure do |setting|
   # Server options
-  # setting.name = "<%= class_name %> web application."
+  # setting.name = "<%= display_name %> web application."
   # setting.port = 80 # Port you wish your app to run
   # setting.log = ::Logger.new(STDOUT)
   # setting.log.level = ::Logger::INFO

--- a/src/amber/cli/templates/app/package.json.ecr
+++ b/src/amber/cli/templates/app/package.json.ecr
@@ -1,7 +1,7 @@
 {
   "name": "<%= @name %>",
   "version": "0.1.0",
-  "description": "<%= @name.camelcase %> with Amber",
+  "description": "<%= class_name %> with Amber",
   "private": true,
   "author": "Amber",
   "license": "UNLICENSED",

--- a/src/amber/cli/templates/app/package.json.ecr
+++ b/src/amber/cli/templates/app/package.json.ecr
@@ -1,7 +1,7 @@
 {
   "name": "<%= @name %>",
   "version": "0.1.0",
-  "description": "<%= @name.capitalize %> with Amber",
+  "description": "<%= @name.camelcase %> with Amber",
   "private": true,
   "author": "Amber",
   "license": "UNLICENSED",

--- a/src/amber/cli/templates/app/package.json.ecr
+++ b/src/amber/cli/templates/app/package.json.ecr
@@ -1,7 +1,7 @@
 {
   "name": "<%= @name %>",
   "version": "0.1.0",
-  "description": "<%= class_name %> with Amber",
+  "description": "<%= display_name %> with Amber",
   "private": true,
   "author": "Amber",
   "license": "UNLICENSED",

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-  <title><%= @name.capitalize %> using Amber</title>
+  <title><%= @name.camelcase %> using Amber</title>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-  <title><%= @name.camelcase %> using Amber</title>
+  <title><%= class_name %> using Amber</title>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-  <title><%= class_name %> using Amber</title>
+  <title><%= display_name %> using Amber</title>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title <%= @name.capitalize %> using Amber
+    title <%= @name.camelcase %> using Amber
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name="viewport" content="width=device-width, initial-scale=1"

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title <%= @name.camelcase %> using Amber
+    title <%= class_name %> using Amber
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name="viewport" content="width=device-width, initial-scale=1"

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title <%= class_name %> using Amber
+    title <%= display_name %> using Amber
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name="viewport" content="width=device-width, initial-scale=1"

--- a/src/amber/cli/templates/auth/db/seeds.cr.ecr
+++ b/src/amber/cli/templates/auth/db/seeds.cr.ecr
@@ -1,7 +1,7 @@
 require "amber"
 require "../src/models/*"
 
-<%= @name %> = <%= @name.camelcase %>.new
+<%= @name %> = <%= class_name %>.new
 <%= @name %>.email = "admin@example.com"
 <%= @name %>.password = "password"
 <%= @name %>.save

--- a/src/amber/cli/templates/auth/db/seeds.cr.ecr
+++ b/src/amber/cli/templates/auth/db/seeds.cr.ecr
@@ -1,7 +1,7 @@
 require "amber"
 require "../src/models/*"
 
-<%= @name %> = <%= @name.capitalize %>.new
+<%= @name %> = <%= @name.camelcase %>.new
 <%= @name %>.email = "admin@example.com"
 <%= @name %>.password = "password"
 <%= @name %>.save

--- a/src/amber/cli/templates/auth/spec/models/{{name}}_spec.cr.ecr
+++ b/src/amber/cli/templates/auth/spec/models/{{name}}_spec.cr.ecr
@@ -1,8 +1,8 @@
 require "./spec_helper"
 require "../../src/models/<%= @name %>.cr"
 
-describe <%= @name.capitalize %> do
+describe <%= @name.camelcase %> do
   Spec.before_each do
-    <%= @name.capitalize %>.clear
+    <%= @name.camelcase %>.clear
   end
 end

--- a/src/amber/cli/templates/auth/spec/models/{{name}}_spec.cr.ecr
+++ b/src/amber/cli/templates/auth/spec/models/{{name}}_spec.cr.ecr
@@ -1,8 +1,8 @@
 require "./spec_helper"
 require "../../src/models/<%= @name %>.cr"
 
-describe <%= @name.camelcase %> do
+describe <%= class_name %> do
   Spec.before_each do
-    <%= @name.camelcase %>.clear
+    <%= class_name %>.clear
   end
 end

--- a/src/amber/cli/templates/auth/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/registration_controller.cr.ecr
@@ -1,19 +1,19 @@
 class RegistrationController < ApplicationController
   def new
-    <%= @name %> = <%= @name.capitalize %>.new
+    <%= @name %> = <%= @name.camelcase %>.new
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.capitalize %>.new(registration_params.validate!)
+    <%= @name %> = <%= @name.camelcase %>.new(registration_params.validate!)
     <%= @name %>.password = params["password"].to_s
 
     if <%= @name %>.valid? && <%= @name %>.save
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash["success"] = "Created <%= @name.capitalize %> successfully."
+      flash["success"] = "Created <%= @name.camelcase %> successfully."
       redirect_to "/"
     else
-      flash["danger"] = "Could not create <%= @name.capitalize %>!"
+      flash["danger"] = "Could not create <%= @name.camelcase %>!"
       render("new.<%= @language %>")
     end
   end

--- a/src/amber/cli/templates/auth/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/registration_controller.cr.ecr
@@ -1,19 +1,19 @@
 class RegistrationController < ApplicationController
   def new
-    <%= @name %> = <%= @name.camelcase %>.new
+    <%= @name %> = <%= class_name %>.new
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.camelcase %>.new(registration_params.validate!)
+    <%= @name %> = <%= class_name %>.new(registration_params.validate!)
     <%= @name %>.password = params["password"].to_s
 
     if <%= @name %>.valid? && <%= @name %>.save
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash["success"] = "Created <%= @name.camelcase %> successfully."
+      flash["success"] = "Created <%= class_name %> successfully."
       redirect_to "/"
     else
-      flash["danger"] = "Could not create <%= @name.camelcase %>!"
+      flash["danger"] = "Could not create <%= class_name %>!"
       render("new.<%= @language %>")
     end
   end

--- a/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
@@ -1,18 +1,18 @@
 class SessionController < ApplicationController
   def new
-    <%= @name %> = <%= @name.camelcase %>.new
+    <%= @name %> = <%= class_name %>.new
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.camelcase %>.find_by(:email, params["email"].to_s)
+    <%= @name %> = <%= class_name %>.find_by(:email, params["email"].to_s)
     if <%= @name %> && <%= @name %>.authenticate(params["password"].to_s)
         session[:<%= @name %>_id] = <%= @name %>.id
         flash[:info] = "Successfully logged in"
         redirect_to "/"
       else
         flash[:danger] = "Invalid email or password"
-        <%= @name %> = <%= @name.camelcase %>.new
+        <%= @name %> = <%= class_name %>.new
         render("new.<%= @language %>")
       end
   end

--- a/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
@@ -1,18 +1,18 @@
 class SessionController < ApplicationController
   def new
-    <%= @name %> = <%= @name.capitalize %>.new
+    <%= @name %> = <%= @name.camelcase %>.new
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.capitalize %>.find_by(:email, params["email"].to_s)
+    <%= @name %> = <%= @name.camelcase %>.find_by(:email, params["email"].to_s)
     if <%= @name %> && <%= @name %>.authenticate(params["password"].to_s)
         session[:<%= @name %>_id] = <%= @name %>.id
         flash[:info] = "Successfully logged in"
         redirect_to "/"
       else
         flash[:danger] = "Invalid email or password"
-        <%= @name %> = <%= @name.capitalize %>.new
+        <%= @name %> = <%= @name.camelcase %>.new
         render("new.<%= @language %>")
       end
   end

--- a/src/amber/cli/templates/auth/src/handlers/authenticate.cr.ecr
+++ b/src/amber/cli/templates/auth/src/handlers/authenticate.cr.ecr
@@ -1,11 +1,11 @@
 class HTTP::Server::Context
-  property current_<%= @name %> : <%= @name.camelcase %>?
+  property current_<%= @name %> : <%= class_name %>?
 end
 
 class Authenticate < Amber::Pipe::Base
   def call(context)
     <%= @name %>_id = context.session["<%= @name %>_id"]?
-    if <%= @name %> = <%= @name.camelcase %>.find <%= @name %>_id
+    if <%= @name %> = <%= class_name %>.find <%= @name %>_id
       context.current_<%= @name %> = <%= @name %>
       call_next(context)
     else

--- a/src/amber/cli/templates/auth/src/handlers/authenticate.cr.ecr
+++ b/src/amber/cli/templates/auth/src/handlers/authenticate.cr.ecr
@@ -1,11 +1,11 @@
 class HTTP::Server::Context
-  property current_<%= @name %> : <%= @name.capitalize %>?
+  property current_<%= @name %> : <%= @name.camelcase %>?
 end
 
 class Authenticate < Amber::Pipe::Base
   def call(context)
     <%= @name %>_id = context.session["<%= @name %>_id"]?
-    if <%= @name %> = <%= @name.capitalize %>.find <%= @name %>_id
+    if <%= @name %> = <%= @name.camelcase %>.find <%= @name %>_id
       context.current_<%= @name %> = <%= @name %>
       call_next(context)
     else

--- a/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
@@ -1,16 +1,16 @@
 require "granite_orm/adapter/<%= @database %>"
 require "crypto/bcrypt/password"
 
-class <%= @name.camelcase %> < Granite::ORM::Base
+class <%= class_name %> < Granite::ORM::Base
   adapter <%= @database %>
   property password : String?
   before_save :encrypt_password
 
-  validate :email, "is required", -> (<%= @name %> : <%= @name.camelcase %>) do
+  validate :email, "is required", -> (<%= @name %> : <%= class_name %>) do
     (<%= @name %>.email != nil) && (!<%= @name %>.email.not_nil!.empty?)
   end
 
-  validate :password, "is to short", -> (<%= @name %> : <%= @name.camelcase %>) do
+  validate :password, "is to short", -> (<%= @name %> : <%= class_name %>) do
     (<%= @name %>.password != nil) && (<%= @name %>.password.not_nil!.size >= 8)
   end
 

--- a/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
@@ -1,16 +1,16 @@
 require "granite_orm/adapter/<%= @database %>"
 require "crypto/bcrypt/password"
 
-class <%= @name.capitalize %> < Granite::ORM::Base
+class <%= @name.camelcase %> < Granite::ORM::Base
   adapter <%= @database %>
   property password : String?
   before_save :encrypt_password
 
-  validate :email, "is required", -> (<%= @name %> : <%= @name.capitalize %>) do
+  validate :email, "is required", -> (<%= @name %> : <%= @name.camelcase %>) do
     (<%= @name %>.email != nil) && (!<%= @name %>.email.not_nil!.empty?)
   end
 
-  validate :password, "is to short", -> (<%= @name %> : <%= @name.capitalize %>) do
+  validate :password, "is to short", -> (<%= @name %> : <%= @name.camelcase %>) do
     (<%= @name %>.password != nil) && (<%= @name %>.password.not_nil!.size >= 8)
   end
 

--- a/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
+++ b/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name.camelcase %>Channel < Amber::WebSockets::Channel
+class <%= class_name %>Channel < Amber::WebSockets::Channel
   def handle_joined(client_socket, message)
   end
 

--- a/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
+++ b/src/amber/cli/templates/channel/src/channels/{{name}}_channel.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name.capitalize %>Channel < Amber::WebSockets::Channel
+class <%= @name.camelcase %>Channel < Amber::WebSockets::Channel
   def handle_joined(client_socket, message)
   end
 

--- a/src/amber/cli/templates/controller.cr
+++ b/src/amber/cli/templates/controller.cr
@@ -13,7 +13,7 @@ module Amber::CLI
       @language = language
       parse_actions(actions)
       add_routes :web, <<-ROUTES
-        #{@actions.map { |action, verb| %Q(#{verb} "/#{@name}/#{action}", #{@name.capitalize}Controller, :#{action}) }.join("\n    ")}
+        #{@actions.map { |action, verb| %Q(#{verb} "/#{@name}/#{action}", #{class_name}Controller, :#{action}) }.join("\n    ")}
       ROUTES
       add_views
     end

--- a/src/amber/cli/templates/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -1,9 +1,9 @@
 require "./spec_helper"
 
-describe <%= @name.camelcase %>Controller do
+describe <%= class_name %>Controller do
 <% @actions.each do |action, verb| -%>
 
-  describe "<%= @name.camelcase %>Controller#<%= action %>" do
+  describe "<%= class_name %>Controller#<%= action %>" do
     it "renders the view" do
     end
   end

--- a/src/amber/cli/templates/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -1,9 +1,9 @@
 require "./spec_helper"
 
-describe <%= @name.capitalize %>Controller do
+describe <%= @name.camelcase %>Controller do
 <% @actions.each do |action, verb| -%>
 
-  describe "<%= @name.capitalize %>Controller#<%= action %>" do
+  describe "<%= @name.camelcase %>Controller#<%= action %>" do
     it "renders the view" do
     end
   end

--- a/src/amber/cli/templates/controller/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/controller/src/controllers/{{name}}_controller.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name.capitalize %>Controller < ApplicationController
+class <%= @name.camelcase %>Controller < ApplicationController
 <%=
   actions = @actions.map do |action, verb|
     <<-ACTION

--- a/src/amber/cli/templates/controller/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/controller/src/controllers/{{name}}_controller.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name.camelcase %>Controller < ApplicationController
+class <%= class_name %>Controller < ApplicationController
 <%=
   actions = @actions.map do |action, verb|
     <<-ACTION

--- a/src/amber/cli/templates/mailer/src/mailers/{{name}}_mailer.cr.ecr
+++ b/src/amber/cli/templates/mailer/src/mailers/{{name}}_mailer.cr.ecr
@@ -1,6 +1,6 @@
 require "quartz_mailer"
 
-class <%= @name.camelcase %>Mailer < Quartz::Mailer
+class <%= class_name %>Mailer < Quartz::Mailer
   def initialize
     super()
     from "from@example.com"

--- a/src/amber/cli/templates/mailer/src/mailers/{{name}}_mailer.cr.ecr
+++ b/src/amber/cli/templates/mailer/src/mailers/{{name}}_mailer.cr.ecr
@@ -1,6 +1,6 @@
 require "quartz_mailer"
 
-class <%= @name.capitalize %>Mailer < Quartz::Mailer
+class <%= @name.camelcase %>Mailer < Quartz::Mailer
   def initialize
     super()
     from "from@example.com"

--- a/src/amber/cli/templates/model.cr
+++ b/src/amber/cli/templates/model.cr
@@ -30,5 +30,9 @@ module Amber::CLI
         return "pg"
       end
     end
+
+    def table_name
+      @table_name ||= "#{@name}s"
+    end
   end
 end

--- a/src/amber/cli/templates/model/crecto/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/crecto/src/models/{{name}}.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name.capitalize %> < Crecto::Model
+class <%= @name.camelcase %> < Crecto::Model
   schema "<%= @name %>s" do
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
     field :<%= field.name %>, <%= field.cr_type %>

--- a/src/amber/cli/templates/model/crecto/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/crecto/src/models/{{name}}.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name.camelcase %> < Crecto::Model
+class <%= class_name %> < Crecto::Model
   schema "<%= @name %>s" do
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
     field :<%= field.name %>, <%= field.cr_type %>

--- a/src/amber/cli/templates/model/crecto/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/crecto/src/models/{{name}}.cr.ecr
@@ -1,5 +1,5 @@
 class <%= class_name %> < Crecto::Model
-  schema "<%= @name %>s" do
+  schema "<%= table_name %>" do
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
     field :<%= field.name %>, <%= field.cr_type %>
 <% end -%>

--- a/src/amber/cli/templates/model/granite/spec/models/{{name}}_spec.cr.ecr
+++ b/src/amber/cli/templates/model/granite/spec/models/{{name}}_spec.cr.ecr
@@ -1,8 +1,8 @@
 require "./spec_helper"
 require "../../src/models/<%= @name %>.cr"
 
-describe <%= @name.capitalize %> do
+describe <%= @name.camelcase %> do
   Spec.before_each do
-    <%= @name.capitalize %>.clear
+    <%= @name.camelcase %>.clear
   end
 end

--- a/src/amber/cli/templates/model/granite/spec/models/{{name}}_spec.cr.ecr
+++ b/src/amber/cli/templates/model/granite/spec/models/{{name}}_spec.cr.ecr
@@ -1,8 +1,8 @@
 require "./spec_helper"
 require "../../src/models/<%= @name %>.cr"
 
-describe <%= @name.camelcase %> do
+describe <%= class_name %> do
   Spec.before_each do
-    <%= @name.camelcase %>.clear
+    <%= class_name %>.clear
   end
 end

--- a/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
@@ -1,6 +1,6 @@
 require "granite_orm/adapter/<%= @database %>"
 
-class <%= @name.camelcase %> < Granite::ORM::Base
+class <%= class_name %> < Granite::ORM::Base
   adapter <%= @database %>
 
 <% @fields.select{|f| f.reference? }.each do |field| -%>

--- a/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
@@ -1,6 +1,6 @@
 require "granite_orm/adapter/<%= @database %>"
 
-class <%= @name.capitalize %> < Granite::ORM::Base
+class <%= @name.camelcase %> < Granite::ORM::Base
   adapter <%= @database %>
 
 <% @fields.select{|f| f.reference? }.each do |field| -%>

--- a/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
@@ -2,6 +2,7 @@ require "granite_orm/adapter/<%= @database %>"
 
 class <%= class_name %> < Granite::ORM::Base
   adapter <%= @database %>
+  <%= "table_name #{table_name}" %>
 
 <% @fields.select{|f| f.reference? }.each do |field| -%>
   belongs_to :<%= field.name %>

--- a/src/amber/cli/templates/scaffold/controller.cr
+++ b/src/amber/cli/templates/scaffold/controller.cr
@@ -20,7 +20,7 @@ module Amber::CLI::Scaffold
       @visible_fields = visible_fields
 
       add_routes :web, <<-ROUTE
-        resources "/#{@name}s", #{@name.capitalize}Controller
+        resources "/#{@name}s", #{class_name}Controller
       ROUTE
     end
 

--- a/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -2,15 +2,15 @@
 require "./spec_helper"
 
 def create_subject
-  subject = <%= @name.capitalize %>.new
+  subject = <%= @name.camelcase %>.new
   subject.<%= field_name %> = "test"
   subject.save
   subject
 end
 
-describe <%= @name.capitalize %>Controller do
+describe <%= @name.camelcase %>Controller do
   Spec.before_each do
-    <%= @name.capitalize %>.clear
+    <%= @name.camelcase %>.clear
   end
 
   describe "index" do
@@ -32,14 +32,14 @@ describe <%= @name.capitalize %>Controller do
   describe "new" do
     it "render new template" do
       get "/<%= @name %>s/new"
-      response.body.should contain "New <%= @name.capitalize %>"
+      response.body.should contain "New <%= @name.camelcase %>"
     end
   end
 
   describe "create" do
     it "creates a <%= @name %>" do
       post "/<%= @name %>s", body: "<%= field_name %>=testing"
-      subject_list = <%= @name.capitalize %>.all
+      subject_list = <%= @name.camelcase %>.all
       subject_list.size.should eq 1
     end
   end
@@ -48,7 +48,7 @@ describe <%= @name.capitalize %>Controller do
     it "renders edit template" do
       subject = create_subject
       get "/<%= @name %>s/#{subject.id}/edit"
-      response.body.should contain "Edit <%= @name.capitalize %>"
+      response.body.should contain "Edit <%= @name.camelcase %>"
     end
   end
 
@@ -56,7 +56,7 @@ describe <%= @name.capitalize %>Controller do
     it "updates a <%= @name %>" do
       subject = create_subject
       patch "/<%= @name %>s/#{subject.id}", body: "<%= field_name %>=test2"
-      result = <%= @name.capitalize %>.find(subject.id).not_nil!
+      result = <%= @name.camelcase %>.find(subject.id).not_nil!
       result.<%= field_name %>.should eq "test2"
     end
   end
@@ -65,7 +65,7 @@ describe <%= @name.capitalize %>Controller do
     it "deletes a <%= @name %>" do
       subject = create_subject
       delete "/<%= @name %>s/#{subject.id}"
-      result = <%= @name.capitalize %>.find subject.id
+      result = <%= @name.camelcase %>.find subject.id
       result.should eq nil
     end
   end

--- a/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -2,15 +2,15 @@
 require "./spec_helper"
 
 def create_subject
-  subject = <%= @name.camelcase %>.new
+  subject = <%= class_name %>.new
   subject.<%= field_name %> = "test"
   subject.save
   subject
 end
 
-describe <%= @name.camelcase %>Controller do
+describe <%= class_name %>Controller do
   Spec.before_each do
-    <%= @name.camelcase %>.clear
+    <%= class_name %>.clear
   end
 
   describe "index" do
@@ -32,14 +32,14 @@ describe <%= @name.camelcase %>Controller do
   describe "new" do
     it "render new template" do
       get "/<%= @name %>s/new"
-      response.body.should contain "New <%= @name.camelcase %>"
+      response.body.should contain "New <%= class_name %>"
     end
   end
 
   describe "create" do
     it "creates a <%= @name %>" do
       post "/<%= @name %>s", body: "<%= field_name %>=testing"
-      subject_list = <%= @name.camelcase %>.all
+      subject_list = <%= class_name %>.all
       subject_list.size.should eq 1
     end
   end
@@ -48,7 +48,7 @@ describe <%= @name.camelcase %>Controller do
     it "renders edit template" do
       subject = create_subject
       get "/<%= @name %>s/#{subject.id}/edit"
-      response.body.should contain "Edit <%= @name.camelcase %>"
+      response.body.should contain "Edit <%= class_name %>"
     end
   end
 
@@ -56,7 +56,7 @@ describe <%= @name.camelcase %>Controller do
     it "updates a <%= @name %>" do
       subject = create_subject
       patch "/<%= @name %>s/#{subject.id}", body: "<%= field_name %>=test2"
-      result = <%= @name.camelcase %>.find(subject.id).not_nil!
+      result = <%= class_name %>.find(subject.id).not_nil!
       result.<%= field_name %>.should eq "test2"
     end
   end
@@ -65,7 +65,7 @@ describe <%= @name.camelcase %>Controller do
     it "deletes a <%= @name %>" do
       subject = create_subject
       delete "/<%= @name %>s/#{subject.id}"
-      result = <%= @name.camelcase %>.find subject.id
+      result = <%= class_name %>.find subject.id
       result.should eq nil
     end
   end

--- a/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -1,71 +1,71 @@
-class <%= @name.capitalize %>Controller < ApplicationController
+class <%= @name.camelcase %>Controller < ApplicationController
   def index
-    <%= @name %>s = Repo.all(<%= @name.capitalize %>)
+    <%= @name %>s = Repo.all(<%= @name.camelcase %>)
     render("index.<%= @language %>")
   end
 
   def show
-    if <%= @name %> = Repo.get(<%= @name.capitalize %>, params["id"])
+    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
       render("show.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def new
-    <%= @name %> = <%= @name.capitalize %>.new
-    changeset = <%= @name.capitalize %>.changeset(<%= @name %>) 
+    <%= @name %> = <%= @name.camelcase %>.new
+    changeset = <%= @name.camelcase %>.changeset(<%= @name %>) 
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.capitalize %>.new
+    <%= @name %> = <%= @name.camelcase %>.new
     <%= @name %>.update_from_hash(params.to_h.select(<%= @visible_fields %>))
     changeset = Repo.insert(<%= @name %>)
 
     if changeset.errors.any?
-      flash["danger"] = "Could not create <%= @name.capitalize %>!"
+      flash["danger"] = "Could not create <%= @name.camelcase %>!"
       render("new.<%= @language %>")
     else
-      flash["success"] = "Created <%= @name.capitalize %> successfully."
+      flash["success"] = "Created <%= @name.camelcase %> successfully."
       redirect_to "/<%= @name %>s"
     end
   end
 
   def edit
-    if <%= @name %> = Repo.get(<%= @name.capitalize %>, params["id"])
+    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
       changeset = Repo.update(<%= @name %>)
       render("edit.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def update
-    if <%= @name %> = Repo.get(<%= @name.capitalize %>, params["id"])
+    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
       <%= @name %>.update_from_hash(params.to_h.select(<%= @visible_fields %>))
       changeset = Repo.update(<%= @name %>)
 
       if changeset.errors.any?
-        flash["danger"] = "Could not update <%= @name.capitalize %>!"
+        flash["danger"] = "Could not update <%= @name.camelcase %>!"
         render("edit.<%= @language %>")
       else
-        flash["success"] = "Updated <%= @name.capitalize %> successfully."
+        flash["success"] = "Updated <%= @name.camelcase %> successfully."
         redirect_to "/<%= @name %>s"
       end
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def destroy
-    if <%= @name %> = Repo.get(<%= @name.capitalize %>, params["id"])
+    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
       Repo.delete(<%= @name %>)
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
     end
     redirect_to "/<%= @name %>s"
   end

--- a/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -1,71 +1,71 @@
-class <%= @name.camelcase %>Controller < ApplicationController
+class <%= class_name %>Controller < ApplicationController
   def index
-    <%= @name %>s = Repo.all(<%= @name.camelcase %>)
+    <%= @name %>s = Repo.all(<%= class_name %>)
     render("index.<%= @language %>")
   end
 
   def show
-    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
+    if <%= @name %> = Repo.get(<%= class_name %>, params["id"])
       render("show.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def new
-    <%= @name %> = <%= @name.camelcase %>.new
-    changeset = <%= @name.camelcase %>.changeset(<%= @name %>) 
+    <%= @name %> = <%= class_name %>.new
+    changeset = <%= class_name %>.changeset(<%= @name %>) 
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.camelcase %>.new
+    <%= @name %> = <%= class_name %>.new
     <%= @name %>.update_from_hash(params.to_h.select(<%= @visible_fields %>))
     changeset = Repo.insert(<%= @name %>)
 
     if changeset.errors.any?
-      flash["danger"] = "Could not create <%= @name.camelcase %>!"
+      flash["danger"] = "Could not create <%= class_name %>!"
       render("new.<%= @language %>")
     else
-      flash["success"] = "Created <%= @name.camelcase %> successfully."
+      flash["success"] = "Created <%= class_name %> successfully."
       redirect_to "/<%= @name %>s"
     end
   end
 
   def edit
-    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
+    if <%= @name %> = Repo.get(<%= class_name %>, params["id"])
       changeset = Repo.update(<%= @name %>)
       render("edit.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def update
-    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
+    if <%= @name %> = Repo.get(<%= class_name %>, params["id"])
       <%= @name %>.update_from_hash(params.to_h.select(<%= @visible_fields %>))
       changeset = Repo.update(<%= @name %>)
 
       if changeset.errors.any?
-        flash["danger"] = "Could not update <%= @name.camelcase %>!"
+        flash["danger"] = "Could not update <%= class_name %>!"
         render("edit.<%= @language %>")
       else
-        flash["success"] = "Updated <%= @name.camelcase %> successfully."
+        flash["success"] = "Updated <%= class_name %> successfully."
         redirect_to "/<%= @name %>s"
       end
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def destroy
-    if <%= @name %> = Repo.get(<%= @name.camelcase %>, params["id"])
+    if <%= @name %> = Repo.get(<%= class_name %>, params["id"])
       Repo.delete(<%= @name %>)
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
     end
     redirect_to "/<%= @name %>s"
   end

--- a/src/amber/cli/templates/scaffold/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -2,15 +2,15 @@
 require "./spec_helper"
 
 def create_subject
-  subject = <%= @name.capitalize %>.new
+  subject = <%= @name.camelcase %>.new
   subject.<%= field_name %> = "test"
   subject.save
   subject
 end
 
-describe <%= @name.capitalize %>Controller do
+describe <%= @name.camelcase %>Controller do
   Spec.before_each do
-    <%= @name.capitalize %>.clear
+    <%= @name.camelcase %>.clear
   end
 
   describe "index" do
@@ -32,14 +32,14 @@ describe <%= @name.capitalize %>Controller do
   describe "new" do
     it "render new template" do
       get "/<%= @name %>s/new"
-      response.body.should contain "New <%= @name.capitalize %>"
+      response.body.should contain "New <%= @name.camelcase %>"
     end
   end
 
   describe "create" do
     it "creates a <%= @name %>" do
       post "/<%= @name %>s", body: "<%= field_name %>=testing"
-      subject_list = <%= @name.capitalize %>.all
+      subject_list = <%= @name.camelcase %>.all
       subject_list.size.should eq 1
     end
   end
@@ -48,7 +48,7 @@ describe <%= @name.capitalize %>Controller do
     it "renders edit template" do
       subject = create_subject
       get "/<%= @name %>s/#{subject.id}/edit"
-      response.body.should contain "Edit <%= @name.capitalize %>"
+      response.body.should contain "Edit <%= @name.camelcase %>"
     end
   end
 
@@ -56,7 +56,7 @@ describe <%= @name.capitalize %>Controller do
     it "updates a <%= @name %>" do
       subject = create_subject
       patch "/<%= @name %>s/#{subject.id}", body: "<%= field_name %>=test2"
-      result = <%= @name.capitalize %>.find(subject.id).not_nil!
+      result = <%= @name.camelcase %>.find(subject.id).not_nil!
       result.<%= field_name %>.should eq "test2"
     end
   end
@@ -65,7 +65,7 @@ describe <%= @name.capitalize %>Controller do
     it "deletes a <%= @name %>" do
       subject = create_subject
       delete "/<%= @name %>s/#{subject.id}"
-      result = <%= @name.capitalize %>.find subject.id
+      result = <%= @name.camelcase %>.find subject.id
       result.should eq nil
     end
   end

--- a/src/amber/cli/templates/scaffold/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -2,15 +2,15 @@
 require "./spec_helper"
 
 def create_subject
-  subject = <%= @name.camelcase %>.new
+  subject = <%= class_name %>.new
   subject.<%= field_name %> = "test"
   subject.save
   subject
 end
 
-describe <%= @name.camelcase %>Controller do
+describe <%= class_name %>Controller do
   Spec.before_each do
-    <%= @name.camelcase %>.clear
+    <%= class_name %>.clear
   end
 
   describe "index" do
@@ -32,14 +32,14 @@ describe <%= @name.camelcase %>Controller do
   describe "new" do
     it "render new template" do
       get "/<%= @name %>s/new"
-      response.body.should contain "New <%= @name.camelcase %>"
+      response.body.should contain "New <%= class_name %>"
     end
   end
 
   describe "create" do
     it "creates a <%= @name %>" do
       post "/<%= @name %>s", body: "<%= field_name %>=testing"
-      subject_list = <%= @name.camelcase %>.all
+      subject_list = <%= class_name %>.all
       subject_list.size.should eq 1
     end
   end
@@ -48,7 +48,7 @@ describe <%= @name.camelcase %>Controller do
     it "renders edit template" do
       subject = create_subject
       get "/<%= @name %>s/#{subject.id}/edit"
-      response.body.should contain "Edit <%= @name.camelcase %>"
+      response.body.should contain "Edit <%= class_name %>"
     end
   end
 
@@ -56,7 +56,7 @@ describe <%= @name.camelcase %>Controller do
     it "updates a <%= @name %>" do
       subject = create_subject
       patch "/<%= @name %>s/#{subject.id}", body: "<%= field_name %>=test2"
-      result = <%= @name.camelcase %>.find(subject.id).not_nil!
+      result = <%= class_name %>.find(subject.id).not_nil!
       result.<%= field_name %>.should eq "test2"
     end
   end
@@ -65,7 +65,7 @@ describe <%= @name.camelcase %>Controller do
     it "deletes a <%= @name %>" do
       subject = create_subject
       delete "/<%= @name %>s/#{subject.id}"
-      result = <%= @name.camelcase %>.find subject.id
+      result = <%= class_name %>.find subject.id
       result.should eq nil
     end
   end

--- a/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -1,70 +1,70 @@
-class <%= @name.capitalize %>Controller < ApplicationController
+class <%= @name.camelcase %>Controller < ApplicationController
   def index
-    <%= @name %>s = <%= @name.capitalize %>.all
+    <%= @name %>s = <%= @name.camelcase %>.all
     render("index.<%= @language %>")
   end
 
   def show
-    if <%= @name %> = <%= @name.capitalize %>.find params["id"]
+    if <%= @name %> = <%= @name.camelcase %>.find params["id"]
       render("show.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def new
-    <%= @name %> = <%= @name.capitalize %>.new
+    <%= @name %> = <%= @name.camelcase %>.new
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.capitalize %>.new(<%= @name.downcase%>_params.validate!)
+    <%= @name %> = <%= @name.camelcase %>.new(<%= @name.underscore %>_params.validate!)
 
     if <%= @name %>.valid? && <%= @name %>.save
-      flash["success"] = "Created <%= @name.capitalize %> successfully."
+      flash["success"] = "Created <%= @name.camelcase %> successfully."
       redirect_to "/<%= @name %>s"
     else
-      flash["danger"] = "Could not create <%= @name.capitalize %>!"
+      flash["danger"] = "Could not create <%= @name.camelcase %>!"
       render("new.<%= @language %>")
     end
   end
 
   def edit
-    if <%= @name %> = <%= @name.capitalize %>.find params["id"]
+    if <%= @name %> = <%= @name.camelcase %>.find params["id"]
       render("edit.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def update
-    if <%= @name %> = <%= @name.capitalize %>.find(params["id"])
-      <%= @name %>.set_attributes(<%= @name.downcase%>_params.validate!)
+    if <%= @name %> = <%= @name.camelcase %>.find(params["id"])
+      <%= @name %>.set_attributes(<%= @name.underscore %>_params.validate!)
       if <%= @name %>.valid? && <%= @name %>.save
-        flash["success"] = "Updated <%= @name.capitalize %> successfully."
+        flash["success"] = "Updated <%= @name.camelcase %> successfully."
         redirect_to "/<%= @name %>s"
       else
-        flash["danger"] = "Could not update <%= @name.capitalize %>!"
+        flash["danger"] = "Could not update <%= @name.camelcase %>!"
         render("edit.<%= @language %>")
       end
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def destroy
-    if <%= @name %> = <%= @name.capitalize %>.find params["id"]
+    if <%= @name %> = <%= @name.camelcase %>.find params["id"]
       <%= @name %>.destroy
     else
-      flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
     end
     redirect_to "/<%= @name %>s"
   end
 
-  def <%= @name %>_params
+  def <%= @name.underscore %>_params
     params.validation do
       <%- @visible_fields.each do |field| -%>
       required(:<%= field %>) { |f| !f.nil? }

--- a/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -1,70 +1,70 @@
-class <%= @name.camelcase %>Controller < ApplicationController
+class <%= class_name %>Controller < ApplicationController
   def index
-    <%= @name %>s = <%= @name.camelcase %>.all
+    <%= @name %>s = <%= class_name %>.all
     render("index.<%= @language %>")
   end
 
   def show
-    if <%= @name %> = <%= @name.camelcase %>.find params["id"]
+    if <%= @name %> = <%= class_name %>.find params["id"]
       render("show.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def new
-    <%= @name %> = <%= @name.camelcase %>.new
+    <%= @name %> = <%= class_name %>.new
     render("new.<%= @language %>")
   end
 
   def create
-    <%= @name %> = <%= @name.camelcase %>.new(<%= @name.underscore %>_params.validate!)
+    <%= @name %> = <%= class_name %>.new(<%= @name %>_params.validate!)
 
     if <%= @name %>.valid? && <%= @name %>.save
-      flash["success"] = "Created <%= @name.camelcase %> successfully."
+      flash["success"] = "Created <%= class_name %> successfully."
       redirect_to "/<%= @name %>s"
     else
-      flash["danger"] = "Could not create <%= @name.camelcase %>!"
+      flash["danger"] = "Could not create <%= class_name %>!"
       render("new.<%= @language %>")
     end
   end
 
   def edit
-    if <%= @name %> = <%= @name.camelcase %>.find params["id"]
+    if <%= @name %> = <%= class_name %>.find params["id"]
       render("edit.<%= @language %>")
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def update
-    if <%= @name %> = <%= @name.camelcase %>.find(params["id"])
-      <%= @name %>.set_attributes(<%= @name.underscore %>_params.validate!)
+    if <%= @name %> = <%= class_name %>.find(params["id"])
+      <%= @name %>.set_attributes(<%= @name %>_params.validate!)
       if <%= @name %>.valid? && <%= @name %>.save
-        flash["success"] = "Updated <%= @name.camelcase %> successfully."
+        flash["success"] = "Updated <%= class_name %> successfully."
         redirect_to "/<%= @name %>s"
       else
-        flash["danger"] = "Could not update <%= @name.camelcase %>!"
+        flash["danger"] = "Could not update <%= class_name %>!"
         render("edit.<%= @language %>")
       end
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
       redirect_to "/<%= @name %>s"
     end
   end
 
   def destroy
-    if <%= @name %> = <%= @name.camelcase %>.find params["id"]
+    if <%= @name %> = <%= class_name %>.find params["id"]
       <%= @name %>.destroy
     else
-      flash["warning"] = "<%= @name.camelcase %> with ID #{params["id"]} Not Found"
+      flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
     end
     redirect_to "/<%= @name %>s"
   end
 
-  def <%= @name.underscore %>_params
+  def <%= @name %>_params
     params.validation do
       <%- @visible_fields.each do |field| -%>
       required(:<%= field %>) { |f| !f.nil? }

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
@@ -1,2 +1,2 @@
 <%="<"%>%- active = context.request.path == "/<%= @name %>s" ? "active" : "" %>
-<a class="nav-item <%="<"%>%= active %>" href="/<%= @name %>s"><%= @name.capitalize %>s</a>
+<a class="nav-item <%="<"%>%= active %>" href="/<%= @name %>s"><%= @name.camelcase %>s</a>

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
@@ -1,2 +1,2 @@
 <%="<"%>%- active = context.request.path == "/<%= @name %>s" ? "active" : "" %>
-<a class="nav-item <%="<"%>%= active %>" href="/<%= @name %>s"><%= @name.camelcase %>s</a>
+<a class="nav-item <%="<"%>%= active %>" href="/<%= @name %>s"><%= class_name %>s</a>

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
@@ -1,2 +1,2 @@
 <%="<"%>%- active = context.request.path == "/<%= @name %>s" ? "active" : "" %>
-<a class="nav-item <%="<"%>%= active %>" href="/<%= @name %>s"><%= class_name %>s</a>
+<a class="nav-item <%="<"%>%= active %>" href="/<%= @name %>s"><%= display_name %>s</a>

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
@@ -1,2 +1,2 @@
 - active = context.request.path == "/<%= @name %>s" ? "active" : ""
-a class="nav-item #{active}" href="/<%= @name %>s" <%= @name.camelcase %>s
+a class="nav-item #{active}" href="/<%= @name %>s" <%= class_name %>s

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
@@ -1,2 +1,2 @@
 - active = context.request.path == "/<%= @name %>s" ? "active" : ""
-a class="nav-item #{active}" href="/<%= @name %>s" <%= @name.capitalize %>s
+a class="nav-item #{active}" href="/<%= @name %>s" <%= @name.camelcase %>s

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
@@ -1,2 +1,2 @@
 - active = context.request.path == "/<%= @name %>s" ? "active" : ""
-a class="nav-item #{active}" href="/<%= @name %>s" <%= class_name %>s
+a class="nav-item #{active}" href="/<%= @name %>s" <%= display_name %>s

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.ecr.ecr
@@ -1,3 +1,3 @@
-<h1>Edit <%= @name.capitalize %></h1>
+<h1>Edit <%= @name.camelcase %></h1>
 
 <%="<"%>%= render(partial: "_form.ecr") %>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.ecr.ecr
@@ -1,3 +1,3 @@
-<h1>Edit <%= @name.camelcase %></h1>
+<h1>Edit <%= class_name %></h1>
 
 <%="<"%>%= render(partial: "_form.ecr") %>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.ecr.ecr
@@ -1,3 +1,3 @@
-<h1>Edit <%= class_name %></h1>
+<h1>Edit <%= display_name %></h1>
 
 <%="<"%>%= render(partial: "_form.ecr") %>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.slang.ecr
@@ -1,3 +1,3 @@
-h1 Edit <%= @name.camelcase %>
+h1 Edit <%= class_name %>
 
 == render(partial: "_form.slang")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.slang.ecr
@@ -1,3 +1,3 @@
-h1 Edit <%= @name.capitalize %>
+h1 Edit <%= @name.camelcase %>
 
 == render(partial: "_form.slang")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/edit.slang.ecr
@@ -1,3 +1,3 @@
-h1 Edit <%= class_name %>
+h1 Edit <%= display_name %>
 
 == render(partial: "_form.slang")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-sm-11">
-    <h2><%= @name.camelcase %>s</h2>
+    <h2><%= class_name %>s</h2>
   </div>
   <div class="col-sm-1">
     <a class="btn btn-success btn-xs" href="/<%= @name %>s/new">New</a>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-sm-11">
-    <h2><%= @name.capitalize %>s</h2>
+    <h2><%= @name.camelcase %>s</h2>
   </div>
   <div class="col-sm-1">
     <a class="btn btn-success btn-xs" href="/<%= @name %>s/new">New</a>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-sm-11">
-    <h2><%= class_name %>s</h2>
+    <h2><%= display_name %>s</h2>
   </div>
   <div class="col-sm-1">
     <a class="btn btn-success btn-xs" href="/<%= @name %>s/new">New</a>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -1,6 +1,6 @@
 div.row
   div.col-sm-11
-    h2 <%= @name.capitalize %>s
+    h2 <%= @name.camelcase %>s
   div.col-sm-1
     a.btn.btn-success.btn-xs href="/<%= @name %>s/new" New
 div.table-responsive

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -1,6 +1,6 @@
 div.row
   div.col-sm-11
-    h2 <%= @name.camelcase %>s
+    h2 <%= class_name %>s
   div.col-sm-1
     a.btn.btn-success.btn-xs href="/<%= @name %>s/new" New
 div.table-responsive

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -1,6 +1,6 @@
 div.row
   div.col-sm-11
-    h2 <%= class_name %>s
+    h2 <%= display_name %>s
   div.col-sm-1
     a.btn.btn-success.btn-xs href="/<%= @name %>s/new" New
 div.table-responsive

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.ecr.ecr
@@ -1,3 +1,3 @@
-<h1>New <%= @name.camelcase %></h1>
+<h1>New <%= class_name %></h1>
 
 <%="<"%>%= render(partial: "_form.ecr") %>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.ecr.ecr
@@ -1,3 +1,3 @@
-<h1>New <%= @name.capitalize %></h1>
+<h1>New <%= @name.camelcase %></h1>
 
 <%="<"%>%= render(partial: "_form.ecr") %>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.ecr.ecr
@@ -1,3 +1,3 @@
-<h1>New <%= class_name %></h1>
+<h1>New <%= display_name %></h1>
 
 <%="<"%>%= render(partial: "_form.ecr") %>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.slang.ecr
@@ -1,3 +1,3 @@
-h1 New <%= @name.camelcase %>
+h1 New <%= class_name %>
 
 == render(partial: "_form.slang")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.slang.ecr
@@ -1,3 +1,3 @@
-h1 New <%= @name.capitalize %>
+h1 New <%= @name.camelcase %>
 
 == render(partial: "_form.slang")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/new.slang.ecr
@@ -1,3 +1,3 @@
-h1 New <%= class_name %>
+h1 New <%= display_name %>
 
 == render(partial: "_form.slang")

--- a/src/amber/cli/templates/socket/src/sockets/{{name}}_socket.cr.ecr
+++ b/src/amber/cli/templates/socket/src/sockets/{{name}}_socket.cr.ecr
@@ -1,4 +1,4 @@
-struct <%= @name.capitalize %>Socket < Amber::WebSockets::ClientSocket
+struct <%= @name.camelcase %>Socket < Amber::WebSockets::ClientSocket
   <%- @fields.each do |field| %>
     channel "<%= field.underscore %>_room:*", <%= field.capitalize %>Channel
   <%- end %>

--- a/src/amber/cli/templates/socket/src/sockets/{{name}}_socket.cr.ecr
+++ b/src/amber/cli/templates/socket/src/sockets/{{name}}_socket.cr.ecr
@@ -1,4 +1,4 @@
-struct <%= @name.camelcase %>Socket < Amber::WebSockets::ClientSocket
+struct <%= class_name %>Socket < Amber::WebSockets::ClientSocket
   <%- @fields.each do |field| %>
     channel "<%= field.underscore %>_room:*", <%= field.capitalize %>Channel
   <%- end %>

--- a/src/amber/cli/templates/template.cr
+++ b/src/amber/cli/templates/template.cr
@@ -20,12 +20,16 @@ require "./auth"
 module Amber::CLI
   class Template
     getter name : String
+    # getter filename : String
+    getter class_name : String
     getter directory : String
     getter fields : Array(String)
 
     def initialize(name : String, directory : String, fields = [] of String)
       if name.match(/\A[a-zA-Z]/)
-        @name = name
+        # @filename = name.underscore
+        @class_name = name.camelcase
+        @name = name.underscore
       else
         raise "Name is not valid."
       end

--- a/src/amber/cli/templates/template.cr
+++ b/src/amber/cli/templates/template.cr
@@ -20,15 +20,11 @@ require "./auth"
 module Amber::CLI
   class Template
     getter name : String
-    # getter filename : String
-    getter class_name : String
     getter directory : String
     getter fields : Array(String)
 
     def initialize(name : String, directory : String, fields = [] of String)
       if name.match(/\A[a-zA-Z]/)
-        # @filename = name.underscore
-        @class_name = name.camelcase
         @name = name.underscore
       else
         raise "Name is not valid."
@@ -142,6 +138,7 @@ end
 
 module Teeplate
   abstract class FileTree
+    @class_name : String?
     # Renders all collected file entries.
     #
     # For more information about the arguments, see `Renderer`.
@@ -155,6 +152,10 @@ module Teeplate
     # Override to filter files rendered
     def filter(entries)
       entries
+    end
+
+    def class_name
+      @class_name ||= @name.camelcase
     end
   end
 end

--- a/src/amber/cli/templates/template.cr
+++ b/src/amber/cli/templates/template.cr
@@ -139,6 +139,8 @@ end
 module Teeplate
   abstract class FileTree
     @class_name : String?
+    @display_name : String?
+
     # Renders all collected file entries.
     #
     # For more information about the arguments, see `Renderer`.
@@ -156,6 +158,14 @@ module Teeplate
 
     def class_name
       @class_name ||= @name.camelcase
+    end
+
+    def display_name
+      @display_name ||= generate_display_name
+    end
+
+    private def generate_display_name
+      @name.underscore.gsub('-', '_').split('_').map(&.capitalize).join(' ')
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

This changes how the generators handle file names and class names. It is related to #316 .
That issue was originally about controllers, but it applies to all the generators, so this fix addresses all of them.

I ended up added a lot of LOC to the test suite. Part of this is due to the `before_each` and `after_each` hooks in crystal being global (so I couldn't use them here), another reason is that the generators create a lot of files, checking each one takes a bit of code.

That said, I'm opening this PR for initial feedback to see if this approach is acceptable - both to testing and coding this fix. If there is a better way to structure the test suite, I'm all ears.

### Alternate Designs

I thought about DRY'ing the code up a bit so that `camelcase` wasn't used in so many places, but it would have required adding at least an instance variable and a getter to the `Template` - in the end that may be the best solution, in case the generators need to deal with other naming considerations (singular and plural).

I went with this solution to get something working, and provided a (hopefully) comprehensive set of tests if a refactor happens in the future.

### Benefits

It fixes issue #316 

### Possible Drawbacks

This change touches a lot of files and has an effect on every generator. Based on the test suite, everything is still generating as normal, but it is possible something breaks in the actual generation of files.

On my machine, one of the pre-existing tests is either not passing, or hanging indefinitely. I checked out the master branch and got the same results. 

It hangs here: https://github.com/amberframework/amber/blob/master/spec/amber/cli/commands/generator_spec.cr#L14

Or fails here: https://github.com/amberframework/amber/blob/master/spec/amber/cli/commands/generator_spec.cr#L16