### PR TITLE
web socket missing let declaration

### DIFF
--- a/assets/js/amber.js
+++ b/assets/js/amber.js
@@ -215,7 +215,7 @@ export class Socket {
   handleMessage(msg) {
     if (msg.data === "ping") return this._handlePing()
 
-    parsed_msg = JSON.parse(msg.data)
+    let parsed_msg = JSON.parse(msg.data)
     this.channels.forEach((channel) => {
       if (channel.topic === parsed_msg.topic) channel.handleMessage(parsed_msg)
     })


### PR DESCRIPTION
### Description of the Change

When trying to use web sockets, I get a javascript error that the variable `parsed_msg` is not defined.  It is missing the `let` declaration.
