### PR TITLE
[Redirect] Allows for Class and Symbol Controller name

### DIFF
--- a/spec/amber/controller/helpers/redirect_spec.cr
+++ b/spec/amber/controller/helpers/redirect_spec.cr
@@ -68,7 +68,7 @@ module Amber::Controller::Helpers
 
       it "redirects to full controller name as symbol" do
         controller = build_controller
-        redirector = Redirector.from_controller_action(:RedirectController, :show, params: {"id" => "5"})
+        redirector = Redirector.from_controller_action(RedirectController, :show, params: {"id" => "5"})
         redirector.redirect(controller)
         assert_expected_response?(controller, "/redirect/5", 302)
       end

--- a/spec/amber/controller/helpers/redirect_spec.cr
+++ b/spec/amber/controller/helpers/redirect_spec.cr
@@ -1,24 +1,25 @@
 require "../../../../spec_helper"
 
+def assert_expected_response?(controller, location, status_code)
+  controller.response.headers["location"].should eq location
+  controller.response.status_code.should eq status_code
+end
+
 module Amber::Controller::Helpers
   describe Redirector do
     describe "#redirect" do
       it "redirects to location" do
         controller = build_controller
         redirector = Redirector.new("/some_path")
-
         redirector.redirect(controller)
-
-        controller.response.headers["location"].should eq "/some_path"
-        controller.response.status_code.should eq 302
-        controller.context.content.nil?.should eq false
+        assert_expected_response?(controller, "/some_path", 302)
       end
 
       it "raises Exception::Controller::Redirect on invalid location" do
         controller = build_controller
-
         expect_raises Exceptions::Controller::Redirect do
           redirector = Redirector.new("", params: {"user_id" => "123"})
+          redirector.redirect(controller)
         end
       end
 
@@ -26,12 +27,9 @@ module Amber::Controller::Helpers
         it "redirect to location and adds params to url" do
           controller = build_controller
           redirector = Redirector.new("/some_path", params: {"user_id" => "123"})
-
           redirector.redirect(controller)
-
-          controller.response.headers["location"].should eq "/some_path?user_id=123"
-          controller.response.status_code.should eq 302
-          controller.context.content.nil?.should eq false
+          assert_expected_response?(controller, "/some_path?user_id=123", 302)
+          controller.response.headers["location"] = ""
         end
       end
 
@@ -39,14 +37,9 @@ module Amber::Controller::Helpers
         it "redirects to location and adds flash" do
           controller = build_controller
           redirector = Redirector.new("/some_path", flash: {"success" => "Record saved!"})
-
-          flash = controller.flash
           redirector.redirect(controller)
-
-          controller.response.headers["location"].should eq "/some_path"
-          flash["success"].should eq "Record saved!"
-          controller.response.status_code.should eq 302
-          controller.context.content.nil?.should eq false
+          controller.flash["success"].should eq "Record saved!"
+          assert_expected_response?(controller, "/some_path", 302)
         end
       end
 
@@ -54,28 +47,19 @@ module Amber::Controller::Helpers
         it "redirects to location and sets a status code" do
           controller = build_controller
           redirector = Redirector.new("/some_path", status = 301)
-
-          flash = controller.flash
           redirector.redirect(controller)
-
-          controller.response.headers["location"].should eq "/some_path"
-          controller.response.status_code.should eq 301
-          controller.context.content.nil?.should eq false
+          assert_expected_response?(controller, "/some_path", 301)
         end
       end
     end
 
     describe ".from_controller_action" do
-      router = Amber::Server.router
-      router.draw :web { get "/hello", HelloController, :index }
-      router.draw :web { get "/hello/:id", HelloController, :show }
-      router.draw :web { get "/hello/:id/edit", HelloController, :edit }
-      router.draw :web { delete "/hello/:id", HelloController, :destroy }
-      router.draw :web, "/scoped" { put "/hello/:id", HelloController, :update }
+      Amber::Server.router.draw :web do
+        get "/redirect/:id", RedirectController, :show
+        get "/redirect", RedirectController, :index
+      end
 
       it "raises an error for invalid controller/action" do
-        controller = build_controller
-
         expect_raises Exceptions::Controller::Redirect do
           redirector = Redirector.from_controller_action("bad", :bad)
         end
@@ -83,81 +67,44 @@ module Amber::Controller::Helpers
 
       it "redirects to full controller name as symbol" do
         controller = build_controller
