### PR TITLE
cli: implement `db create/drop` for sqlite3

### DIFF
--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -6,6 +6,34 @@ include CLIHelper
 include CLIFixtures
 
 module Amber::CLI
+  context "sqlite" do
+    cleanup
+    MainCommand.run ["new", TESTING_APP, "-d", "sqlite"]
+
+    describe "database" do
+      db_filename = db_yml["sqlite"]["database"].to_s.sub("sqlite3:", "")
+
+      Dir.cd(TESTING_APP)
+
+      it "does not create the database when `db create`" do
+        MainCommand.run ["db", "create"]
+        File.exists?(db_filename).should be_false
+      end
+
+      it "does create the database when `db migrate`" do
+        MainCommand.run ["generate", "model", "Post"]
+        MainCommand.run ["db", "migrate"]
+        File.exists?(db_filename).should be_true
+        File.stat(db_filename).size.should_not eq 0
+      end
+
+      it "deletes the database when `db drop`" do
+        MainCommand.run ["db", "drop"]
+        File.exists?(db_filename).should be_false
+      end
+    end
+  end
+
   describe "amber generate" do
     ENV["AMBER_ENV"] = "test"
     camel_case = "PostComment"


### PR DESCRIPTION
When running `amber db create` for an sqlite3 database, amber displays
the error:

  could not determine database name

This can be confusing to the user who doesn't know that `amber db
create` does not need to be run for sqlite3 databases. Display a
friendlier message.

Also implement `amber db drop` to delete the database.