### PR TITLE
Fix dependencies for amber projects using default app template

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -23,28 +23,36 @@ dependencies:
 <% case @model when "crecto" -%>
   crecto:
     github: Crecto/crecto
+    version: ~> 0.7.1
 <% else -%>
   granite_orm:
     github: amberframework/granite-orm
+    version: ~> 0.7.6
 <% end -%>
 
   quartz_mailer:
     github: amberframework/quartz-mailer
+    version: ~> 0.2.0
 
   jasper_helpers:
     github: amberframework/jasper-helpers
+    version: ~> 0.1.6
 
 <% case @database when "pg" -%>
   pg:
     github: will/crystal-pg
+    version: ~> 0.13.4
 <% when "mysql" -%>
   mysql:
     github: crystal-lang/crystal-mysql
+    version: ~> 0.3.3
 <% when "sqlite" -%>
   sqlite3:
     github: crystal-lang/crystal-sqlite3
+    version: ~> 0.8.3
 <% end -%>
  
 development_dependencies:
   amber_spec:
     github: amberframework/amber-spec
+    version: ~> 0.1.2

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -32,7 +32,7 @@ dependencies:
 
   quartz_mailer:
     github: amberframework/quartz-mailer
-    version: ~> 0.2.0
+    version: 0.2.0
 
   jasper_helpers:
     github: amberframework/jasper-helpers


### PR DESCRIPTION
### Description of the Change

Hi, currently we don't specify the version required on dependencies, so when new releases are published, we can find issues like https://github.com/amberframework/quartz-mailer/issues/7

That issue was because I published quartz-mailer `v0.2.1` to pass #370 , My bad 😢 I though dependencies were already fixed.

This PR fixes dependencies to the latest working version for amber `v0.3.0`, However we would need to push again tag `0.3.0` to fix current dependency issues successfully.

### Alternate Designs

Keep current template, being vulnerable to unexpected changes on dependencies.

### Benefits

Ensure the dependencies match to amber release

### Possible Drawbacks

Not That I know
