### PR TITLE
Better Request Parsing Parameters

### DIFF
--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -4,8 +4,7 @@ struct UserSocket < Amber::WebSockets::ClientSocket; end
 
 struct RoomSocket < Amber::WebSockets::ClientSocket; end
 
-
-describe Amber do 
+describe Amber do
   describe ".env" do
     it "should return test" do
       Amber.env.test?.should be_truthy
@@ -54,9 +53,10 @@ describe Amber do
         settings.secret_key_base.should eq "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
       end
 
-      it "retains environment.yml settings that haven't been overwritten" do # NOTE: Any changes to settings here remain for all specs run afterwards.
-        # This is a problem.
-
+      it "retains environment.yml settings that haven't been overwritten" do
+        # NOTE: Any changes to settings here remain for all specs run afterwards.
+        # Added for convenience until settings is change to an instances
+        # instead of singleton this is still an "a problem".
         Amber::Server.configure do |server|
           server.name = "Hello World App"
           server.port = 8080

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -6,14 +6,15 @@ module Amber::CLI
       context "scaffold" do
         it "generates and compile generated app" do
           ENV["AMBER_ENV"] = "test"
-
           MainCommand.run ["new", TESTING_APP]
           Dir.cd(TESTING_APP)
           MainCommand.run ["generate", "scaffold", "Animal", "name:string"]
           Amber::CLI::Spec.prepare_yaml(Dir.current)
+
           `shards build`
 
-          File.exists?("bin/#{TESTING_APP.split("/").last}").should be_true
+          File.exists?("bin/#{TEST_APP_NAME}").should be_true
+
           Amber::CLI::Spec.cleanup
         end
       end
@@ -49,6 +50,7 @@ module Amber::CLI
           File.read("./config/routes.cr").includes?(routes_get).should be_true
           File.read("./config/routes.cr").includes?(routes_delete).should be_true
           File.read("./src/controllers/animal_controller.cr").should eq output_class
+
           Amber::CLI::Spec.cleanup
         end
       end

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -2,7 +2,7 @@ require "../../../spec_helper"
 
 describe HTTP::Server::Context do
   describe "#override_request_method!" do
-    describe "when X-HTTP-Method-Overrid is present" do
+    context "when X-HTTP-Method-Override is present" do
       it "overrides form POST method to PUT, PATCH, DELETE" do
         %w(PUT PATCH DELETE).each do |method|
           header = HTTP::Headers.new
@@ -147,23 +147,24 @@ describe HTTP::Server::Context do
   it "parses json hash" do
     headers = HTTP::Headers.new
     headers["Content-Type"] = "application/json"
-    body = "{\"test\":\"test\"}"
+    body = %({ "test": "test", "address": { "city": "New York" }})
     request = HTTP::Request.new("POST", "/", headers, body)
 
     context = create_context(request)
 
     context.params["test"].should eq "test"
+    context.params["address"].as(Hash)["city"].should eq "New York"
   end
 
   it "parses json array" do
     headers = HTTP::Headers.new
     headers["Content-Type"] = "application/json"
-    body = "[\"test\",\"test2\"]"
+    body = %(["test", "test2"])
     request = HTTP::Request.new("POST", "/", headers, body)
 
     context = create_context(request)
 
-    context.params["_json"].should eq "[\"test\", \"test2\"]"
+    context.params["_json"].should eq %w(test test2)
   end
 
   it "parses files from multipart forms" do

--- a/spec/amber/validations/params_spec.cr
+++ b/spec/amber/validations/params_spec.cr
@@ -4,7 +4,7 @@ module Amber::Validators
   describe BaseRule do
     describe "#apply" do
       it "raises error when missing field" do
-        params = HTTP::Params.parse("")
+        params = params_builder("")
         rule = BaseRule.new("field", "") do
           false
         end
@@ -15,7 +15,7 @@ module Amber::Validators
       end
 
       it "returns true for given block" do
-        params = HTTP::Params.parse("field=val")
+        params = params_builder("field=val")
         rule = BaseRule.new("field", "") do
           true
         end
