### PR TITLE
Fix postgresql database naming convention

### DIFF
--- a/spec/amber/cli/commands/init_spec.cr
+++ b/spec/amber/cli/commands/init_spec.cr
@@ -20,6 +20,21 @@ module Amber::CLI
       end
 
       context "database" do
+        context "postgres" do
+          MainCommand.run ["new", TESTING_APP]
+          it "creates app with correct settings" do
+            Amber::CLI::Spec.shard_yml["dependencies"]["pg"].should_not be_nil
+            Amber::CLI::Spec.db_yml["pg"].should_not be_nil
+            db_url = Amber::CLI::Spec.db_yml["pg"]["database"].as_s
+            db_url.should_not be_nil
+
+            db_name = Amber::CLI::Spec.db_name(db_url)
+            db_name.should_not eq ""
+            db_name.should_not contain "-"
+          end
+          Amber::CLI::Spec.cleanup
+        end
+
         it "create app with mysql settings" do
           MainCommand.run ["new", TESTING_APP, "-d", "mysql", "-t", "ecr"]
 

--- a/spec/amber/cli/commands/init_spec.cr
+++ b/spec/amber/cli/commands/init_spec.cr
@@ -47,6 +47,20 @@ module Amber::CLI
               db_name.should_not contain "-"
             end
           end
+
+          it "creates app with correct docker-compose database urls and names" do
+            db_env_db_name = Amber::CLI::Spec.docker_compose_yml["services"]["db"]["environment"]["POSTGRES_DB"].as_s
+            app_env_db_url = Amber::CLI::Spec.docker_compose_yml["services"]["app"]["environment"]["DATABASE_URL"].as_s
+            app_env_db_name = Amber::CLI::Spec.db_name(app_env_db_url)
+            migrate_env_db_url = Amber::CLI::Spec.docker_compose_yml["services"]["migrate"]["environment"]["DATABASE_URL"].as_s
+            migrate_env_db_name = Amber::CLI::Spec.db_name(migrate_env_db_url)
+
+            [db_env_db_name, app_env_db_name, migrate_env_db_name].each do |db_name|
+              db_name.should_not eq ""
+              db_name.should contain "development"
+              db_name.should_not contain "-"
+            end
+          end
           Amber::CLI::Spec.cleanup
         end
 

--- a/spec/amber/cli/commands/init_spec.cr
+++ b/spec/amber/cli/commands/init_spec.cr
@@ -32,6 +32,21 @@ module Amber::CLI
             db_name.should_not eq ""
             db_name.should_not contain "-"
           end
+
+          it "creates app with correct environment database urls" do
+            dev_db_url = Amber::CLI::Spec.development_yml["secrets"]["database"].as_s
+            dev_db_url.should_not eq ""
+            dev_db_url.should contain "development"
+            test_db_url = Amber::CLI::Spec.test_yml["secrets"]["database"].as_s
+            test_db_url.should_not eq ""
+            test_db_url.should contain "test"
+
+            [dev_db_url, test_db_url].each do |db_url|
+              db_name = Amber::CLI::Spec.db_name(db_url)
+              db_name.should_not eq ""
+              db_name.should_not contain "-"
+            end
+          end
           Amber::CLI::Spec.cleanup
         end
 

--- a/spec/amber/cli/templates/app_spec.cr
+++ b/spec/amber/cli/templates/app_spec.cr
@@ -1,0 +1,21 @@
+require "../../../spec_helper"
+
+module Amber::CLI
+  describe App do
+    pg_app = App.new("sample-app")
+    mysql_app = App.new("sample-app", "mysql")
+    sqlite_app = App.new("sample-app", "sqlite")
+
+    describe "#database_name_base" do
+      it "should return a postgres compatible name" do
+        pg_app.database_name_base.should_not contain "-"
+      end
+
+      it "should return a consistent name for all db types" do
+        mysql_app.database_name_base.should eq pg_app.database_name_base
+        sqlite_app.database_name_base.should eq pg_app.database_name_base
+      end
+    end
+
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -30,6 +30,15 @@ module Amber::CLI::Spec
     gen_dirs.map { |dir| dir[(app.size + 1)..-1] }
   end
 
+  def db_name(db_url : String) : String
+    db_name(URI.parse(db_url))
+  end
+
+  def db_name(db_uri : URI) : String
+    path = db_uri.path
+    path ? path.split('/').last : ""
+  end
+
   def db_yml
     YAML.parse(File.read("#{TESTING_APP}/config/database.yml"))
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -67,6 +67,10 @@ module Amber::CLI::Spec
     environment_yml("test")
   end
 
+  def docker_compose_yml
+    YAML.parse(File.read("#{TESTING_APP}/docker-compose.yml"))
+  end
+
   def prepare_yaml(path)
     shard = File.read("#{path}/shard.yml")
     shard = shard.gsub("github: amberframework/amber\n", "path: ../../\n")

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,7 +4,7 @@ ENV["AMBER_ENV"] = "test"
 TEST_PATH     = "spec/support/sample"
 PUBLIC_PATH   = TEST_PATH + "/public"
 VIEWS_PATH    = TEST_PATH + "/views"
