### PR TITLE
Ep/move properties to server

### DIFF
--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -16,9 +16,12 @@ describe Amber do
   end
 
   describe Amber::Server do
+    server = Amber::Server.instance
+
     describe ".configure" do
       it "overrides enviroment settings" do
-        Amber::Server.instance.settings = Amber::Settings.new
+        server.settings = Amber::Settings.new
+
         Amber::Server.configure do |server|
           server.name = "Hello World App"
           server.port = 8080
@@ -36,7 +39,8 @@ describe Amber do
       end
 
       it "retains environment.yml settings that haven't been overwritten" do
-        Amber::Server.instance.settings = Amber::Settings.new
+        server.settings = Amber::Settings.new
+
         Amber::Server.configure do |server|
           server.name = "New name"
           server.port = 8080
@@ -61,7 +65,7 @@ describe Amber do
       end
 
       it "defines socket endpoint" do
-        Amber::Server.settings.router.socket_routes = [] of NamedTuple(path: String, handler: Amber::WebSockets::Server::Handler)
+        Amber::Server.router.socket_routes = [] of NamedTuple(path: String, handler: Amber::WebSockets::Server::Handler)
 
         Amber::Server.configure do |app|
           pipeline :web do
@@ -73,7 +77,7 @@ describe Amber do
           end
         end
 
-        router = Amber::Server.settings.router
+        router = Amber::Server.router
         websockets = router.socket_routes
 
         websockets[0][:path].should eq "/user"

--- a/spec/amber/dsl/server_spec.cr
+++ b/spec/amber/dsl/server_spec.cr
@@ -6,8 +6,9 @@ module Amber
       describe "pipeline" do
         context "generating a single ':custom' pipeline" do
           server = Amber::Server.instance
-          server.settings.handler.pipeline.clear
-          Amber::Server.settings do |app|
+          server.handler.pipeline.clear
+
+          Amber::Server.configure do |app|
             pipeline :custom do
               plug Pipe::Logger.new
               plug Pipe::Error.new
@@ -15,13 +16,13 @@ module Amber
           end
 
           it "should add ':custom' to the server's pipeline" do
-            valves = server.settings.handler.pipeline.keys
+            valves = server.handler.pipeline.keys
             valves.should contain :custom
           end
 
           it "have added pipes in the pipeline" do
             expected = [Pipe::Logger, Pipe::Error]
-            plugs = server.settings.handler.pipeline[:custom]?
+            plugs = server.handler.pipeline[:custom]?
             plugs.should_not be nil
             (plugs.map(&.class).should eq expected) if plugs
           end
@@ -29,8 +30,9 @@ module Amber
 
         context "generating a single pipeline with multiple calls" do
           server = Amber::Server.instance
-          server.settings.handler.pipeline.clear
-          Amber::Server.settings do |app|
+          server.handler.pipeline.clear
+
+          Amber::Server.configure do |app|
             pipeline :custom do
               plug Pipe::Logger.new
               plug Pipe::Error.new
@@ -43,7 +45,7 @@ module Amber
 
           it "should have all pipes in pipeline" do
             expected = [Pipe::Logger, Pipe::Error, Pipe::CSRF]
-            plugs = server.settings.handler.pipeline[:custom]?
+            plugs = server.handler.pipeline[:custom]?
             plugs.should_not be nil
             (plugs.map(&.class).should eq expected) if plugs
           end
@@ -51,8 +53,9 @@ module Amber
 
         context "generating multiple pipelines" do
           server = Amber::Server.instance
-          server.settings.handler.pipeline.clear
-          Amber::Server.settings do |app|
+          server.handler.pipeline.clear
+
+          Amber::Server.configure do |app|
             pipeline :api, :web do
               plug Pipe::Logger.new
               plug Pipe::Error.new
@@ -60,7 +63,7 @@ module Amber
           end
 
           it "should add all pipelines to the server's pipeline" do
-            valves = server.settings.handler.pipeline.keys
+            valves = server.handler.pipeline.keys
             valves.should contain :api
             valves.should contain :web
           end
@@ -68,7 +71,7 @@ module Amber
           it "have added shared pipes in all pipelines" do
             expected = [Pipe::Logger, Pipe::Error]
             [:api, :web].each do |name|
-              plugs = server.settings.handler.pipeline[name]?
+              plugs = server.handler.pipeline[name]?
               plugs.should_not be nil
               (plugs.map(&.class).should eq expected) if plugs
             end
@@ -77,8 +80,9 @@ module Amber
 
         context "generating multiple pipelines and single pipelines" do
           server = Amber::Server.instance
-          server.settings.handler.pipeline.clear
-          Amber::Server.settings do |app|
+          server.handler.pipeline.clear
+
+          Amber::Server.configure do |app|
             pipeline :api do
               plug Pipe::CORS.new
             end
@@ -94,27 +98,27 @@ module Amber
           end
 
           it "existing pipes should be at the front of the pipeline" do
-            plugs = server.settings.handler.pipeline[:api]?
+            plugs = server.handler.pipeline[:api]?
             plugs.should_not be nil
             (plugs.first?.should be_a Pipe::CORS) if plugs
           end
 
           it "additional pipes should be at the end of the pipeline" do
