### PR TITLE
Fixed csrf delete for generated scaffolding

### DIFF
--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -24,9 +24,9 @@
 <% end -%>
         <td>
           <span>
-            <a class="btn btn-default btn-xs" href="/<%= @name %>s/<%="<"%>%= <%= @name %>.id %>">read</a>
-            <a class="btn btn-success btn-xs" href="/<%= @name %>s/<%="<"%>%= <%= @name %>.id %>/edit">edit</a>
-            <a class="btn btn-danger btn-xs" href="/<%= @name %>s/<%="<"%>%= <%= @name %>.id %>?_method=delete" onclick="return confirm('Are you sure?');">delete</a>
+            <%="<"%>%= link_to("read", "/<%= @name %>s/#{<%= @name %>.id}", class: "btn btn-success btn-xs") -%>
+            <%="<"%>%= link_to("edit", "/<%= @name %>s/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs") -%>
+            <%="<"%>%= link_to("delete", "/<%= @name %>s/#{<%= @name %>.id}?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');") -%>
           </span>
         </td>
       </tr>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -19,7 +19,6 @@ div.table-responsive
 <% end -%>
         td
           span
-            a.btn.btn-primary.btn-xs href="/<%= @name %>s/#{ <%= @name %>.id }" read
-            a.btn.btn-success.btn-xs href="/<%= @name %>s/#{ <%= @name %>.id }/edit" edit
-            a.btn.btn-danger.btn-xs href="/<%= @name %>s/#{ <%= @name %>.id }?_method=delete" onclick="return confirm('Are you sure?');" delete
-
+            == link_to("read", "/<%= @name %>s/#{<%= @name %>.id}", class: "btn btn-success btn-xs")
+            == link_to("edit", "/<%= @name %>s/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
+            == link_to("delete", "/<%= @name %>s/#{ <%= @name %>.id }?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
@@ -2,7 +2,7 @@
 <p><%="<"%>%= <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %> %></p>
 <% end -%>
 <p>
-          <a class="btn btn-default btn-xs" href="/<%= @name %>s">back</a>
-          <a class="btn btn-success btn-xs" href="/<%= @name %>s/<%="<"%>%= <%= @name %>.id %>/edit">edit</a>
-          <a class="btn btn-danger btn-xs" href="/<%= @name %>s/<%="<"%>%= <%= @name %>.id %>?_method=delete" onclick="return confirm('Are you sure?');">delete</a>
+  <%="<"%>%= link_to("back", "/<%= @name %>s", class: "btn btn-success btn-xs") -%>
+  <%="<"%>%= link_to("edit", "/<%= @name %>s/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs") -%>
+  <%="<"%>%= link_to("delete", "/<%= @name %>s/#{<%= @name %>.id}?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');") -%>
 </p>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
@@ -2,6 +2,6 @@
 p = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
 <% end -%>
 p
-  a.btn.btn-default.btn-xs href="/<%= @name %>s" back
-  a.btn.btn-success.btn-xs href="/<%= @name %>s/#{ <%= @name %>.id }/edit" edit
-  a.btn.btn-danger.btn-xs href="/<%= @name %>s/#{ <%= @name %>.id }?_method=delete" onclick="return confirm('Are you sure?');" delete
+  == link_to("back", "/<%= @name %>s", class: "btn btn-success btn-xs")
+  == link_to("edit", "/<%= @name %>s/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
+  == link_to("delete", "/<%= @name %>s/#{<%= @name %>.id}?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');")


### PR DESCRIPTION
### Description of the Change

Fixes https://github.com/amberframework/amber/issues/339. 

Also uses link helpers instead of `<a href...>`

### Alternate Designs

At some point we might want to use a helper to generate a form that posts or a JS hack that does it onclick.

### Benefits

Protects from cross site scripting, so that javascript in other tabs can't post valid requests to domains associated with your cookies.
