### PR TITLE
Move build test to its own file and test more aspects of build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - docker build -t amber-spec -f spec/Dockerfile .
 
 script:
-  - docker-compose -f spec/docker-compose.yml run spec -D run_build_tests
+  - docker-compose -f spec/docker-compose.yml run spec
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - docker build -t amber-spec -f spec/Dockerfile .
 
 script:
-  - docker-compose -f spec/docker-compose.yml run spec
+  - docker-compose -f spec/docker-compose.yml run spec -D run_build_tests
 
 notifications:
   webhooks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: '2'
 services:
   spec:
     build: .
-    command: 'bash -c "cd /app/user && crystal spec"'
+    command: 'bash -c "cd /app/user && crystal spec -D run_build_tests"'
     working_dir: /app/user
     tmpfs: /app/testing

--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -6,4 +6,4 @@ ADD . /app/user
 
 RUN crystal deps
 
-CMD ["crystal", "spec"]
+CMD ["crystal", "spec", "-D", "run_build_tests"]

--- a/spec/amber/cli/build_spec.cr
+++ b/spec/amber/cli/build_spec.cr
@@ -1,0 +1,40 @@
+{% if flag?(:run_build_tests) %}
+require "../../spec_helper"
+
+module Amber::CLI
+  begin
+    describe "building a generated app" do
+      ENV["AMBER_ENV"] = "test"
+      MainCommand.run ["new", TESTING_APP]
+      Dir.cd(TESTING_APP)
+      MainCommand.run ["generate", "scaffold", "Animal", "name:string"]
+      Amber::CLI::Spec.prepare_yaml(Dir.current)
+
+      build_result = `shards build`
+      db_result = `amber db drop create migrate`
+
+      it `generates a binary` do
+        File.exists?("bin/#{TEST_APP_NAME}").should be_true
+      end
+
+      context "crystal spec" do
+        spec_result = `crystal spec`
+
+        it "can be executed" do
+          spec_result.should contain "Finished in"
+        end
+
+        it "has no errors" do
+          spec_result.should_not contain "Error in line"
+        end
+
+        it "has no failures" do
+          spec_result.should_not contain "Failures"
+        end
+      end
+    end
+  ensure
+    Amber::CLI::Spec.cleanup
+  end
+end
+{% end %}

--- a/spec/amber/cli/build_spec.cr
+++ b/spec/amber/cli/build_spec.cr
@@ -7,7 +7,18 @@ module Amber::CLI
       ENV["AMBER_ENV"] = "test"
       MainCommand.run ["new", TESTING_APP]
       Dir.cd(TESTING_APP)
-      MainCommand.run ["generate", "scaffold", "Animal", "name:string"]
+
+      options = ["user:reference", "name:string", "body:text", "age:integer", "published:bool"]
+      MainCommand.run ["generate", "auth", "User"] | (options - ["user:reference"])
+      MainCommand.run ["generate", "scaffold", "Animal"] | options
+      MainCommand.run ["generate", "scaffold", "Post"] | options
+      MainCommand.run ["generate", "scaffold", "PostComment"] | (options + ["post:reference"])
+      MainCommand.run ["generate", "model", "Bat"] | options
+      MainCommand.run ["generate", "migration", "Crocodile"] | options
+      MainCommand.run ["generate", "mailer", "Dinosaur"] | options
+      MainCommand.run ["generate", "socket", "Eagle"] | options
+      MainCommand.run ["generate", "channel", "Falcon"] | options
+
       Amber::CLI::Spec.prepare_yaml(Dir.current)
 
       build_result = `shards build`

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -4,19 +4,6 @@ module Amber::CLI
   begin
     describe MainCommand::Generate do
       context "scaffold" do
-        it "generates and compile generated app" do
-          ENV["AMBER_ENV"] = "test"
-          MainCommand.run ["new", TESTING_APP]
-          Dir.cd(TESTING_APP)
-          MainCommand.run ["generate", "scaffold", "Animal", "name:string"]
-          Amber::CLI::Spec.prepare_yaml(Dir.current)
-
-          `shards build`
-
-          File.exists?("bin/#{TEST_APP_NAME}").should be_true
-
-          Amber::CLI::Spec.cleanup
-        end
 
         it "follows naming conventions for all files and class names" do
           camel_case = "PostComment"


### PR DESCRIPTION
### Description of the Change

This addresses #342 and should also provide a more complete test of the build process.

There will be a couple tests failing, as soon as I update the `docker-compose.yml` to run the build tests. **This is a good thing**. It has uncovered that currently, the controller spec tests that are generated from a scaffold will error out.

So, if a user does `amber new app && cd app && amber g scaffold Animal name:string && amber db create migrate && crystal spec` - There will be 3 failures before they touch any code.

### Alternate Designs

Using environment variables, but I think using the flags is better.

### Benefits

By default the test suite will run much faster during development and by default the test suite will run the build tests for CI (and anything using docker-compose)

### Possible Drawbacks

A developer may forget to run the build tests before pushing and opening a PR.