@@ -24,7 +24,7 @@ module Amber::Validators
       end
 
       it "returns false for the given block" do
-        params = HTTP::Params.parse("field=val")
+        params = params_builder("field=val")
         rule = BaseRule.new("field", "") do
           false
         end
@@ -35,7 +35,7 @@ module Amber::Validators
 
     describe "#error" do
       it "returns default error message" do
-        params = HTTP::Params.parse("field=val")
+        params = params_builder("field=val")
         error_message = "Field field is required"
         rule = BaseRule.new("field", nil) do
           false
@@ -47,7 +47,7 @@ module Amber::Validators
       end
 
       it "returns the given error message" do
-        params = HTTP::Params.parse("field=val")
+        params = params_builder("field=val")
         error_message = "You must provide this field"
         rule = BaseRule.new("field", error_message) do
           false
@@ -63,17 +63,17 @@ module Amber::Validators
   describe OptionalRule do
     describe "#apply" do
       it "does not apply rule when field is missing" do
-        params = HTTP::Params.parse("")
+        params = params_builder("")
         error_message = "You must provide this field"
         rule = OptionalRule.new("field", error_message) do
-          false
+          true
         end
 
         rule.apply(params).should be_true
       end
 
       it "applies rule when field is present" do
-        params = HTTP::Params.parse("field=val")
+        params = params_builder("field=val")
         error_message = "You must provide this field"
         rule = OptionalRule.new("field", error_message) do
           true
@@ -87,12 +87,12 @@ module Amber::Validators
   describe Params do
     describe "#validation" do
       it "validates required field" do
-        http_params = HTTP::Params.parse("name=elias&last_name=perez&middle=j")
+        http_params = params_builder("name=elias&last_name=perez&middle=j")
         validator = Validators::Params.new(http_params)
 
         result = validator.validation do
-          required(:name) { |v| v.str? & !v.empty? }
-          required("last_name") { |v| v.str? & !v.empty? }
+          required(:name) { |v| !v.nil? }
+          required("last_name") { |v| !v.nil? }
         end
 
         validator.valid?.should be_true
@@ -102,12 +102,12 @@ module Amber::Validators
       context "optional params" do
         context "when missing" do
           it "does not validate optional field" do
-            http_params = HTTP::Params.parse("last_name=&middle=j")
+            http_params = params_builder("last_name=&middle=j")
             validator = Validators::Params.new(http_params)
 
             result = validator.validation do
-              optional(:name) { |v| v.empty? }
-              required("last_name") { |v| v.empty? }
+              optional(:name) { |v| !v.nil? }
+              required("last_name") { |v| !v.nil? }
             end
 
             validator.valid?.should be_true
@@ -117,15 +117,33 @@ module Amber::Validators
 
         context "when present" do
           it "validates optional field" do
-            http_params = HTTP::Params.parse("name=")
+            http_params = params_builder("name=")
             validator = Validators::Params.new(http_params)
 
             result = validator.validation do
-              optional(:name) { |v| !v.empty? }
+              optional(:name) { |v| v.nil? }
             end
 
             validator.valid?.should be_false
             validator.errors.size.should eq 1
+          end
+        end
+
+        context "casting" do
+          it "returns false for the given block" do
+            params = params_builder("name=john&number=1&price=3.45&list=[1,2,3]")
+            validator = Validators::Params.new(params)
+            validator.validation do
+              required(:name) { |f| !f.to_s.empty? }
+              required(:number) { |f| f.as(String).to_i > 0 }
+              required(:price) { |f| f.as(String).to_f == 3.45 }
+              required(:list) do |f|
+                list = JSON.parse(f.as(String)).as_a
+                (list == [1, 2, 3] && !list.includes? 6)
+              end
+            end
+
+            validator.valid?.should be_truthy
           end
         end
       end
@@ -133,24 +151,24 @@ module Amber::Validators
 
     describe "#valid?" do
       it "returns false with invalid fields" do