-        redirector = controller.redirect_to(:HelloController, :destroy, params: {"id" => "5"})
-
-        controller.response.headers["location"].should eq "/hello/5"
-        controller.response.status_code.should eq 302
-        controller.context.content.nil?.should eq false
+        redirector = Redirector.from_controller_action(:RedirectController, :show, params: {"id" => "5"})
+        redirector.redirect(controller)
+        assert_expected_response?(controller, "/redirect/5", 302)
       end
 
       it "redirects to full controller name as class" do
         controller = build_controller
-        redirector = controller.redirect_to(HelloController, :destroy, params: {"id" => "5"})
-
-        controller.response.headers["location"].should eq "/hello/5"
-        controller.response.status_code.should eq 302
-        controller.context.content.nil?.should eq false
+        redirector = Redirector.from_controller_action(RedirectController, :show, params: {"id" => "5"})
+        redirector.redirect(controller)
+        assert_expected_response?(controller, "/redirect/5", 302)
       end
 
-      context "when scope is present" do
-        it "redirects to the correct scoped location" do
-          controller = build_controller
-          redirector = Redirector.from_controller_action("hello", :update, params: {"id" => "5"})
-
-          redirector.redirect(controller)
-
-          controller.response.headers["location"].should eq "/scoped/hello/5"
-          controller.response.status_code.should eq 302
-          controller.context.content.nil?.should eq false
-        end
+      it "redirects to correct location for given controller action" do
+        controller = build_controller
+        redirector = Redirector.from_controller_action("redirect", :show, params: {"id" => "11"})
+        redirector.redirect(controller)
+        assert_expected_response?(controller, "/redirect/11", 302)
       end
 
-      context "with params" do
-        it "redirects to correct location for given controller action" do
-          controller = build_controller
-          redirector = Redirector.from_controller_action("hello", :show, params: {"id" => "11"})
-
-          redirector.redirect(controller)
-
-          controller.response.headers["location"].should eq "/hello/11"
-          controller.response.status_code.should eq 302
-          controller.context.content.nil?.should eq false
-        end
-      end
-
-      context "without params" do
-        it "redirects to correct location for given controller action" do
-          controller = build_controller
-          redirector = Redirector.from_controller_action("hello", :index)
-
-          redirector.redirect(controller)
-
-          controller.response.headers["location"].should eq "/hello"
-          controller.response.status_code.should eq 302
-          controller.context.content.nil?.should eq false
-        end
+      it "redirects to correct location for given controller action" do
+        controller = build_controller
+        redirector = Redirector.from_controller_action("redirect", :index)
+        redirector.redirect(controller)
+        assert_expected_response?(controller, "/redirect", 302)
       end
     end
 
     describe "#redirect_back" do
-      context "and has a valid referrer" do
-        it "sets the correct response headers" do
-          hello_controller = build_controller("/world")
-
-          hello_controller.redirect_back
-          response = hello_controller.response
-
-          response.headers["Location"].should eq "/world"
-        end
+      it "sets the correct response headers" do
+        controller = build_controller("/redirect")
+        controller.redirect_back
+        controller.response.headers["Location"].should eq "/redirect"
       end
 
-      context "and does not have a referrer" do
-        it "raises an error" do
-          hello_controller = build_controller
-
-          expect_raises Exceptions::Controller::Redirect do
-            hello_controller.redirect_back
-          end
+      it "raises an error" do
+        controller = build_controller("")
+        expect_raises Exceptions::Controller::Redirect do
+          controller.redirect_back
         end
       end
     end

--- a/spec/amber/controller/helpers/redirect_spec.cr
+++ b/spec/amber/controller/helpers/redirect_spec.cr
@@ -56,12 +56,13 @@ module Amber::Controller::Helpers
     describe ".from_controller_action" do
       Amber::Server.router.draw :web do
         get "/redirect/:id", RedirectController, :show
+        get "/redirect/:id/edit", RedirectController, :edit
         get "/redirect", RedirectController, :index
       end
 
       it "raises an error for invalid controller/action" do
-        expect_raises Exceptions::Controller::Redirect do
-          redirector = Redirector.from_controller_action("bad", :bad)
+        expect_raises KeyError do
+          redirector = Redirector.from_controller_action(:bad, :bad)
         end
       end
 
