### PR TITLE
[Controller] Adds Route Helper Methods to Controller

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -27,10 +27,9 @@ module Amber::Controller
       controller.responds_to?(:client_ip).should eq true
       controller.responds_to?(:request).should eq true
       controller.responds_to?(:response).should eq true
-      controller.responds_to?(:route_action).should eq true
+      controller.responds_to?(:action_name).should eq true
       controller.responds_to?(:route_resource).should eq true
       controller.responds_to?(:route_scope).should eq true
-      controller.responds_to?(:route_controller).should eq true
       controller.responds_to?(:controller_name).should eq true
     end
 

--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -27,6 +27,11 @@ module Amber::Controller
       controller.responds_to?(:client_ip).should eq true
       controller.responds_to?(:request).should eq true
       controller.responds_to?(:response).should eq true
+      controller.responds_to?(:route_action).should eq true
+      controller.responds_to?(:route_resource).should eq true
+      controller.responds_to?(:route_scope).should eq true
+      controller.responds_to?(:route_controller).should eq true
+      controller.responds_to?(:controller_name).should eq true
     end
 
     describe "#redirect_back" do

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -9,6 +9,7 @@ module Amber::Controller
     include Helpers::Redirect
     include Helpers::Render
     include Helpers::Responders
+    include Helpers::Route
 
     include Callbacks
 

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -23,9 +23,5 @@ module Amber::Controller
     def initialize(@context : HTTP::Server::Context)
       @params = Amber::Validators::Params.new(context.params)
     end
-
-    def controller_name
-      self.class.name.gsub(/Controller/i, "")
-    end
   end
 end

--- a/src/amber/controller/helpers/route.cr
+++ b/src/amber/controller/helpers/route.cr
@@ -1,6 +1,6 @@
 module Amber::Controller::Helpers
   module Route
-    def route_action
+    def action_name
       context.request_handler.action
     end
 
@@ -12,12 +12,8 @@ module Amber::Controller::Helpers
       context.request_handler.scope
     end
 
-    def route_controller
-      context.request_handler.controller
-    end
-
     def controller_name
-      self.class.name.gsub(/Controller/i, "")
+      self.class.name.sub(/Controller$/, "").underscore
     end
   end
 end

--- a/src/amber/controller/helpers/route.cr
+++ b/src/amber/controller/helpers/route.cr
@@ -1,0 +1,23 @@
+module Amber::Controller::Helpers
+  module Route
+    def route_action
+      context.request_handler.action
+    end
+
+    def route_resource
+      context.request_handler.resource
+    end
+
+    def route_scope
+      context.request_handler.scope
+    end
+
+    def route_controller
+      context.request_handler.controller
+    end
+
+    def controller_name
+      self.class.name.gsub(/Controller/i, "")
+    end
+  end
+end


### PR DESCRIPTION
> As a developer I want to have access to the current matched
route information such as the Action, Controller, Resource
and Scope accessed.

This adds a Route helper file
- Includes the following methods route_action, route_controller,
route_resource, route_scope in the controller

### Alternate Design

I thought of using a different name such as action_name, controller_name
but it seemed more explicit to have `route_` prefix to hint the user where is
this information is coming from.