-        http_params = HTTP::Params.parse("name=john&last_name=doe&middle=j")
+        http_params = params_builder("name=john&last_name=doe&middle=j")
         validator = Validators::Params.new(http_params)
 
         validator.validation do
-          required("name") { |v| v.empty? }
-          required("last_name") { |v| v.str? & !v.empty? }
+          required("name") { |v| v.nil? }
+          required("last_name") { |v| !v.nil? }
         end
 
         validator.valid?.should be_false
       end
 
       it "returns false when key does not exist" do
-        http_params = HTTP::Params.parse("name=elias")
+        http_params = params_builder("name=elias")
         validator = Validators::Params.new(http_params)
         result = {"nonexisting" => {nil, "Param [nonexisting] does not exist."}}
 
         validator.validation do
-          required("nonexisting") { |v| v.str? & !v.empty? }
+          required("nonexisting") { |v| !v.nil? }
         end
 
         expect_raises Exceptions::Validator::InvalidParam do
@@ -159,12 +177,12 @@ module Amber::Validators
       end
 
       it "returns true with valid fields" do
-        http_params = HTTP::Params.parse("name=elias&last_name=perez&middle=j")
+        http_params = params_builder("name=elias&last_name=perez&middle=j")
         validator = Validators::Params.new(http_params)
 
         validator.validation do
-          required("name") { |v| v.str? & !v.empty? }
-          required("last_name") { |v| v.str? & !v.empty? }
+          required("name") { |v| !v.nil? }
+          required("last_name") { |v| !v.nil? }
         end
 
         validator.valid?.should be_true
@@ -173,12 +191,12 @@ module Amber::Validators
 
     describe "#validate!" do
       it "raises error on failed validation" do
-        http_params = HTTP::Params.parse("name=elias&last_name=perez&middle=j")
+        http_params = params_builder("name=&last_name=&middle=j")
         validator = Validators::Params.new(http_params)
 
         validator.validation do
-          required("name") { |v| v.str? & v.empty? }
-          required("last_name") { |v| v.str? & !v.empty? }
+          required("name") { |v| !v.to_s.empty? }
+          required("last_name") { |v| !v.to_s.empty? }
         end
 
         expect_raises Exceptions::Validator::ValidationFailed do
@@ -187,17 +205,27 @@ module Amber::Validators
       end
 
       it "returns validated params on successful validation" do
-        http_params = HTTP::Params.parse("name=elias&last_name=perez&middle=j")
+        http_params = params_builder("name=elias&last_name=perez&middle=j")
         validator = Validators::Params.new(http_params)
         result : Hash(String, String) = {"name" => "elias", "last_name" => "perez"}
 
         validator.validation do
-          required("name") { |v| v.str? & !v.empty? }
-          required("last_name") { |v| v.str? & !v.empty? }
+          required("name") { |v| !v.nil? }
+          required("last_name") { |v| !v.nil? }
         end
 
         validator.validate!.should eq result
       end
     end
+  end
+end
+
+def params_builder(body = "")
+  params = {} of String | Symbol => Amber::Router::ParamsType
+  return params if body.empty?
+
+  body.tr("?", "").split("&").each_with_object(params) do |item, params|
+    key, value = item.split("=")
+    params[key] = value
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,12 +1,13 @@
 # NOTE: Constants should be set before require begins.
 
 ENV["AMBER_ENV"] = "test"
-TEST_PATH    = "spec/support/sample"
-PUBLIC_PATH  = TEST_PATH + "/public"
-VIEWS_PATH   = TEST_PATH + "/views"
-TESTING_APP  = "./tmp/test_app"
-APP_TPL_PATH = "./src/amber/cli/templates/app"
-CURRENT_DIR  = Dir.current
+TEST_PATH     = "spec/support/sample"
+PUBLIC_PATH   = TEST_PATH + "/public"
+VIEWS_PATH    = TEST_PATH + "/views"
+TEST_APP_NAME = "test_app"
+TESTING_APP   = "./tmp/#{TEST_APP_NAME}"
+APP_TPL_PATH  = "./src/amber/cli/templates/app"
+CURRENT_DIR   = Dir.current
 
 require "http"
 require "spec"

