### PR TITLE
Ep/more db spec

### DIFF
--- a/spec/amber/cli/commands/database_spec.cr
+++ b/spec/amber/cli/commands/database_spec.cr
@@ -9,8 +9,8 @@ module Amber::CLI
   describe "database" do
     describe "sqlite" do
       cleanup
-			scaffold_app(TESTING_APP, "-d", "sqlite")
-			db_filename = db_yml("./")["sqlite"]["database"].to_s.sub("sqlite3:", "")
+      scaffold_app(TESTING_APP, "-d", "sqlite")
+      db_filename = db_yml("./")["sqlite"]["database"].to_s.sub("sqlite3:", "")
 
       it "does not create the database when `db create`" do
         MainCommand.run ["db", "create"]

--- a/spec/amber/cli/commands/database_spec.cr
+++ b/spec/amber/cli/commands/database_spec.cr
@@ -1,0 +1,33 @@
+require "../../../spec_helper"
+require "../../../support/helpers/cli_helper"
+require "../../../support/fixtures/cli_fixtures"
+
+include CLIHelper
+include CLIFixtures
+
+module Amber::CLI
+  describe "database" do
+    describe "sqlite" do
+      cleanup
+			scaffold_app(TESTING_APP, "-d", "sqlite")
+			db_filename = db_yml("./")["sqlite"]["database"].to_s.sub("sqlite3:", "")
+
+      it "does not create the database when `db create`" do
+        MainCommand.run ["db", "create"]
+        File.exists?(db_filename).should be_false
+      end
+
+      it "does create the database when `db migrate`" do
+        MainCommand.run ["generate", "model", "Post"]
+        MainCommand.run ["db", "migrate"]
+        File.exists?(db_filename).should be_true
+        File.stat(db_filename).size.should_not eq 0
+      end
+
+      it "deletes the database when `db drop`" do
+        MainCommand.run ["db", "drop"]
+        File.exists?(db_filename).should be_false
+      end
+    end
+  end
+end

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -6,34 +6,6 @@ include CLIHelper
 include CLIFixtures
 
 module Amber::CLI
-  context "sqlite" do
-    cleanup
-    MainCommand.run ["new", TESTING_APP, "-d", "sqlite"]
-
-    describe "database" do
-      db_filename = db_yml["sqlite"]["database"].to_s.sub("sqlite3:", "")
-
-      Dir.cd(TESTING_APP)
-
-      it "does not create the database when `db create`" do
-        MainCommand.run ["db", "create"]
-        File.exists?(db_filename).should be_false
-      end
-
-      it "does create the database when `db migrate`" do
-        MainCommand.run ["generate", "model", "Post"]
-        MainCommand.run ["db", "migrate"]
-        File.exists?(db_filename).should be_true
-        File.stat(db_filename).size.should_not eq 0
-      end
-
-      it "deletes the database when `db drop`" do
-        MainCommand.run ["db", "drop"]
-        File.exists?(db_filename).should be_false
-      end
-    end
-  end
-
   describe "amber generate" do
     ENV["AMBER_ENV"] = "test"
     camel_case = "PostComment"

--- a/spec/support/helpers/cli_helper.cr
+++ b/spec/support/helpers/cli_helper.cr
@@ -19,16 +19,16 @@ module CLIHelper
     path ? path.split('/').last : ""
   end
 
-  def db_yml
-    YAML.parse(File.read("#{TESTING_APP}/config/database.yml"))
+  def db_yml(path = TESTING_APP)
+    YAML.parse(File.read("#{path}/config/database.yml"))
   end
 
-  def amber_yml
-    YAML.parse(File.read("#{TESTING_APP}/.amber.yml"))
+  def amber_yml(path = TESTING_APP)
+    YAML.parse(File.read("#{path}/.amber.yml"))
   end
 
-  def shard_yml
-    YAML.parse(File.read("#{TESTING_APP}/shard.yml"))
+  def shard_yml(path = TESTING_APP)
+    YAML.parse(File.read("#{path}/shard.yml"))
   end
 
   def environment_yml(environment : String)


### PR DESCRIPTION
## [CLI] Move DB Spec into Correct Spec File

Currently the Database spec is residing inside the generator spec
breaking our current spec design conventions.

This moves the `db` command spec to the correct file providing better
organization for the test suite.