### PR TITLE
cli: add "amber exec" command for executing one-liners (#352)

### DIFF
--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -12,6 +12,7 @@ module Amber::CLI
     it "executes one-liners from the first command-line argument" do
       expected_result = "[:a, :b, :c, :d]\n"
       MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
+      Dir.glob("tmp/*")
       logs = Dir.glob("./tmp/*_console_result.log")
       File.read(logs.last?.to_s).should eq expected_result
     end
@@ -19,6 +20,7 @@ module Amber::CLI
     it "executes a .cr file from the first command-line argument" do
       File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
       MainCommand.run(["exec", "amber_exec_spec_test.cr", "-e", "tail"])
+      Dir.glob("tmp/*")
       logs = Dir.glob("./tmp/*_console_result.log")
       File.read(logs.last?.to_s).should eq "[:a, :b]\n"
       File.delete("amber_exec_spec_test.cr")
@@ -26,12 +28,14 @@ module Amber::CLI
 
     it "opens editor and executes .cr file on close" do
       MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
+      Dir.glob("tmp/*")
       logs = Dir.glob("./tmp/*_console_result.log")
       File.read(logs.last?.to_s).should eq "1000\n"
     end
 
     it "copies previous run into new file for editing and runs it returning results" do
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
+      Dir.glob("tmp/*")
       logs = Dir.glob("./tmp/*_console_result.log")
       File.read(logs.last?.to_s).should eq "1000\n"
     end
@@ -41,6 +45,7 @@ module Amber::CLI
     it "complains if not in the root of a project" do
       expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
       MainCommand.run(["exec", ":hello"])
+      Dir.glob("tmp/*")
       logs = Dir.glob("./tmp/*_console_result.log")
       File.read(logs.last?.to_s).should eq expected_result
     end

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -1,3 +1,4 @@
+{% if flag?(:run_build_tests) %}
 require "../../../spec_helper"
 require "../../../support/helpers/cli_helper"
 
@@ -50,3 +51,4 @@ module Amber::CLI
     cleanup
   end
 end
+{% end %}

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -1,4 +1,4 @@
-#{% if flag?(:run_build_tests) %}
+# {% if flag?(:run_build_tests) %}
 require "../../../spec_helper"
 require "../../../support/helpers/cli_helper"
 
@@ -6,47 +6,52 @@ include CLIHelper
 
 module Amber::CLI
   describe "amber exec" do
-    cleanup
-    scaffold_app(TESTING_APP)
-    `shards`
+    context "within project" do
+      cleanup
+      scaffold_app(TESTING_APP)
+      `shards`
 
-    it "executes one-liners from the first command-line argument" do
-      expected_result = "[:a, :b, :c, :d]\n"
-      MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
-      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
-      File.read(logs.last?.to_s).should eq expected_result
+      it "executes one-liners from the first command-line argument" do
+        expected_result = "[:a, :b, :c, :d]\n"
+        MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        File.read(logs.last?.to_s).should eq expected_result
+      end
+
+      it "executes a .cr file from the first command-line argument" do
+        File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
+        MainCommand.run(["exec", "amber_exec_spec_test.cr", "-e", "tail"])
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        File.read(logs.last?.to_s).should eq "[:a, :b]\n"
+        File.delete("amber_exec_spec_test.cr")
+      end
+
+      it "opens editor and executes .cr file on close" do
+        MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        File.read(logs.last?.to_s).should eq "1000\n"
+      end
+
+      it "copies previous run into new file for editing and runs it returning results" do
+        MainCommand.run(["exec", "1337"])
+        MainCommand.run(["exec", "-e", "tail", "-b", "1"])
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        File.read(logs.last?.to_s).should eq "1337\n"
+      end
+
+      cleanup
     end
 
-    it "executes a .cr file from the first command-line argument" do
-      File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
-      MainCommand.run(["exec", "amber_exec_spec_test.cr", "-e", "tail"])
-      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
-      File.read(logs.last?.to_s).should eq "[:a, :b]\n"
-      File.delete("amber_exec_spec_test.cr")
-    end
+    context "outside of project" do
+      it "complains if not in the root of a project" do
+        expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
+        MainCommand.run(["exec", ":hello"])
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        File.read(logs.last?.to_s).should eq expected_result
+      end
 
-    it "opens editor and executes .cr file on close" do
-      MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
-      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
-      File.read(logs.last?.to_s).should eq "1000\n"
+      cleanup
     end
-
-    it "copies previous run into new file for editing and runs it returning results" do
-      MainCommand.run(["exec", "1337"])
-      MainCommand.run(["exec", "-e", "tail", "-b", "1"])
-      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
-      File.read(logs.last?.to_s).should eq "1337\n"
-    end
-
-    cleanup
-
-    it "complains if not in the root of a project" do
-      expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
-      MainCommand.run(["exec", ":hello"])
-      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
-      File.read(logs.last?.to_s).should eq expected_result
-    end
-    cleanup
   end
 end
-#{% end %}
+# {% end %}

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -14,31 +14,28 @@ module Amber::CLI
       MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
 
       # This one weird trick, to make the specs pass in linux leaves scientists puzzled.
-      Dir.glob("tmp/*")
-      logs = Dir.glob("./tmp/*_console_result.log")
+      #Dir.glob("tmp/*")
+      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
       File.read(logs.last?.to_s).should eq expected_result
     end
 
     it "executes a .cr file from the first command-line argument" do
       File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
       MainCommand.run(["exec", "amber_exec_spec_test.cr", "-e", "tail"])
-      Dir.glob("tmp/*")
-      logs = Dir.glob("./tmp/*_console_result.log")
+      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
       File.read(logs.last?.to_s).should eq "[:a, :b]\n"
       File.delete("amber_exec_spec_test.cr")
     end
 
     it "opens editor and executes .cr file on close" do
       MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
-      Dir.glob("tmp/*")
-      logs = Dir.glob("./tmp/*_console_result.log")
+      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
       File.read(logs.last?.to_s).should eq "1000\n"
     end
 
     it "copies previous run into new file for editing and runs it returning results" do
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
-      Dir.glob("tmp/*")
-      logs = Dir.glob("./tmp/*_console_result.log")
+      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
       File.read(logs.last?.to_s).should eq "1000\n"
     end
 
@@ -47,8 +44,7 @@ module Amber::CLI
     it "complains if not in the root of a project" do
       expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
       MainCommand.run(["exec", ":hello"])
-      Dir.glob("tmp/*")
-      logs = Dir.glob("./tmp/*_console_result.log")
+      logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
       File.read(logs.last?.to_s).should eq expected_result
     end
     cleanup

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -32,9 +32,10 @@ module Amber::CLI
     end
 
     it "copies previous run into new file for editing and runs it returning results" do
+      MainCommand.run(["exec", "1337"])
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
       logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
-      File.read(logs.last?.to_s).should eq "1000\n"
+      File.read(logs.last?.to_s).should eq "1337\n"
     end
 
     cleanup

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -24,16 +24,12 @@ module Amber::CLI
 
     it "opens editor and executes .cr file on close" do
       MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
-      sleep 1
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
     end
 
     it "copies previous run into new file for editing and runs it returning results" do
-      MainCommand.run(["exec", "1337"])
-      sleep 1
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
-      sleep 1
-      File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1337\n"
+      File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
     end
 
     cleanup

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -14,28 +14,28 @@ module Amber::CLI
       it "executes one-liners from the first command-line argument" do
         expected_result = "[:a, :b, :c, :d]\n"
         MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
-        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
         File.read(logs.last?.to_s).should eq expected_result
       end
 
       it "executes a .cr file from the first command-line argument" do
         File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
         MainCommand.run(["exec", "amber_exec_spec_test.cr", "-e", "tail"])
-        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
         File.read(logs.last?.to_s).should eq "[:a, :b]\n"
         File.delete("amber_exec_spec_test.cr")
       end
 
       it "opens editor and executes .cr file on close" do
         MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
-        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
         File.read(logs.last?.to_s).should eq "1000\n"
       end
 
       it "copies previous run into new file for editing and runs it returning results" do
         MainCommand.run(["exec", "1337"])
         MainCommand.run(["exec", "-e", "tail", "-b", "1"])
-        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
         File.read(logs.last?.to_s).should eq "1337\n"
       end
 
@@ -46,7 +46,7 @@ module Amber::CLI
       it "complains if not in the root of a project" do
         expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
         MainCommand.run(["exec", ":hello"])
-        logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
         File.read(logs.last?.to_s).should eq expected_result
       end
 

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -13,9 +13,6 @@ module Amber::CLI
     it "executes one-liners from the first command-line argument" do
       expected_result = "[:a, :b, :c, :d]\n"
       MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
-
-      # This one weird trick, to make the specs pass in linux leaves scientists puzzled.
-      #Dir.glob("tmp/*")
       logs = `ls tmp/*_console_result.log`.strip.split(/\s/)
       File.read(logs.last?.to_s).should eq expected_result
     end

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -12,6 +12,7 @@ module Amber::CLI
     it "executes one-liners from the first command-line argument" do
       expected_result = "[:a, :b, :c, :d]\n"
       MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
+      Dir.glob("./tmp/*_console_result.log")
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq expected_result
     end
 
@@ -19,16 +20,19 @@ module Amber::CLI
       File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
       MainCommand.run(["exec", "amber_exec_spec_test.cr", "-e", "tail"])
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "[:a, :b]\n"
+      Dir.glob("./tmp/*_console_result.log")
       File.delete("amber_exec_spec_test.cr")
     end
 
     it "opens editor and executes .cr file on close" do
       MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
+      Dir.glob("./tmp/*_console_result.log")
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
     end
 
     it "copies previous run into new file for editing and runs it returning results" do
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
+      Dir.glob("./tmp/*_console_result.log")
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
     end
 
@@ -37,6 +41,7 @@ module Amber::CLI
     it "complains if not in the root of a project" do
       expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
       MainCommand.run(["exec", ":hello"])
+      Dir.glob("./tmp/*_console_result.log")
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq expected_result
     end
     cleanup

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -12,6 +12,8 @@ module Amber::CLI
     it "executes one-liners from the first command-line argument" do
       expected_result = "[:a, :b, :c, :d]\n"
       MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
+
+      # This one weird trick, to make the specs pass in linux leaves scientists puzzled.
       Dir.glob("tmp/*")
       logs = Dir.glob("./tmp/*_console_result.log")
       File.read(logs.last?.to_s).should eq expected_result

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -27,7 +27,7 @@ module Amber::CLI
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
     end
 
-    it "copies previous run into new files for editing and runs it returning results" do
+    it "copies previous run into new file for editing and runs it returning results" do
       MainCommand.run(["exec", "1337"])
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1337\n"

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -12,28 +12,28 @@ module Amber::CLI
     it "executes one-liners from the first command-line argument" do
       expected_result = "[:a, :b, :c, :d]\n"
       MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
-      Dir.glob("./tmp/*_console_result.log")
-      File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq expected_result
+      logs = Dir.glob("./tmp/*_console_result.log")
+      File.read(logs.last?.to_s).should eq expected_result
     end
 
     it "executes a .cr file from the first command-line argument" do
       File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
       MainCommand.run(["exec", "amber_exec_spec_test.cr", "-e", "tail"])
-      File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "[:a, :b]\n"
-      Dir.glob("./tmp/*_console_result.log")
+      logs = Dir.glob("./tmp/*_console_result.log")
+      File.read(logs.last?.to_s).should eq "[:a, :b]\n"
       File.delete("amber_exec_spec_test.cr")
     end
 
     it "opens editor and executes .cr file on close" do
       MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
-      Dir.glob("./tmp/*_console_result.log")
-      File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
+      logs = Dir.glob("./tmp/*_console_result.log")
+      File.read(logs.last?.to_s).should eq "1000\n"
     end
 
     it "copies previous run into new file for editing and runs it returning results" do
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
-      Dir.glob("./tmp/*_console_result.log")
-      File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
+      logs = Dir.glob("./tmp/*_console_result.log")
+      File.read(logs.last?.to_s).should eq "1000\n"
     end
 
     cleanup
@@ -41,8 +41,8 @@ module Amber::CLI
     it "complains if not in the root of a project" do
       expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
       MainCommand.run(["exec", ":hello"])
-      Dir.glob("./tmp/*_console_result.log")
-      File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq expected_result
+      logs = Dir.glob("./tmp/*_console_result.log")
+      File.read(logs.last?.to_s).should eq expected_result
     end
     cleanup
   end

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -1,0 +1,31 @@
+require "../../../spec_helper"
+require "../../../support/helpers/cli_helper"
+
+include CLIHelper
+
+module Amber::CLI
+  describe "amber exec" do
+    cleanup
+    scaffold_app(TESTING_APP)
+
+    it "executes one-liners from the first command-line argument" do
+      MainCommand.run(["exec", "[:a, :b, :c] + [:d]"]).should eq "[:a, :b, :c, :d]\n"
+    end
+
+    it "executes a .cr file from the first command-line argument" do
+      File.write "amber_exec_spec_test.cr", "puts([:a] + [:b])"
+      MainCommand.run(["exec", "amber_exec_spec_test.cr"]).should eq "[:a, :b]\n"
+      File.delete("amber_exec_spec_test.cr")
+    end
+
+    it "attempts to run the specified editor in zero-arg mode" do
+      MainCommand.run(["exec", "-e", "a-non-existent-editor"]).should eq ""
+    end
+
+    cleanup
+
+    it "complains if not in the root of a project" do
+      MainCommand.run(["exec", ":hello"]).should eq "error: 'amber exec' can only be used from the root of a valid amber project"
+    end
+  end
+end

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -1,4 +1,4 @@
-{% if flag?(:run_build_tests) %}
+#{% if flag?(:run_build_tests) %}
 require "../../../spec_helper"
 require "../../../support/helpers/cli_helper"
 
@@ -48,4 +48,4 @@ module Amber::CLI
     cleanup
   end
 end
-{% end %}
+#{% end %}

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -29,6 +29,7 @@ module Amber::CLI
 
     it "copies previous run into new file for editing and runs it returning results" do
       MainCommand.run(["exec", "1337"])
+      puts Dir.glob("./tmp/*_console_result.log")
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1337\n"
     end

--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -24,13 +24,15 @@ module Amber::CLI
 
     it "opens editor and executes .cr file on close" do
       MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
+      sleep 1
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1000\n"
     end
 
     it "copies previous run into new file for editing and runs it returning results" do
       MainCommand.run(["exec", "1337"])
-      puts Dir.glob("./tmp/*_console_result.log")
+      sleep 1
       MainCommand.run(["exec", "-e", "tail", "-b", "1"])
+      sleep 1
       File.read(Dir.glob("./tmp/*_console_result.log").last?.to_s).should eq "1337\n"
     end
 

--- a/spec/amber/dsl/server_spec.cr
+++ b/spec/amber/dsl/server_spec.cr
@@ -3,7 +3,6 @@ require "../../../spec_helper"
 module Amber
   module DSL
     describe Server do
-
       describe "pipeline" do
         context "generating a single ':custom' pipeline" do
           server = Amber::Server.instance
@@ -26,7 +25,6 @@ module Amber
             plugs.should_not be nil
             (plugs.map(&.class).should eq expected) if plugs
           end
-
         end
 
         context "generating a single pipeline with multiple calls" do
@@ -121,9 +119,7 @@ module Amber
             (plugs.map(&.class).should eq expected) if plugs
           end
         end
-
       end
     end
-
   end
 end

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -2,7 +2,7 @@ require "cli"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand
-    command "e", aliased: "exec"
+    command "ex", aliased: "exec"
 
     class Exec < ::Cli::Command
       command_name "exec"
@@ -10,7 +10,7 @@ module Amber::CLI
       class Options
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", required: false, default: nil
         string ["-e", "--editor"], desc: "Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
-        bool ["-p", "--persist"], desc: "Persist the code across invocations of 'amber exec'"
+        string ["-b", "--back"], desc: "Runs prevous command files 'amber exec'", default: "0"
       end
 
       class Help
@@ -21,15 +21,21 @@ module Amber::CLI
         result = ""
         if args.size > 0 && args.code
           if args.code.ends_with?(".cr") && File.exists?(args.code)
+            system("#{options.editor} #{args.code}")
             result = `crystal eval 'require "../config/*"; require "./#{args.code}"'`
           else
             result = `crystal eval 'require "../config/*"; puts (#{args.code}).inspect'`
           end
         else
-          system("#{options.editor} .amber_exec.cr")
-          if File.exists?(".amber_exec.cr")
-            result = `crystal eval 'require "../config/*"; require "./.amber_exec.cr"'`
-            File.delete(".amber_exec.cr") unless options.persist?
+          Dir.mkdir("tmp") unless Dir.exists?("tmp")
+          filename = "./tmp/console_#{Time.now.epoch}.cr"
+          if options.back.to_i(strict: false) > 0
+            old_filename = Dir.glob("./tmp/console_*.cr").reverse[options.back.to_i(strict: false) - 1]
+            system("cp #{old_filename} #{filename}")
+          end
+          system("#{options.editor} #{filename}")
+          if File.exists?(filename)
+            result = `crystal eval 'require "../config/*"; require "#{filename}"'`
           end
         end
         if result.includes?("Error in line 1:") &&

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -21,7 +21,6 @@ module Amber::CLI
         result = ""
         if args.size > 0 && args.code
           if args.code.ends_with?(".cr") && File.exists?(args.code)
-            system("#{options.editor} #{args.code}")
             result = `crystal eval 'require "../config/*"; require "./#{args.code}"'`
           else
             result = `crystal eval 'require "../config/*"; puts (#{args.code}).inspect'`
@@ -40,10 +39,10 @@ module Amber::CLI
         end
         if result.includes?("Error in line 1:") &&
            result.includes?("while requiring \"../config/*\": can't find file '../config/*' relative to '.'")
-          puts "error: 'amber exec' can only be used within the root of a valid amber project"
-        else
-          puts result
+          result = "error: 'amber exec' can only be used from the root of a valid amber project"
         end
+        puts result
+        result
       end
     end
   end

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -2,15 +2,17 @@ require "cli"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand
-    command "ex", aliased: "exec"
+    command "x", aliased: "exec"
 
     class Exec < ::Cli::Command
       command_name "exec"
+      @filename = "./tmp/console_#{Time.now.epoch}.cr"
+      @result : String? = nil
 
       class Options
-        arg "code", desc: "Crystal code or .cr file to execute within the application scope", required: false, default: nil
+        arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
         string ["-e", "--editor"], desc: "Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
-        string ["-b", "--back"], desc: "Runs prevous command files 'amber exec'", default: "0"
+        string ["-b", "--back"], desc: "Runs prevous command files: 'amber exec -b [times_ago]'", default: "0"
       end
 
       class Help
@@ -18,31 +20,30 @@ module Amber::CLI
       end
 
       def run
-        result = ""
-        if args.size > 0 && args.code
-          if args.code.ends_with?(".cr") && File.exists?(args.code)
-            result = `crystal eval 'require "../config/*"; require "./#{args.code}"'`
-          else
-            result = `crystal eval 'require "../config/*"; puts (#{args.code}).inspect'`
-          end
+        unless args.code.blank? || File.exists?(args.code)
+          @result = `crystal eval 'require "../config/*"; puts (#{args.code}).inspect'`
         else
-          Dir.mkdir("tmp") unless Dir.exists?("tmp")
-          filename = "./tmp/console_#{Time.now.epoch}.cr"
-          if options.back.to_i(strict: false) > 0
-            old_filename = Dir.glob("./tmp/console_*.cr").reverse[options.back.to_i(strict: false) - 1]
-            system("cp #{old_filename} #{filename}")
-          end
-          system("#{options.editor} #{filename}")
-          if File.exists?(filename)
-            result = `crystal eval 'require "../config/*"; require "#{filename}"'`
-          end
+          prepare_file
+          system("#{options.editor} #{@filename}")
+          @result = `crystal eval 'require "../config/*"; require "#{@filename}"'` if File.exists?(@filename)
         end
-        if result.includes?("Error in line 1:") &&
-           result.includes?("while requiring \"../config/*\": can't find file '../config/*' relative to '.'")
-          result = "error: 'amber exec' can only be used from the root of a valid amber project"
+
+        if @result && @result.not_nil!.includes?("while requiring \"../config/*\": can't find file '../config/*' relative to '.'")
+          @result = "Error: 'amber exec' can only be used from the root of a valid amber project"
         end
-        puts result
-        result
+        puts @result
+        @result
+      end
+
+      def prepare_file
+        _filename = if File.exists?(args.code)
+                      args.code
+                    elsif options.back.to_i(strict: false) > 0 
+                      Dir.glob("./tmp/console_*.cr").reverse[options.back.to_i(strict: false) - 1]?
+                    end
+
+        system("cp #{_filename} #{@filename}") if _filename
+        @filename
       end
     end
   end

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -1,0 +1,44 @@
+require "cli"
+
+module Amber::CLI
+  class MainCommand < ::Cli::Supercommand
+    command "e", aliased: "exec"
+
+    class Exec < ::Cli::Command
+      command_name "exec"
+
+      class Options
+        arg "code", desc: "Crystal code or .cr file to execute within the application scope", required: false, default: nil
+        string ["-e", "--editor"], desc: "Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
+        bool ["-p", "--persist"], desc: "Persist the code across invocations of 'amber exec'"
+      end
+
+      class Help
+        caption "# It runs Crystal code within the application scope"
+      end
+
+      def run
+        result = ""
+        if args.size > 0 && args.code
+          if args.code.ends_with?(".cr") && File.exists?(args.code)
+            result = `crystal eval 'require "../config/*"; require "./#{args.code}"'`
+          else
+            result = `crystal eval 'require "../config/*"; puts (#{args.code}).inspect'`
+          end
+        else
+          system("#{options.editor} .amber_exec.cr")
+          if File.exists?(".amber_exec.cr")
+            result = `crystal eval 'require "../config/*"; require "./.amber_exec.cr"'`
+            File.delete(".amber_exec.cr") unless options.persist?
+          end
+        end
+        if result.includes?("Error in line 1:") &&
+           result.includes?("while requiring \"../config/*\": can't find file '../config/*' relative to '.'")
+          puts "error: 'amber exec' can only be used within the root of a valid amber project"
+        else
+          puts result
+        end
+      end
+    end
+  end
+end

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -6,8 +6,7 @@ module Amber::CLI
 
     class Exec < ::Cli::Command
       command_name "exec"
-      @filename = "./tmp/console_#{Time.now.epoch}.cr"
-      @result : String? = nil
+      @filename = "./tmp/#{Time.now.epoch}_console.cr"
 
       class Options
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
@@ -19,31 +18,35 @@ module Amber::CLI
         caption "# It runs Crystal code within the application scope"
       end
 
-      def run
-        unless args.code.blank? || File.exists?(args.code)
-          @result = `crystal eval 'require "../config/*"; puts (#{args.code}).inspect'`
-        else
-          prepare_file
-          system("#{options.editor} #{@filename}")
-          @result = `crystal eval 'require "../config/*"; require "#{@filename}"'` if File.exists?(@filename)
-        end
-
-        if @result && @result.not_nil!.includes?("while requiring \"../config/*\": can't find file '../config/*' relative to '.'")
-          @result = "Error: 'amber exec' can only be used from the root of a valid amber project"
-        end
-        puts @result
-        @result
-      end
-
       def prepare_file
         _filename = if File.exists?(args.code)
                       args.code
-                    elsif options.back.to_i(strict: false) > 0 
-                      Dir.glob("./tmp/console_*.cr").reverse[options.back.to_i(strict: false) - 1]?
+                    elsif options.back.to_i(strict: false) > 0
+                      Dir.glob("./tmp/*_console.cr").reverse[options.back.to_i(strict: false) - 1]?
                     end
 
         system("cp #{_filename} #{@filename}") if _filename
-        @filename
+      end
+
+      def run
+        Dir.mkdir("tmp") unless Dir.exists?("tmp")
+
+        unless args.code.blank? || File.exists?(args.code)
+          File.write(@filename, "puts (#{args.code}).inspect")
+        else
+          prepare_file
+          system("#{options.editor} #{@filename}")
+        end
+
+        result = ""
+        result = `crystal eval 'require "./config/*"; require "#{@filename}"'` if File.exists?(@filename)
+
+        if result.includes?("while requiring \"./config/*\": can't find file './config/*' relative to '.'")
+          result = "Error: 'amber exec' can only be used from the root of a valid amber project"
+        end
+
+        File.write(@filename.sub("console.cr", "console_result.log"), result) unless result.blank?
+        puts result
       end
     end
   end

--- a/src/amber/cli/templates/app/.gitignore
+++ b/src/amber/cli/templates/app/.gitignore
@@ -3,6 +3,7 @@
 /.crystal/
 /.shards/
 /.vscode/
+/tmp/
 .env
 .amber_secret_key
 production.yml

--- a/src/amber/scripts/environment_loader.cr
+++ b/src/amber/scripts/environment_loader.cr
@@ -38,7 +38,7 @@ str = String.build do |s|
   s.puts %(@port_reuse = #{settings["port_reuse"]? == nil ? true : settings["port_reuse"]})
   s.puts %(@process_count = #{settings["process_count"]? || 1})
   s.puts %(@log = #{settings["log"]? || "::Logger.new(STDOUT)"}.tap{|l| l.level = #{settings["log_level"]? || "::Logger::INFO"}})
-  #s.puts %(@log.level = #{settings["log_level"]? || "::Logger::INFO"})
+  # s.puts %(@log.level = #{settings["log_level"]? || "::Logger::INFO"})
   s.puts %(@color = #{settings["color"]? == nil ? true : settings["color"]})
   s.puts %(@redis_url = "#{settings["redis_url"]? || "redis://localhost:6379"}")
   s.puts %(@port = #{settings["port"]? || 3000})

--- a/src/amber/server/configuration.cr
+++ b/src/amber/server/configuration.cr
@@ -6,7 +6,7 @@ module Amber
       def self.instance
         @@instance ||= new
       end
-      
+
       # Configure should probably be deprecated in favor of settings.
       def self.configure
         with settings yield settings


### PR DESCRIPTION
### Description of the Change

Adds a simple CLI command for executing one-liner pieces of crystal code within the application scope and printing the result.

Syntax:
```
$ amber exec 'puts User.first'
#<User:0xc04f80>
$ amber x # opens file and runs it on save/exit.
$ amber x -b 1 # runs the previous saved command.
$ amber x file.cr # copies file contents to new tmp file opens in editor and runs on exit.
```

update:
* now supports `amber encrypt`-style syntax using your preferred text editor
* now supports specifying a .cr file instead of code

related issue #352 

### Alternate Designs

1. ICR: bad because it's a fake REPL and can cause unintended side effects since all lines are re-run each time a new line is added
2. reworking `amber play`: bad because it requires a web browser and suffers from similar re-running issues

### Benefits

* extremely simple
* enables effective devops by allowing code to be executed against the preferred amber environment
* e.g. you could do `AMBER_ENV=production amber exec 'code here'`
* does not suffer from code-rerunning issues, since we are only running what you can cram onto a single

### Possible Drawbacks

* implementation would be better if it automatically detected whether or not you are currently in an amber project directory, instead of assuming you are in the root of a project. I'm open to suggestions on how we should handle this
* would be cool if we could cache some of the compilation somehow so successive calls to `amber exec` only need to re-compile changed files, but this might be overkill

### Testing

I have manually tested this on my system. I'd be happy to write unit tests -- not familiar with specs in amber but I can dive in and figure it out if required. If someone could provide some high level advice on writing specs for this I'd greatly appreciate it (i.e. testing this command requires a dummy project skeleton to be in place).