@@ -79,18 +80,18 @@ module Amber::Controller::Helpers
         assert_expected_response?(controller, "/redirect/5", 302)
       end
 
-      it "redirects to correct location for given controller action" do
+      it "redirects to :show" do
         controller = build_controller
-        redirector = Redirector.from_controller_action("redirect", :show, params: {"id" => "11"})
+        redirector = Redirector.from_controller_action(:redirect, :show, params: {"id" => "11"})
         redirector.redirect(controller)
         assert_expected_response?(controller, "/redirect/11", 302)
       end
 
-      it "redirects to correct location for given controller action" do
+      it "redirects to edit action" do
         controller = build_controller
-        redirector = Redirector.from_controller_action("redirect", :index)
+        redirector = Redirector.from_controller_action(:redirect, :edit, params: {"id" => "123"})
         redirector.redirect(controller)
-        assert_expected_response?(controller, "/redirect", 302)
+        assert_expected_response?(controller, "/redirect/123/edit", 302)
       end
     end
 

--- a/spec/amber/router/pipe/pipeline_spec.cr
+++ b/spec/amber/router/pipe/pipeline_spec.cr
@@ -14,98 +14,61 @@ module Amber
         pipeline.pipeline[:api].size.should eq 2
       end
 
-      describe "#call" do
+      describe "with given server config" do
+        pipeline = Pipeline.new
+
+        Amber::Server.router.draw :web do
+          get "/valid/route", HelloController, :world
+          get "/index/:name", HelloController, :world
+          resources "/hello", HelloController
+        end
+
+        pipeline.build :web { }
+        pipeline.prepare_pipelines
+
         it "raises exception when route not found" do
-          pipeline = Pipeline.new
           request = HTTP::Request.new("GET", "/bad/route")
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { get "/valid/route", HelloController, :world }
           create_request_and_return_io(pipeline, request).status_code.should eq 404
         end
 
         it "routes" do
-          pipeline = Pipeline.new
           request = HTTP::Request.new("GET", "/index/elias")
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { get "/index/:name", HelloController, :world }
-
-          pipeline.prepare_pipelines
           response = create_request_and_return_io(pipeline, request)
-
           response.body.should eq "Hello World!"
         end
-      end
 
-      describe "http requests" do
         it "perform GET request" do
           request = HTTP::Request.new("GET", "/hello")
-          pipeline = Pipeline.new
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { get "/hello", HelloController, :index }
-
-          pipeline.prepare_pipelines
           response = create_request_and_return_io(pipeline, request)
-
           response.body.should eq "Index"
         end
 
         it "perform PUT request" do
           request = HTTP::Request.new("PUT", "/hello/1")
-          pipeline = Pipeline.new
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { put "/hello/:id", HelloController, :update }
-
-          pipeline.prepare_pipelines
           response = create_request_and_return_io(pipeline, request)
-
           response.body.should eq "Update"
         end
 
         it "perform PATCH request" do
           request = HTTP::Request.new("PATCH", "/hello/1")
-          pipeline = Pipeline.new
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { patch "/hello/:id", HelloController, :update }
-
-          pipeline.prepare_pipelines
           response = create_request_and_return_io(pipeline, request)
-
           response.body.should eq "Update"
         end
 
         it "perform POST request" do
           request = HTTP::Request.new("POST", "/hello")
-          pipeline = Pipeline.new
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { post "/hello", HelloController, :create }
-
-          pipeline.prepare_pipelines
           response = create_request_and_return_io(pipeline, request)
-
           response.body.should eq "Create"
         end
 
         it "perform DELETE request" do
           request = HTTP::Request.new("DELETE", "/hello/1")
-          pipeline = Pipeline.new
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { delete "/hello/:id", HelloController, :destroy }
-
-          pipeline.prepare_pipelines
           response = create_request_and_return_io(pipeline, request)
-
           response.body.should eq "Destroy"
         end
-      end
 
-      describe "X-Powered-By Header" do
         it "initializes context with X-Powered-By: Amber" do
-          pipeline = Pipeline.new
           request = HTTP::Request.new("GET", "/index/faustino")
-          pipeline.build :web { plug Amber::Pipe::Logger.new }
-          Amber::Server.router.draw :web { get "/index/:name", HelloController, :world }
-
-          pipeline.prepare_pipelines
           response = create_request_and_return_io(pipeline, request)
           response.headers["X-Powered-By"].should eq "Amber"
         end

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -2,10 +2,10 @@ require "../../../spec_helper"
 
 module Amber
   describe Route do