--- a/src/amber/cli/commands.cr
+++ b/src/amber/cli/commands.cr
@@ -49,7 +49,7 @@ module Amber::CLI
       help desc: "# Describe available commands and usages"
       string ["-t", "--template"], desc: "# Preconfigure for selected template engine. Options: slang | ecr", default: "slang"
       string ["-d", "--database"], desc: "# Preconfigure for selected database. Options: pg | mysql | sqlite", default: "pg"
-      string ["-m", "--model"],    desc: "# Preconfigure for selected model. Options: granite | crecto", default: "granite"
+      string ["-m", "--model"], desc: "# Preconfigure for selected model. Options: granite | crecto", default: "granite"
     end
   end
 end

--- a/src/amber/cli/templates/auth.cr
+++ b/src/amber/cli/templates/auth.cr
@@ -25,7 +25,7 @@ module Amber::CLI
       @timestamp = Time.now.to_s("%Y%m%d%H%M%S")
       @primary_key = primary_key
       @visible_fields = @fields.reject(&.hidden).map(&.name)
-      
+
       add_routes :web, <<-ROUTES
         get "/signin", SessionController, :new
           post "/session", SessionController, :create
@@ -37,7 +37,7 @@ module Amber::CLI
       add_plugs :web, <<-PLUGS
         plug Authenticate.new
       PLUGS
-      
+
       add_dependencies <<-DEPENDENCY
       require "../src/models/**"
       require "../src/handlers/**"

--- a/src/amber/cli/templates/auth.cr
+++ b/src/amber/cli/templates/auth.cr
@@ -28,10 +28,10 @@ module Amber::CLI
 
       add_routes :web, <<-ROUTES
         get "/signin", SessionController, :new
-          post "/session", SessionController, :create
-          get "/signout", SessionController, :delete
-          get "/signup", RegistrationController, :new
-          post "/registration", RegistrationController, :create
+        post "/session", SessionController, :create
+        get "/signout", SessionController, :delete
+        get "/signup", RegistrationController, :new
+        post "/registration", RegistrationController, :create
       ROUTES
 
       add_plugs :web, <<-PLUGS

--- a/src/amber/cli/templates/auth/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/registration_controller.cr.ecr
@@ -5,8 +5,8 @@ class RegistrationController < ApplicationController
   end
 
   def create
-    <%= @name %> = <%= @name.capitalize %>.new(params.to_h.select(<%= @visible_fields %>))
-    <%= @name %>.password = params["password"]
+    <%= @name %> = <%= @name.capitalize %>.new(registration_params.validate!)
+    <%= @name %>.password = params["password"].to_s
 
     if <%= @name %>.valid? && <%= @name %>.save
       session[:<%= @name %>_id] = <%= @name %>.id
@@ -15,6 +15,13 @@ class RegistrationController < ApplicationController
     else
       flash["danger"] = "Could not create <%= @name.capitalize %>!"
       render("new.<%= @language %>")
+    end
+  end
+
+  private def registration_params
+    params.validation do
+      required(:email) { |f| !f.nil? }
+      required(:password) { |f| !f.nil? }
     end
   end
 end

--- a/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
@@ -5,8 +5,8 @@ class SessionController < ApplicationController
   end
 
   def create
-    <%= @name %> = <%= @name.capitalize %>.find_by(:email, params["email"])
-    if <%= @name %> && <%= @name %>.authenticate(params["password"])
+    <%= @name %> = <%= @name.capitalize %>.find_by(:email, params["email"].to_s)
+    if <%= @name %> && <%= @name %>.authenticate(params["password"].to_s)
         session[:<%= @name %>_id] = <%= @name %>.id
         flash[:info] = "Successfully logged in"
         redirect_to "/"
@@ -19,7 +19,7 @@ class SessionController < ApplicationController
 
   def delete
     session.delete(:<%= @name %>_id)