-            plugs = server.settings.handler.pipeline[:web]?
+            plugs = server.handler.pipeline[:web]?
             plugs.should_not be nil
             (plugs.last?.should be_a Pipe::CSRF) if plugs
           end
 
           it "pipes should be in the same order when appending" do
             expected = [Pipe::CORS, Pipe::Logger, Pipe::Error]
-            plugs = server.settings.handler.pipeline[:api]?
+            plugs = server.handler.pipeline[:api]?
             plugs.should_not be nil
             (plugs.map(&.class).should eq expected) if plugs
           end
 
           it "pipes should be in the same order when prepending" do
             expected = [Pipe::Logger, Pipe::Error, Pipe::CSRF]
-            plugs = server.settings.handler.pipeline[:web]?
+            plugs = server.handler.pipeline[:web]?
             plugs.should_not be nil
             (plugs.map(&.class).should eq expected) if plugs
           end

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -19,6 +19,8 @@ require "./amber/websockets/**"
 module Amber
   class Server
     include Amber::Configuration
+    getter handler = Pipe::Pipeline.new
+    getter router = Router::Router.new
 
     def initialize
       settings.log.level = ::Logger::INFO

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -18,7 +18,10 @@ require "./amber/websockets/**"
 
 module Amber
   class Server
+    include Amber::DSL::Server
     include Amber::Configuration
+    alias WebSocketAdapter = WebSockets::Adapters::RedisAdapter.class | WebSockets::Adapters::MemoryAdapter.class
+    property pubsub_adapter : WebSocketAdapter = WebSockets::Adapters::MemoryAdapter
     getter handler = Pipe::Pipeline.new
     getter router = Router::Router.new
 
@@ -46,8 +49,8 @@ module Amber
     def start
       time = Time.now
       settings.log.info "#{version} serving application \"#{settings.name}\" at #{host_url}".to_s
-      settings.handler.prepare_pipelines
-      server = HTTP::Server.new(settings.host, settings.port, settings.handler)
+      handler.prepare_pipelines
+      server = HTTP::Server.new(settings.host, settings.port, handler)
       server.tls = Amber::SSL.new(settings.ssl_key_file.not_nil!, settings.ssl_cert_file.not_nil!).generate_tls if ssl_enabled?
 
       Signal::INT.trap do

--- a/src/amber/server/configuration.cr
+++ b/src/amber/server/configuration.cr
@@ -41,7 +41,11 @@ module Amber
       end
 
       def self.router
-        settings.router
+        instance.router
+      end
+
+      def self.handler
+        instance.handler
       end
 
       def self.handler

--- a/src/amber/server/configuration.cr
+++ b/src/amber/server/configuration.cr
@@ -1,9 +1,6 @@
 module Amber
   module Configuration
     macro included
-      include Amber::DSL::Server
-      alias WebSocketAdapter = WebSockets::Adapters::RedisAdapter.class | WebSockets::Adapters::MemoryAdapter.class
-      property pubsub_adapter : WebSocketAdapter = WebSockets::Adapters::MemoryAdapter
       property settings = Settings.new
 
       def self.instance
@@ -45,10 +42,6 @@ module Amber
 
       def self.handler
         instance.handler
-      end
-
-      def self.handler
-        settings.handler
       end
 
       def self.redis_url

--- a/src/amber/server/configuration.cr
+++ b/src/amber/server/configuration.cr
@@ -1,6 +1,9 @@
 module Amber
   module Configuration
     macro included
+      include Amber::DSL::Server
+      alias WebSocketAdapter = WebSockets::Adapters::RedisAdapter.class | WebSockets::Adapters::MemoryAdapter.class
+      property pubsub_adapter : WebSocketAdapter = WebSockets::Adapters::MemoryAdapter
       property settings = Settings.new
 
       def self.instance
@@ -9,11 +12,7 @@ module Amber
 
       # Configure should probably be deprecated in favor of settings.
       def self.configure
-        with settings yield settings
-      end
-
-      def self.settings(&block)
-        with settings yield settings
+        with self yield settings
       end
 
       def self.settings
@@ -37,7 +36,7 @@ module Amber
       end
 
       def self.pubsub_adapter
-        settings.pubsub_adapter.instance
+        instance.pubsub_adapter.instance
       end
 
       def self.router

--- a/src/amber/server/settings.cr
+++ b/src/amber/server/settings.cr
@@ -5,10 +5,6 @@ require "./ssl"
 module Amber
   class Settings
     include Amber::DSL::Server
-    alias WebSocketAdapter = WebSockets::Adapters::RedisAdapter.class | WebSockets::Adapters::MemoryAdapter.class
-    getter handler = Pipe::Pipeline.new
-    getter router = Router::Router.new
-    property pubsub_adapter : WebSocketAdapter = WebSockets::Adapters::MemoryAdapter
     property port_reuse : Bool
     property log : ::Logger
     property color : Bool = true


### PR DESCRIPTION
- [Server] Moves Router and Handler out off Settings 
  - Moves the Pipeline instance from Amber::Settings into the Server instance
  - Moves the Router instance from Amber::Settings into the Server instance
- [Server] Moves WebSocketAdapter and Removes Settings class method
- [Server] Move websockets from Configuration to Server
  - Replace settings.handler with just handler