### PR TITLE
Update font-end dependencies on app template

### DIFF
--- a/src/amber/cli/templates/app/config/webpack/common.js
+++ b/src/amber/cli/templates/app/config/webpack/common.js
@@ -54,7 +54,7 @@ let config = {
         exclude: /node_modules/,
         loader: 'babel-loader',
         query: {
-          presets: ['es2015']
+          presets: ['env']
         }
       }
     ]

--- a/src/amber/cli/templates/app/package.json.ecr
+++ b/src/amber/cli/templates/app/package.json.ecr
@@ -14,14 +14,14 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
-    "babel-preset-es2015": "^6.24.1",
-    "css-loader": "^0.28.5",
-    "file-loader": "^0.11.2",
-    "node-sass": "^4.5.3",
+    "babel-preset-env": "^1.6.1",
+    "css-loader": "^0.28.7",
+    "file-loader": "^1.1.5",
+    "node-sass": "^4.6.0",
     "sass-loader": "^6.0.6",
-    "style-loader": "^0.18.2",
-    "webpack": "^3.5.5",
-    "webpack-merge": "^4.1.0",
-    "extract-text-webpack-plugin": "^3.0.1"
+    "style-loader": "^0.19.0",
+    "webpack": "^3.8.1",
+    "webpack-merge": "^4.1.1",
+    "extract-text-webpack-plugin": "^3.0.2"
   }
 }


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Update front-end dependencies, also fix babel warning:

> npm WARN deprecated babel-preset-es2015@6.24.1: We're super 😸  excited that you're trying to use ES2015 syntax, but insted of continuing yearly presets 😭 , the team recommends using 'babel-preset-env' with 'npm install babel-preset-env'. prest-env without options will compile ES2015+ down to ES5. By further targeting specific browsers, Babel can do less work and you can ship native ES2015+ to users 😎 ! Also please give http://babeljs.io/blog/2017/09/12/planning-for-7.0 for our proress on 7.0! Thanks so much for using Babel 🙏 , please give us a follow on Twitter @babeljs for more update

https://babeljs.io/docs/plugins/preset-env/

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
No

### Benefits

<!-- What benefits will be realized by the code change? -->
Update dependencies

### Possible Drawbacks

No
<!-- What are the possible side-effects or negative impacts of the code change? -->