-    flash[:info] = "Logged out.  See ya later!"
+    flash[:info] = "Logged out. See ya later!"
     redirect_to "/"
   end
 end

--- a/src/amber/cli/templates/scaffold/controller.cr
+++ b/src/amber/cli/templates/scaffold/controller.cr
@@ -51,4 +51,3 @@ module Amber::CLI::Scaffold
     end
   end
 end
-

--- a/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -19,7 +19,7 @@ class <%= @name.capitalize %>Controller < ApplicationController
   end
 
   def create
-    <%= @name %> = <%= @name.capitalize %>.new(params.to_h.select(<%= @visible_fields %>))
+    <%= @name %> = <%= @name.capitalize %>.new(<%= @name.downcase%>_params.validate!)
 
     if <%= @name %>.valid? && <%= @name %>.save
       flash["success"] = "Created <%= @name.capitalize %> successfully."
@@ -41,7 +41,7 @@ class <%= @name.capitalize %>Controller < ApplicationController
 
   def update
     if <%= @name %> = <%= @name.capitalize %>.find(params["id"])
-      <%= @name %>.set_attributes(params.to_h.select(<%= @visible_fields %>))
+      <%= @name %>.set_attributes(<%= @name.downcase%>_params.validate!)
       if <%= @name %>.valid? && <%= @name %>.save
         flash["success"] = "Updated <%= @name.capitalize %> successfully."
         redirect_to "/<%= @name %>s"
@@ -62,5 +62,13 @@ class <%= @name.capitalize %>Controller < ApplicationController
       flash["warning"] = "<%= @name.capitalize %> with ID #{params["id"]} Not Found"
     end
     redirect_to "/<%= @name %>s"
+  end
+
+  def <%= @name %>_params
+    params.validation do
+      <%- @visible_fields.each do |field| -%>
+      required(:<%= field %>) { |f| !f.nil? }
+      <%- end -%>
+    end
   end
 end

--- a/src/amber/controller/static.cr
+++ b/src/amber/controller/static.cr
@@ -8,4 +8,3 @@ module Amber::Controller
     end
   end
 end
-

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -21,7 +21,7 @@ class HTTP::Server::Context
   include Amber::Router::Files
   include Amber::Router::Session
   include Amber::Router::Flash
-  include Amber::Router::Params
+  include Amber::Router::ParamsParser
 
   getter router : Amber::Router::Router
   setter flash : Amber::Router::Flash::FlashStore?

--- a/src/amber/router/params_parser.cr
+++ b/src/amber/router/params_parser.cr
@@ -1,14 +1,16 @@
 require "json"
 
 module Amber::Router
-  # The Params module will parse parameters from a URL, a form post or a JSON
+  alias ParamsType = String | JSON::Type
+  alias ParamsHash = Hash(String | Symbol, Amber::Router::ParamsType)
+
+  # The Parameters module will parse parameters from a URL, a form post or a JSON
   # post and provide them in the self params hash.  This unifies access to
   # parameters into one place to simplify access to them.
   # Note: other params from the router will be handled in the router handler
   # instead of here.  This removes a dependency on the router in case it is
   # replaced or not needed.
-  module Params
-    property params = HTTP::Params.new({} of String => Array(String))
+  module ParamsParser
     URL_ENCODED_FORM = "application/x-www-form-urlencoded"
     MULTIPART_FORM   = "multipart/form-data"
     APPLICATION_JSON = "application/json"
@@ -16,13 +18,12 @@ module Amber::Router
     OVERRIDE_HEADER  = "X-HTTP-Method-Override"
     OVERRIDE_METHODS = %w(PATCH PUT DELETE)
 
+    property params = Hash(String | Symbol, ParamsType).new
+
     @override_method : String?
 
-    alias ParamTypes = Nil | String | Int64 | Float64 | Bool | Hash(String, JSON::Type) | Array(JSON::Type)
-
-    # clear the params.
     def clear_params
-      @params = HTTP::Params.new({} of String => Array(String))
+      @params = Hash(String | Symbol, ParamsType).new
     end
 
     def parse_params