+    handler = ->(context : HTTP::Server::Context) {}
+    subject = Route.new("GET", "/fake/action/:id/:name", handler, :action, :web, "", "FakeController")
+
     it "Initializes correctly with Decendant controller" do
-      handler = ->(context : HTTP::Server::Context) {
-        context.content = "Hey yo world!"
-      }
       request = HTTP::Request.new("GET", "/?test=test")
       context = create_context(request)
 
@@ -16,79 +16,27 @@ module Amber
 
     describe "#substitute_keys)in_path" do
       it "parses route resource params" do
-        handler = ->(context : HTTP::Server::Context) {}
         params = {"id" => "123", "name" => "John"}
-        route = Route.new("GET",
-          "/fake/action/:id/:name",
-          handler,
-          :action,
-          :web,
-          "", "FakeController")
-
         empty_hash = {} of String => String
-        route.substitute_keys_in_path(params).should eq({"/fake/action/123/John", empty_hash})
+        subject.substitute_keys_in_path(params).should eq({"/fake/action/123/John", empty_hash})
       end
     end
 
     describe "#match?" do
       it "matches by controller and action" do
-        handler = ->(context : HTTP::Server::Context) {}
-        route = Route.new("GET",
-          "/fake/action/:id/:name",
-          handler,
-          :action,
-          :web,
-          "", "FakeController")
+        subject.match?(:fake, :action).should be_truthy
+      end
 
-        route.match?("fake", :action).should eq true
+      it "does not match with invalid action" do
+        subject.match?(:fake, :invalid).should be_falsey
       end
 
       it "does not match with invalid controller" do
-        handler = ->(context : HTTP::Server::Context) {}
-        route = Route.new("GET",
-          "/fake/action/:id/:name",
-          handler,
-          :action,
-          :web,
-          "", "FakeController")
-
-        route.match?("invalid", :action).should eq false
+        subject.match?(:invalid, :action).should be_falsey
       end
 
-      it "does not match with nil controller" do
-        handler = ->(context : HTTP::Server::Context) {}
-        route = Route.new("GET",
-          "/fake/action/:id/:name",
-          handler,
-          :action,
-          :web,
-          "", "FakeController")
-
-        route.match?(nil, :action).should eq false
-      end
-
-      it "does not match with nil action" do
-        handler = ->(context : HTTP::Server::Context) {}
-        route = Route.new("GET",
-          "/fake/action/:id/:name",
-          handler,
-          :action,
-          :web,
-          "", "FakeController")
-
-        route.match?("fake", nil).should eq false
-      end
-
-      it "does not match with invalid controller" do
-        handler = ->(context : HTTP::Server::Context) {}
-        route = Route.new("GET",
-          "/fake/action/:id/:name",
-          handler,
-          :action,
-          :web,
-          "", "FakeController")
-
-        route.match?("false", :invalid).should eq false
+      it "does not match with invalid controller and invalid action" do
+        subject.match?(:invalid, :invalid).should be_falsey
       end
     end
 

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -22,24 +22,6 @@ module Amber
       end
     end
 
-    describe "#match?" do
-      it "matches by controller and action" do
-        subject.match?(:fake, :action).should be_truthy
-      end
-
-      it "does not match with invalid action" do
-        subject.match?(:fake, :invalid).should be_falsey
-      end
-
-      it "does not match with invalid controller" do
-        subject.match?(:invalid, :action).should be_falsey
-      end
-
-      it "does not match with invalid controller and invalid action" do
-        subject.match?(:invalid, :invalid).should be_falsey
-      end
-    end
-
     describe "#call" do
       context "before action" do
         it "does not execute action" do

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -137,19 +137,19 @@ module Amber
         router.add routeD
 
         it "matches route by controller and action" do
-          router.match_by_controller_action(:fake, :index).should eq routeA
+          router.match_by_controller_action(:fakecontroller, :index).should eq routeA
         end
 
         it "matches controller new action" do
-          router.match_by_controller_action(:fake, :new).should eq routeB
+          router.match_by_controller_action(:fakecontroller, :new).should eq routeB
         end
 
         it "matches controller show action" do