-TEST_APP_NAME = "test_app"
+TEST_APP_NAME = "sample-app"
 TESTING_APP   = "./tmp/#{TEST_APP_NAME}"
 APP_TPL_PATH  = "./src/amber/cli/templates/app"
 CURRENT_DIR   = Dir.current
@@ -49,6 +49,22 @@ module Amber::CLI::Spec
 
   def shard_yml
     YAML.parse(File.read("#{TESTING_APP}/shard.yml"))
+  end
+
+  def environment_yml(environment : String)
+    YAML.parse(File.read("#{TESTING_APP}/config/environments/#{environment}.yml"))
+  end
+
+  def development_yml
+    environment_yml("development")
+  end
+
+  def production_yml
+    environment_yml("production")
+  end
+
+  def test_yml
+    environment_yml("test")
   end
 
   def prepare_yaml(path)

--- a/src/amber/cli/templates/app.cr
+++ b/src/amber/cli/templates/app.cr
@@ -1,9 +1,11 @@
 module Amber::CLI
   class App < Teeplate::FileTree
     directory "#{__DIR__}/app"
+    getter database_name_base
 
     @name : String
     @database : String
+    @database_name_base : String
     @language : String
     @model : String
     @db_url : String
@@ -12,10 +14,16 @@ module Amber::CLI
     def initialize(@name, @database = "pg", @language = "slang", @model = "granite")
       @db_url = ""
       @wait_for = ""
+      @database_name_base = generate_database_name_base
     end
 
     def filter(entries)
       entries.reject { |entry| entry.path.includes?("src/views") && !entry.path.includes?("#{@language}") }
     end
+
+    private def generate_database_name_base
+      @name.gsub('-','_')
+    end
+
   end
 end

--- a/src/amber/cli/templates/app/config/database.yml.ecr
+++ b/src/amber/cli/templates/app/config/database.yml.ecr
@@ -3,7 +3,7 @@
    when "mysql" -%>
   database: mysql://root@localhost:3306/<%= "#{@name}_development" %>
 <% when "pg" -%>
-  database: postgres://root:@localhost:5432/<%= "#{@name}_development" %>
+  database: postgres://root:@localhost:5432/<%= "#{@name.gsub('-','_')}_development" %>
 <% when "sqlite" -%>
   database: sqlite3:./db/<%= "#{@name}_development" %>.db
 <% end -%>

--- a/src/amber/cli/templates/app/config/database.yml.ecr
+++ b/src/amber/cli/templates/app/config/database.yml.ecr
@@ -1,9 +1,9 @@
 <%= @database %>:
 <% case @database
    when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= "#{@name}_development" %>
+  database: mysql://root@localhost:3306/<%= "#{database_name_base}_development" %>
 <% when "pg" -%>
-  database: postgres://postgres:@localhost:5432/<%= "#{@name.gsub('-','_')}_development" %>
+  database: postgres://postgres:@localhost:5432/<%= "#{database_name_base}_development" %>
 <% when "sqlite" -%>
-  database: sqlite3:./db/<%= "#{@name}_development" %>.db
+  database: sqlite3:./db/<%= "#{database_name_base}_development" %>.db
 <% end -%>

--- a/src/amber/cli/templates/app/config/database.yml.ecr
+++ b/src/amber/cli/templates/app/config/database.yml.ecr
@@ -3,7 +3,7 @@
    when "mysql" -%>
   database: mysql://root@localhost:3306/<%= "#{@name}_development" %>
 <% when "pg" -%>
-  database: postgres://root:@localhost:5432/<%= "#{@name.gsub('-','_')}_development" %>
+  database: postgres://postgres:@localhost:5432/<%= "#{@name.gsub('-','_')}_development" %>
 <% when "sqlite" -%>
   database: sqlite3:./db/<%= "#{@name}_development" %>.db
 <% end -%>

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -18,9 +18,9 @@ secrets:
   description: Store your development secrets credentials and settings here.
 <%case @database
   when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= @name %>_development
+  database: mysql://root@localhost:3306/<%= database_name_base %>_development
 <%when "pg" -%>
-  database: postgres://postgres:@pg:5432/<%= @name.gsub('-','_') %>_development
+  database: postgres://postgres:@pg:5432/<%= database_name_base %>_development
 <%when "sqlite" -%>
-  database: sqlite3:./db/<%= @name %>_development.db
+  database: sqlite3:./db/<%= database_name_base %>_development.db
 <%end -%>

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -20,7 +20,7 @@ secrets:
   when "mysql" -%>
   database: mysql://root@localhost:3306/<%= @name %>_development
 <%when "pg" -%>
-  database: postgres://postgres:@pg:5432/<%= @name %>_development
+  database: postgres://postgres:@pg:5432/<%= @name.gsub('-','_') %>_development
 <%when "sqlite" -%>
   database: sqlite3:./db/<%= @name %>_development.db
 <%end -%>

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -18,9 +18,9 @@ secrets:
   description: Store your production secrets credentials and settings here.
 <%case @database
   when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= @name %>
