### PR TITLE
Set ENV["PORT"] to be used by default if defined.

### DIFF
--- a/spec/amber/scripts/environment_loader_spec.cr
+++ b/spec/amber/scripts/environment_loader_spec.cr
@@ -10,7 +10,7 @@ describe Amber::Server do
       @log = ::Logger.new(STDOUT).tap{|l| l.level = ::Logger::INFO}
       @color = true
       @redis_url = "\#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
-      @port = 3000
+      @port = (ENV["PORT"] ||= "3000").to_i
       @host = "0.0.0.0"
       @secret_key_base = "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
       @session = {
@@ -22,28 +22,6 @@ describe Amber::Server do
 
       EXP
       {{run("../../../src/amber/scripts/environment_loader.cr", "test").stringify}}.should eq expected
-    end
-
-    it "should load expected output" do
-      expected = <<-EXP
-      @name = "amber_test_app"
-      @port_reuse = true
-      @process_count = (ENV[%(AMBER_PROCESS_COUNT)]? || 1).to_i
-      @log = ::Logger.new(STDOUT).tap{|l| l.level = ::Logger::INFO}
-      @color = true
-      @redis_url = "\#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
-      @port = 1337
-      @host = "0.0.0.0"
-      @secret_key_base = "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
-      @session = {
-        :key => "amber.session",
-        :store => :signed_cookie,
-        :expires => 0, 
-      }
-      getter secrets = {"description": "Store your test secrets credentials and settings here.", "database": "mysql://root@localhost:3306/amber_test_app_test"}
-
-      EXP
-      `PORT=1337 AMBER_ENV=test crystal ./src/amber/scripts/environment_loader.cr`.should eq expected
     end
 
     it "should load default settings when environment file doesn't exist." do

--- a/spec/amber/scripts/environment_loader_spec.cr
+++ b/spec/amber/scripts/environment_loader_spec.cr
@@ -24,6 +24,28 @@ describe Amber::Server do
       {{run("../../../src/amber/scripts/environment_loader.cr", "test").stringify}}.should eq expected
     end
 
+    it "should load expected output" do
+      expected = <<-EXP
+      @name = "amber_test_app"
+      @port_reuse = true
+      @process_count = (ENV[%(AMBER_PROCESS_COUNT)]? || 1).to_i
+      @log = ::Logger.new(STDOUT).tap{|l| l.level = ::Logger::INFO}
+      @color = true
+      @redis_url = "\#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
+      @port = 1337
+      @host = "0.0.0.0"
+      @secret_key_base = "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
+      @session = {
+        :key => "amber.session",
+        :store => :signed_cookie,
+        :expires => 0, 
+      }
+      getter secrets = {"description": "Store your test secrets credentials and settings here.", "database": "mysql://root@localhost:3306/amber_test_app_test"}
+
+      EXP
+      `PORT=1337 AMBER_ENV=test crystal ./src/amber/scripts/environment_loader.cr`.should eq expected
+    end
+
     it "should load default settings when environment file doesn't exist." do
       expected = <<-EXP
       @name = "Amber_App"

--- a/spec/amber/server/settings_spec.cr
+++ b/spec/amber/server/settings_spec.cr
@@ -18,4 +18,11 @@ describe Amber::Settings do
     }
     settings.secrets.should eq expected_secrets
   end
+
+  it "loads environment settings from test.yml with env overload for port." do
+    ENV["PORT"] = "1337"
+    settings = Amber::Settings.new
+
+    settings.port.should eq 1337
+  end
 end

--- a/spec/support/config/test.yml
+++ b/spec/support/config/test.yml
@@ -1,6 +1,6 @@
 name: amber_test_app
 secret_key_base: mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8
-port: 3000
+port: (ENV["PORT"] ||= "3000").to_i
 log: "::Logger.new(STDOUT)"
 log_level: "::Logger::INFO"
 color: true

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -1,5 +1,5 @@
 secret_key_base: <%= SecureRandom.urlsafe_base64(32) %>
-port: 3000
+port: <%= (ENV["PORT"] ||= "3000").to_i %>
 name: <%= @name %>
 log: "::Logger.new(STDOUT)"
 log_level: "::Logger::INFO"

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -1,5 +1,5 @@
 secret_key_base: <%= SecureRandom.urlsafe_base64(32) %>
-port: 80
+port: <%= (ENV["PORT"] ||= "80").to_i %>
 name: <%= @name %>
 log: "::Logger.new(STDOUT)"
 log_level: "::Logger::INFO"

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -1,5 +1,5 @@
 secret_key_base: <%= SecureRandom.urlsafe_base64(32) %>
-port: 3000
+port: <%= (ENV["PORT"] ||= "3000").to_i %>
 name: <%= @name %>
 log: "::Logger.new(STDOUT)"
 log_level: "::Logger::INFO"

--- a/src/amber/scripts/environment_loader.cr
+++ b/src/amber/scripts/environment_loader.cr
@@ -41,7 +41,7 @@ str = String.build do |s|
   #s.puts %(@log.level = #{settings["log_level"]? || "::Logger::INFO"})
   s.puts %(@color = #{settings["color"]? == nil ? true : settings["color"]})
   s.puts %(@redis_url = "#{settings["redis_url"]? || "redis://localhost:6379"}")
-  s.puts %(@port = #{settings["port"]? || 3000})
+  s.puts %(@port = #{ENV["PORT"]? || settings["port"]? || 3000})
   s.puts %(@host = "#{settings["host"]? || "127.0.0.1"}")
   s.puts %(@secret_key_base = "#{settings["secret_key_base"]? || SecureRandom.urlsafe_base64(32)}")
 

--- a/src/amber/scripts/environment_loader.cr
+++ b/src/amber/scripts/environment_loader.cr
@@ -38,10 +38,9 @@ str = String.build do |s|
   s.puts %(@port_reuse = #{settings["port_reuse"]? == nil ? true : settings["port_reuse"]})
   s.puts %(@process_count = #{settings["process_count"]? || 1})
   s.puts %(@log = #{settings["log"]? || "::Logger.new(STDOUT)"}.tap{|l| l.level = #{settings["log_level"]? || "::Logger::INFO"}})
-  #s.puts %(@log.level = #{settings["log_level"]? || "::Logger::INFO"})
   s.puts %(@color = #{settings["color"]? == nil ? true : settings["color"]})
   s.puts %(@redis_url = "#{settings["redis_url"]? || "redis://localhost:6379"}")
-  s.puts %(@port = #{ENV["PORT"]? || settings["port"]? || 3000})
+  s.puts %(@port = #{settings["port"]? || 3000})
   s.puts %(@host = "#{settings["host"]? || "127.0.0.1"}")
   s.puts %(@secret_key_base = "#{settings["secret_key_base"]? || SecureRandom.urlsafe_base64(32)}")
 


### PR DESCRIPTION
### Description of the Change

Fixed small bug where `ENV["PORT"]` wasn't being used by default. I thought that it would be good to leave this more configurable, but agree that this might be confusing to users.