### PR TITLE
CORS headers check should be case insensitive

### DIFF
--- a/spec/amber/router/pipe/cors_spec.cr
+++ b/spec/amber/router/pipe/cors_spec.cr
@@ -1,0 +1,32 @@
+require "../../../../spec_helper"
+
+module Amber
+  module Pipe
+    describe CORS do
+      context "allowed headers" do
+        pipeline = Pipeline.new
+
+        pipeline.build :cors do
+          plug CORS.new
+        end
+
+        Amber::Server.router.draw :cors do
+          options "/test", HelloController, :world
+        end
+
+        pipeline.prepare_pipelines
+
+        it "should allow a case-insensitive header values" do
+          cors = CORS.new
+          request = HTTP::Request.new("OPTIONS", "/test")
+          request.headers["Access-Control-Request-Method"] = "OPTIONS"
+          request.headers["Access-Control-Request-Headers"] = "cOnTeNt-TyPe"
+
+          response = create_request_and_return_io(pipeline, request)
+
+          response.status_code.should eq 200
+        end
+      end
+    end
+  end
+end

--- a/src/amber/router/pipe/cors.cr
+++ b/src/amber/router/pipe/cors.cr
@@ -7,7 +7,7 @@ module Amber
 
       def initialize
         @allow_origin = "*"
-        @allow_headers = "Accept, Content-Type"
+        @allow_headers = "accept, content-type"
         @allow_methods = "GET, HEAD, POST, DELETE, OPTIONS, PUT, PATCH"
         @allow_credentials = false
         @max_age = 0
@@ -47,7 +47,7 @@ module Amber
 
             if requested_headers = context.request.headers["Access-Control-Request-Headers"]
               requested_headers.split(",").each do |requested_header|
-                if allow_headers.includes? requested_header.strip
+                if allow_headers.includes? requested_header.strip.downcase
                   context.response.headers["Access-Control-Allow-Headers"] = allow_headers
                 else
                   context.response.status_code = 403


### PR DESCRIPTION
### Description of the Change

Fixes issue #376 

According to [RFC 2616 section 4.2](https://tools.ietf.org/html/rfc2616#section-4.2) CORS message headers should be case-insensitive.  The 2 javascript libraries I tried (jquery ajax and vue-resource) were sending headers as all lowercase which was failing the CORS check requiring me to extend and patch the existing CORS middleware.

This change just makes `@allow-headers` lowercase, and calls `downcase` on the incoming request header.

Also created a cors spec file with a test for this case.

### Benefits

CORS can be used correctly now without patching CORS