@@ -73,11 +74,11 @@ module Amber::Router
     end
 
     private def override_method
-      @override_method ||= (params[METHOD]? || override_header?).try &.upcase
+      @override_method ||= (params[METHOD]? || override_header?).try &.to_s.upcase
     end
 
     def merge_route_params
-      route_params.each { |k, v| params.add(k.to_s, v) }
+      route_params.each { |k, v| params[k] = v }
     end
 
     def route_params
@@ -87,13 +88,13 @@ module Amber::Router
     def parse_json
       if body = request.body.not_nil!.gets_to_end
         if body.size > 2
-          case json = JSON.parse(body).raw
+          case json = JSON.parse_raw(body)
           when Hash
             json.each do |key, value|
-              params[key.as(String)] = value.to_s
+              params[key.as(String)] = value
             end
           when Array
-            params["_json"] = json.to_s
+            params["_json"] = json
           end
         end
       end
@@ -106,7 +107,7 @@ module Amber::Router
         if filename.is_a?(String) && !filename.empty?
           files[upload.name] = Files::File.new(upload: upload)
         else
-          params.add(upload.name, upload.body.gets_to_end)
+          params[upload.name] = upload.body.gets_to_end
         end
       end
     end
@@ -122,7 +123,7 @@ module Amber::Router
                end
 
       HTTP::Params.parse(values) do |key, value|
-        params.add(key, value)
+        params[key] = value
       end
     end
   end

--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -25,7 +25,7 @@ module Amber
       protected getter id : String
       getter socket : HTTP::WebSocket
       protected getter context : HTTP::Server::Context
-      protected getter raw_params : HTTP::Params
+      protected getter raw_params : Amber::Router::ParamsHash
       protected getter params : Amber::Validators::Params
       protected getter session : Amber::Router::Session::AbstractStore?
       protected getter cookies : Amber::Router::Cookies::Store?


### PR DESCRIPTION
Edited by @eliasjpr
### Description of the Change

The framework should be able to parse JSON request body appropriately by
returning a `JSON::Any` object.

Currently, there is a bug when trying to parse JSON parameters from the
body of a request where nested JSON payload is not being parsed correctly

```crystal
{ "test": "test", "address": { "city": "New York" }
params["address"].as(Hash)["city"]
```
Params is now a custom Hash of the following signature
`Hash(String | Symbol, Amber::Router::ParamsType)` or
`Amber::Router::ParamsHash.new`

To give more context all parameters where being parsed using the
**HTTP::Params.parse** method which returns an object of type
**Hash(String, Array(String))** this caused issues when parsing
JSON params from the body, It turns out that nested JSON keys where
being parsed as a string. Basically, all `params` values are currently
returning as a string.

With the changes presented in this PR users can now define model objects
with JSON mapping that should be evaluated correctly based on the mapping
defined. 

**Controller**
The controller now generates the app using params.validation similar to
Rails strong params. It adds a method to the Controller and overloads the
Granite initializer and set_attributes methods.

```crystal
private def animal_params
  params.validation do
    required(:name) { |v| v.str? & !v.empty? }
    required(:last_name, "Last name is required")
    optional(:phone)  
  end
end

# Validate! returns a hash of only the specified params above.
animal = Animal.new(animal_params.validate!)
```

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Alternate Designs

It would be nice to specify a type that can be cast automatically

```crystal
required(:last_name, :string, "Last name is required") do
...validation code here...
end
```

### Benefits
- Fixes Issue: https://github.com/amberframework/amber/issues/310
- Parses JSON body as JSON::Type. with this type user can convert to the correct type either using 
`.to_i`, `.to_f`, `.to_s` or traverse the JSON using `json = JSON.parse(params["some_key"])`
- Uses params.validation to validate request params before any processing. Inspired by http://hanamirb.org/guides/1.0/actions/parameters/#validations-amp-coercion
- Updates Auth, scaffold generators to use the params.validation

### Possible Drawbacks

-Fear something can break

### Example app using this branch 
https://github.com/eliasjpr/params-test-app