-          router.match_by_controller_action(:fake, :show).should eq routeC
+          router.match_by_controller_action(:fakecontroller, :show).should eq routeC
         end
 
         it "matches controller another action" do
-          router.match_by_controller_action(:fake, :another).should eq routeD
+          router.match_by_controller_action(:fakecontroller, :another).should eq routeD
         end
       end
 

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -124,15 +124,32 @@ module Amber
       end
 
       describe "#match_by_controller_action" do
-        it "matches route by controller and action" do
-          router = Router.new
-          handler = ->(context : HTTP::Server::Context) {}
-          routeA = Route.new("GET", "/fake", handler, :index, :web, "", "FakeController")
-          route = Route.new("GET", "/fake/route", handler, :route, :web, "", "FakeController")
-          router.add routeA
-          router.add route
+        handler = ->(context : HTTP::Server::Context) {}
+        router = Router.new
+        routeA = Route.new("GET", "/fake", handler, :index, :web, "", "FakeController")
+        routeB = Route.new("GET", "/fake/new", handler, :new, :web, "", "FakeController")
+        routeC = Route.new("GET", "/fake/:id", handler, :show, :web, "", "FakeController")
+        routeD = Route.new("GET", "/another/:id", handler, :another, :web, "", "FakeController")
 
-          router.match_by_controller_action("fake", :route).should eq route
+        router.add routeA
+        router.add routeB
+        router.add routeC
+        router.add routeD
+
+        it "matches route by controller and action" do
+          router.match_by_controller_action(:fake, :index).should eq routeA
+        end
+
+        it "matches controller new action" do
+          router.match_by_controller_action(:fake, :new).should eq routeB
+        end
+
+        it "matches controller show action" do
+          router.match_by_controller_action(:fake, :show).should eq routeC
+        end
+
+        it "matches controller another action" do
+          router.match_by_controller_action(:fake, :another).should eq routeD
         end
       end
 

--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -1,3 +1,25 @@
+class RedirectController < Amber::Controller::Base
+  def index
+    "Index"
+  end
+
+  def show
+    "Show"
+  end
+
+  def edit
+    "Edit"
+  end
+
+  def update
+    "Update"
+  end
+
+  def destroy
+    "Destroy"
+  end
+end
+
 class HelloController < Amber::Controller::Base
   @total : Int32 = 0
 

--- a/src/amber/controller/helpers/redirect.cr
+++ b/src/amber/controller/helpers/redirect.cr
@@ -8,7 +8,7 @@ module Amber::Controller::Helpers
       Redirector.from_controller_action(controller_name, action, **args).redirect(self)
     end
 
-    def redirect_to(controller : String | Symbol | Class, action : Symbol, **args)
+    def redirect_to(controller : Symbol | Class, action : Symbol, **args)
       Redirector.from_controller_action(controller, action, **args).redirect(self)
     end
 
@@ -28,10 +28,8 @@ module Amber::Controller::Helpers
     @params : Hash(String, String)? = nil
     @flash : Hash(String, String)? = nil
 
-    def self.from_controller_action(controller : String | Symbol | Class, action : Symbol, **options)
-      controller = controller.to_s.sub(/Controller$/, "").downcase
+    def self.from_controller_action(controller : Symbol | Class, action : Symbol, **options)
       route = Amber::Server.router.match_by_controller_action(controller, action)
-      raise Exceptions::Controller::Redirect.new("#{controller}##{action} not found!") unless route
       params = options[:params]?
       location, params = route.not_nil!.substitute_keys_in_path(params)
       status = options[:status]? || DEFAULT_STATUS_CODE

--- a/src/amber/controller/helpers/redirect.cr
+++ b/src/amber/controller/helpers/redirect.cr
@@ -8,8 +8,7 @@ module Amber::Controller::Helpers
       Redirector.from_controller_action(controller_name, action, **args).redirect(self)
     end
 
-    def redirect_to(controller : Symbol | Class, action : Symbol, **args)
-      controller = controller.to_s.downcase.gsub(/controller/i, "")
+    def redirect_to(controller : String | Symbol | Class, action : Symbol, **args)
       Redirector.from_controller_action(controller, action, **args).redirect(self)
     end
 
@@ -29,7 +28,8 @@ module Amber::Controller::Helpers
     @params : Hash(String, String)? = nil
     @flash : Hash(String, String)? = nil
 