+  database: mysql://root@localhost:3306/<%= database_name_base %>
 <%when "pg" -%>
-  database: postgres://postgres:@pg:5432/<%= @name.gsub('-','_') %>
+  database: postgres://postgres:@pg:5432/<%= database_name_base %>
 <%when "sqlite" -%>
-  database: sqlite3:./db/<%= @name %>.db
+  database: sqlite3:./db/<%= database_name_base %>.db
 <%end -%>

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -20,7 +20,7 @@ secrets:
   when "mysql" -%>
   database: mysql://root@localhost:3306/<%= @name %>
 <%when "pg" -%>
-  database: postgres://postgres:@pg:5432/<%= @name %>
+  database: postgres://postgres:@pg:5432/<%= @name.gsub('-','_') %>
 <%when "sqlite" -%>
   database: sqlite3:./db/<%= @name %>.db
 <%end -%>

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -20,7 +20,7 @@ secrets:
   when "mysql" -%>
   database: mysql://root@localhost:3306/<%= @name %>_test
 <%when "pg" -%>
-  database: postgres://postgres:@pg:5432/<%= @name %>_test
+  database: postgres://postgres:@pg:5432/<%= @name.gsub('-','_') %>_test
 <%when "sqlite" -%>
   database: sqlite3:./db/<%= @name %>_test.db
 <%end -%>

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -18,9 +18,9 @@ secrets:
   description: Store your test secrets credentials and settings here.
 <%case @database
   when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= @name %>_test
+  database: mysql://root@localhost:3306/<%= database_name_base %>_test
 <%when "pg" -%>
-  database: postgres://postgres:@pg:5432/<%= @name.gsub('-','_') %>_test
+  database: postgres://postgres:@pg:5432/<%= database_name_base %>_test
 <%when "sqlite" -%>
-  database: sqlite3:./db/<%= @name %>_test.db
+  database: sqlite3:./db/<%= database_name_base %>_test.db
 <%end -%>

--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -1,5 +1,5 @@
 <% if @database == "pg"
-     @db_url = "postgres://admin:password@db:5432/#{@name}_development"
+     @db_url = "postgres://admin:password@db:5432/#{@name.gsub('-','_')}_development"
      @wait_for = "while ! nc -q 1 db 5432 </dev/null; do sleep 1; done && "
    elsif @database == "mysql"
      @db_url = "mysql://admin:password@db:3306/#{@name}_development"
@@ -59,7 +59,7 @@ services:
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: <%= "#{@name}_development" %>
+      POSTGRES_DB: <%= "#{@name.gsub('-','_')}_development" %>
     volumes:
       - 'db:/var/lib/postgres/data'
 <% elsif @database == "mysql" -%>

--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -59,7 +59,7 @@ services:
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: password
-      POSTGRES_DB: <%= "#{@name.gsub('-','_')}_development" %>
+      POSTGRES_DB: <%= "#{database_name_base}_development" %>
     volumes:
       - 'db:/var/lib/postgres/data'
 <% elsif @database == "mysql" -%>
@@ -68,7 +68,7 @@ services:
     environment:
       MYSQL_USER: admin
       MYSQL_PASSWORD: password
-      MYSQL_DATABASE: <%= "#{@name}_development" %>
+      MYSQL_DATABASE: <%= "#{database_name_base}_development" %>
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
     volumes:
       - 'db:/var/lib/mysql'

--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -1,11 +1,11 @@
 <% if @database == "pg"
-     @db_url = "postgres://admin:password@db:5432/#{@name.gsub('-','_')}_development"
+     @db_url = "postgres://admin:password@db:5432/#{database_name_base}_development"
      @wait_for = "while ! nc -q 1 db 5432 </dev/null; do sleep 1; done && "
    elsif @database == "mysql"
-     @db_url = "mysql://admin:password@db:3306/#{@name}_development"
+     @db_url = "mysql://admin:password@db:3306/#{database_name_base}_development"
      @wait_for = "while ! nc -q 1 db 3306 </dev/null; do sleep 1; done && "
    else
-     @db_url = "sqlite3:./db/#{@name}_development.db"
+     @db_url = "sqlite3:./db/#{database_name_base}_development.db"
      @wait_for = ""
    end
 -%>


### PR DESCRIPTION
### Description of the Change

This fixes the issue that if an app name has a dash "-" in it, then an invalid database name will be generated for postgresql.

### Alternate Designs

Some alternative choices:
- Treat the database name consistently, and have this convention apply to all database types
- Refactor to have the database name generation take place in one spot, instead of across many files

Adopting the first would make the second easier to accomplish.

### Benefits

Users will not face errors generating a new postgresql database when their app name has a dash in it. Fixes #329 

### Possible Drawbacks

As written, this will create inconsistent database names between postgresql and other databases.

Also, I changed the name of the `TESTING_APP` from `test_app` to `sample-app`. It didn't cause any pre-existing tests to fail, so I don't think it is an issue.