-    def self.from_controller_action(controller : String, action : Symbol, **options)
+    def self.from_controller_action(controller : String | Symbol | Class, action : Symbol, **options)
+      controller = controller.to_s.sub(/Controller$/, "").downcase
       route = Amber::Server.router.match_by_controller_action(controller, action)
       raise Exceptions::Controller::Redirect.new("#{controller}##{action} not found!") unless route
       params = options[:params]?

--- a/src/amber/controller/helpers/redirect.cr
+++ b/src/amber/controller/helpers/redirect.cr
@@ -28,8 +28,17 @@ module Amber::Controller::Helpers
     @params : Hash(String, String)? = nil
     @flash : Hash(String, String)? = nil
 
-    def self.from_controller_action(controller : Symbol | Class, action : Symbol, **options)
-      route = Amber::Server.router.match_by_controller_action(controller, action)
+    def self.from_controller_action(controller : Class, action : Symbol, **options)
+      route = Amber::Server.router.match_by_controller_action(controller.to_s.downcase, action)
+      redirect(route, **options)
+    end
+
+    def self.from_controller_action(controller : Symbol, action : Symbol, **options)
+      route = Amber::Server.router.match_by_controller_action("#{controller}controller", action)
+      redirect(route, **options)
+    end
+
+    def self.redirect(route, **options)
       params = options[:params]?
       location, params = route.not_nil!.substitute_keys_in_path(params)
       status = options[:status]? || DEFAULT_STATUS_CODE

--- a/src/amber/controller/helpers/redirect.cr
+++ b/src/amber/controller/helpers/redirect.cr
@@ -8,8 +8,9 @@ module Amber::Controller::Helpers
       Redirector.from_controller_action(controller_name, action, **args).redirect(self)
     end
 
-    def redirect_to(controller : Symbol, action : Symbol, **args)
-      Redirector.from_controller_action(controller.to_s, action, **args).redirect(self)
+    def redirect_to(controller : Symbol | Class, action : Symbol, **args)
+      controller = controller.to_s.downcase.gsub(/controller/i, "")
+      Redirector.from_controller_action(controller, action, **args).redirect(self)
     end
 
     def redirect_back(**args)
@@ -17,7 +18,7 @@ module Amber::Controller::Helpers
     end
   end
 
-  class Redirector
+  private class Redirector
     DEFAULT_STATUS_CODE = 302
     LOCATION_HEADER     = "Location"
 

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -29,7 +29,7 @@ module Amber
       # Connects pipes to a pipeline to process requests
       def build(valve : Symbol, &block)
         @valve = valve
-        @pipeline[valve] = [] of HTTP::Handler unless pipeline.key? valve
+        @pipeline[valve] = [] of HTTP::Handler unless pipeline.has_key? valve
         with DSL::Pipeline.new(self) yield
       end
 

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -48,13 +48,5 @@ module Amber
       end
       {result, params}
     end
-
-    def match?(controller : Class, action : Symbol)
-      self.controller.downcase == controller.to_s.downcase && self.action == action
-    end
-
-    def match?(controller : Symbol, action : Symbol)
-      self.controller.downcase == "#{controller}controller" && self.action == action
-    end
   end
 end

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -49,7 +49,11 @@ module Amber
       {result, params}
     end
 
-    def match?(controller, action)
+    def match?(controller : Class, action : Symbol)
+      self.controller.downcase == controller.to_s.downcase && self.action == action
+    end
+
+    def match?(controller : Symbol, action : Symbol)
       self.controller.downcase == "#{controller}controller" && self.action == action
     end
   end

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -5,7 +5,7 @@ module Amber
     # This is the main application handler all routers should finally hit this
     # handler.
     class Router
-      property :routes, :socket_routes
+      property :routes, :routes_hash, :socket_routes
 
       def initialize
         @routes = Radix::Tree(Route).new

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -54,7 +54,7 @@ module Amber
       end
 
       def match_by_controller_action(controller, action)
-        @routes_hash["#{controller}controller##{action}"]
+        @routes_hash["#{controller}##{action}"]
       end
 
       def all


### PR DESCRIPTION
Issue: https://github.com/amberframework/amber/issues/353

> As a developer I would like to pass and full controller name to a
redirect as a class or symbol and allow for the redirection to happen

Example

`redirect_to controller: :HomeController, action: :index`

- Would be nice to accept HelloController::Index or
Admin::UserController:Index
