### PR TITLE
[CLI] Moves DB settings to config/environments

### DIFF
--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -56,9 +56,9 @@ describe Amber do
         expected_session = {:key => "amber.session", :store => :signed_cookie, :expires => 0}
         settings.session.should eq expected_session
         settings.port.should_not eq 3000
+        settings.database.should eq "mysql://root@localhost:3306/amber_test_app_test"
         expected_secrets = {
           description: "Store your test secrets credentials and settings here.",
-          database:    "mysql://root@localhost:3306/amber_test_app_test",
         }
         settings.secrets.should eq expected_secrets
         settings.secret_key_base.should eq "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"

--- a/spec/amber/cli/build_spec.cr
+++ b/spec/amber/cli/build_spec.cr
@@ -25,7 +25,7 @@ module Amber::CLI
 
       prepare_yaml(Dir.current)
 
-      prepare_db_yml if ENV["CI"]? == "true"
+      prepare_db_yml(CLIHelper::BASE_ENV_PATH) if ENV["CI"]? == "true"
 
       puts "====== START Creating database for #{TEST_APP_NAME} ======"
       MainCommand.run ["db", "drop"]

--- a/spec/amber/cli/commands/database_spec.cr
+++ b/spec/amber/cli/commands/database_spec.cr
@@ -8,25 +8,47 @@ include CLIFixtures
 module Amber::CLI
   describe "database" do
     describe "sqlite" do
+      env = ENV["AMBER_ENV"]
       cleanup
       scaffold_app(TESTING_APP, "-d", "sqlite")
-      db_filename = db_yml("./")["sqlite"]["database"].to_s.sub("sqlite3:", "")
 
-      it "does not create the database when `db create`" do
-        MainCommand.run ["db", "create"]
-        File.exists?(db_filename).should be_false
+      context env do
+        env_yml = environment_yml(env, path: CLIHelper::BASE_ENV_PATH)
+        db_filename = env_yml["database"].to_s.gsub("sqlite3:", "")
+
+        it "has connection settings in config/environments/env.yml" do
+          env_yml["database"].should eq expected_db_url("sqlite3", env)
+        end
+
+        it "does not create the database when `db create`" do
+          MainCommand.run ["db", "create"]
+          File.exists?(db_filename).should be_false
+        end
+
+        it "does create the database when `db migrate`" do
+          MainCommand.run ["generate", "model", "Post"]
+          MainCommand.run ["db", "migrate"]
+          p db_filename
+          File.exists?(db_filename).should be_true
+          File.stat(db_filename).size.should_not eq 0
+        end
+
+        it "deletes the database when `db drop`" do
+          MainCommand.run ["db", "drop"]
+          File.exists?(db_filename).should be_false
+        end
       end
+    end
 
-      it "does create the database when `db migrate`" do
-        MainCommand.run ["generate", "model", "Post"]
-        MainCommand.run ["db", "migrate"]
-        File.exists?(db_filename).should be_true
-        File.stat(db_filename).size.should_not eq 0
-      end
+    describe "postgres" do
+      cleanup
+      scaffold_app(TESTING_APP, "-d", "pg")
+      env = ENV["AMBER_ENV"]
 
-      it "deletes the database when `db drop`" do
-        MainCommand.run ["db", "drop"]
-        File.exists?(db_filename).should be_false
+      context "when #{env} environment" do
+        it "has #{env} environment connection settings" do
+          environment_yml(env, path: CLIHelper::BASE_ENV_PATH)["database"].should eq expected_db_url("pg", env)
+        end
       end
     end
   end

--- a/spec/amber/cli/commands/init_spec.cr
+++ b/spec/amber/cli/commands/init_spec.cr
@@ -68,43 +68,18 @@ module Amber::CLI
       cleanup
       MainCommand.run ["new", TESTING_APP, "-d", db]
 
-      describe "database.yml config for #{db}" do
-        db_key = db == "sqlite" ? "sqlite3" : db
-        db_url = db_yml[db]["database"].as_s
-        db_name = db_name(db_url)
+      describe "#{db}" do
+        %w(development test).each do |env|
+          db_key = db == "sqlite" ? "sqlite3" : db
+          db_url = environment_yml(env)["database"].as_s
 
-        it "adds #{db} section" do
-          db_yml[db].should_not be_nil
-        end
+          context "is #{env.upcase}" do
+            it "sets #{db} shards dependencies" do
+              shard_yml["dependencies"][db_key].should_not be_nil
+            end
 
-        it "sets #{db} shards dependencies" do
-          shard_yml["dependencies"][db_key].should_not be_nil
-        end
-
-        it "has a database url" do
-          db_url.should_not be_nil
-          db_url.should_not eq ""
-        end
-
-        it "has correct db name" do
-          db_name.should_not contain "-"
-          db_name.should contain "development"
-        end
-
-        context "when environment" do
-          %w(development test).each do |env|
-            context "is #{env.upcase}" do
-              env_db_url = environment_yml(env)["secrets"]["database"].as_s
-              env_db_name = db_name(env_db_url)
-
-              it "has a database url" do
-                env_db_url.should contain env
-              end
-
-              it "hass correct name" do
-                env_db_name.should contain env
-                env_db_name.should_not contain "-"
-              end
+            it "has correct database connection string" do
+              db_url.should eq expected_db_url(db_key, env)
             end
           end
         end

--- a/spec/amber/scripts/environment_loader_spec.cr
+++ b/spec/amber/scripts/environment_loader_spec.cr
@@ -10,15 +10,16 @@ describe Amber::Server do
       @log = ::Logger.new(STDOUT).tap{|l| l.level = ::Logger::INFO}
       @color = true
       @redis_url = "\#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
+      @database = "mysql://root@localhost:3306/amber_test_app_test"
       @port = (ENV["PORT"] ||= "3000").to_i
       @host = "0.0.0.0"
       @secret_key_base = "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
       @session = {
         :key => "amber.session",
         :store => :signed_cookie,
-        :expires => 0, 
+        :expires => 0,
       }
-      getter secrets = {"description": "Store your test secrets credentials and settings here.", "database": "mysql://root@localhost:3306/amber_test_app_test"}
+      getter secrets = {"description": "Store your test secrets credentials and settings here."}
 
       EXP
       {{run("../../../src/amber/scripts/environment_loader.cr", "test").stringify}}.should eq expected
@@ -32,6 +33,7 @@ describe Amber::Server do
       @log = ::Logger.new(STDOUT).tap{|l| l.level = ::Logger::INFO}
       @color = true
       @redis_url = "redis://localhost:6379"
+      @database = ""
       @port = 3000
       @host = "127.0.0.1"
       @session = {:key => "amber.session", :store => :signed_cookie, :expires => 0}

--- a/spec/amber/server/settings_spec.cr
+++ b/spec/amber/server/settings_spec.cr
@@ -7,6 +7,7 @@ describe Amber::Settings do
     settings.name.should eq "amber_test_app"
     settings.port_reuse.should eq true
     settings.redis_url.should eq "#{ENV["REDIS_URL"]? || "redis://localhost:6379"}"
+    settings.database = ""
     settings.port.should eq 3000
     settings.color.should eq true
     settings.secret_key_base.should eq "mV6kTmG3k1yVFh-fPYpugSn0wbZveDvrvfQuv88DPF8"
@@ -14,7 +15,6 @@ describe Amber::Settings do
     settings.session.should eq expected_session
     expected_secrets = {
       description: "Store your test secrets credentials and settings here.",
-      database:    "mysql://root@localhost:3306/amber_test_app_test",
     }
     settings.secrets.should eq expected_secrets
   end

--- a/spec/support/config/test.yml
+++ b/spec/support/config/test.yml
@@ -10,10 +10,10 @@ host: 0.0.0.0
 ssl_key_file:
 ssl_cert_file:
 redis_url: "#{ENV[%(REDIS_URL)]? || %(redis://localhost:6379)}"
+database: mysql://root@localhost:3306/amber_test_app_test
 session:
   key: "amber.session"
   store: :signed_cookie
   expires: 0
 secrets:
   description: Store your test secrets credentials and settings here.
-  database: mysql://root@localhost:3306/amber_test_app_test

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -5,6 +5,9 @@ require "sqlite3"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand
+    AMBER_ENV       = (ENV["AMBER_ENV"] ||= "development")
+    ENV_CONFIG_PATH = "./config/environments/#{AMBER_ENV}.yml"
+
     command "db", aliased: "database"
 
     class Database < ::Cli::Command
@@ -45,19 +48,16 @@ module Amber::CLI
               Micrate::Cli.print_help
             end
           rescue e : Micrate::UnorderedMigrationsException
-            Micrate::Cli.report_unordered_migrations(e.versions)
-            exit 1
+            exit! Micrate::Cli.report_unordered_migrations(e.versions), error: true
           rescue e : DB::ConnectionRefused
-            puts "Connection refused: #{Micrate::DB.connection_url}"
-            exit 1
+            exit! "Connection refused: #{Micrate::DB.connection_url}", error: true
           rescue e : Exception
-            puts e.message
-            exit 1
+            exit! e.message, error: true
           end
         end
       end
 
-      def drop_database
+      private def drop_database
         url = Micrate::DB.connection_url.to_s
         if url.starts_with? "sqlite3:"
           path = url.gsub("sqlite3:", "")
@@ -66,13 +66,13 @@ module Amber::CLI
         else
           name = set_database_to_schema url
           Micrate::DB.connect do |db|
-            db.exec "DROP DATABASE #{name};"
+            db.exec "DROP DATABASE IF EXISTS #{name};"
           end
           puts "Dropped database #{name}"
         end
       end
 
-      def create_database
+      private def create_database
         url = Micrate::DB.connection_url.to_s
         if url.starts_with? "sqlite3:"
           puts "For sqlite3, the database will be created during the first migration."
@@ -85,7 +85,7 @@ module Amber::CLI
         end
       end
 
-      def set_database_to_schema(url)
+      private def set_database_to_schema(url)
         uri = URI.parse(url)
         if path = uri.path
           Micrate::DB.connection_url = url.gsub(path, "/#{uri.scheme}")
@@ -95,24 +95,11 @@ module Amber::CLI
         end
       end
 
-      def database_url
+      private def database_url
         ENV["DATABASE_URL"]? || begin
-          yaml_file = File.read("config/database.yml")
+          yaml_file = File.read(ENV_CONFIG_PATH)
           yaml = YAML.parse(yaml_file)
-          db = yaml.first.to_s
-          settings = yaml[db]
-          env(settings["database"].to_s)
-        end
-      end
-
-      private def env(url)
-        regex = /\$\{(.*?)\}/
-        if regex.match(url)
-          url = url.gsub(regex) do |match|
-            ENV[match.gsub("${", "").gsub("}", "")]
-          end
-        else
-          return url
+          yaml["database"].to_s
         end
       end
     end

--- a/src/amber/cli/templates/app/config/database.yml.ecr
+++ b/src/amber/cli/templates/app/config/database.yml.ecr
@@ -1,9 +1,0 @@
-<%= @database %>:
-<% case @database
-   when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= "#{database_name_base}_development" %>
-<% when "pg" -%>
-  database: postgres://postgres:@localhost:5432/<%= "#{database_name_base}_development" %>
-<% when "sqlite" -%>
-  database: sqlite3:./db/<%= "#{database_name_base}_development" %>.db
-<% end -%>

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -10,17 +10,17 @@ process_count: (ENV[%(AMBER_PROCESS_COUNT)]? || 1).to_i
 ssl_key_file:
 ssl_cert_file:
 redis_url: "redis://localhost:6379"
+<%case @database
+  when "mysql" -%>
+database: mysql://root@localhost:3306/<%= database_name_base %>_development
+<%when "pg" -%>
+database: postgres://postgres:@localhost:5432/<%= database_name_base %>_development
+<%when "sqlite" -%>
+database: sqlite3:./db/<%= database_name_base %>_development.db
+<%end -%>
 session:
   key: amber.session
   store: :signed_cookie
   expires: 0
 secrets:
   description: Store your development secrets credentials and settings here.
-<%case @database
-  when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= database_name_base %>_development
-<%when "pg" -%>
-  database: postgres://postgres:@localhost:5432/<%= database_name_base %>_development
-<%when "sqlite" -%>
-  database: sqlite3:./db/<%= database_name_base %>_development.db
-<%end -%>

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -10,17 +10,17 @@ process_count: (ENV[%(AMBER_PROCESS_COUNT)]? || 1).to_i
 ssl_key_file:
 ssl_cert_file:
 redis_url: "redis://localhost:6379"
+<%case @database
+  when "mysql" -%>
+database: mysql://root@localhost:3306/<%= database_name_base %>
+<%when "pg" -%>
+database: postgres://postgres:@localhost:5432/<%= database_name_base %>
+<%when "sqlite" -%>
+database: sqlite3:./db/<%= database_name_base %>.db
+<%end -%>
 session:
   key: amber.session
   store: :signed_cookie
   expires: 0
 secrets:
   description: Store your production secrets credentials and settings here.
-<%case @database
-  when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= database_name_base %>
-<%when "pg" -%>
-  database: postgres://postgres:@localhost:5432/<%= database_name_base %>
-<%when "sqlite" -%>
-  database: sqlite3:./db/<%= database_name_base %>.db
-<%end -%>

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -10,17 +10,17 @@ process_count: (ENV[%(AMBER_PROCESS_COUNT)]? || 1).to_i
 ssl_key_file:
 ssl_cert_file:
 redis_url: "redis://localhost:6379"
+<%case @database
+  when "mysql" -%>
+database: mysql://root@localhost:3306/<%= database_name_base %>_test
+<%when "pg" -%>
+database: postgres://postgres:@localhost:5432/<%= database_name_base %>_test
+<%when "sqlite" -%>
+database: sqlite3:./db/<%= database_name_base %>_test.db
+<%end -%>
 session:
   key: amber.session
   store: :signed_cookie
   expires: 0
 secrets:
   description: Store your test secrets credentials and settings here.
-<%case @database
-  when "mysql" -%>
-  database: mysql://root@localhost:3306/<%= database_name_base %>_test
-<%when "pg" -%>
-  database: postgres://postgres:@localhost:5432/<%= database_name_base %>_test
-<%when "sqlite" -%>
-  database: sqlite3:./db/<%= database_name_base %>_test.db
-<%end -%>

--- a/src/amber/scripts/environment_loader.cr
+++ b/src/amber/scripts/environment_loader.cr
@@ -40,6 +40,7 @@ str = String.build do |s|
   s.puts %(@log = #{settings["log"]? || "::Logger.new(STDOUT)"}.tap{|l| l.level = #{settings["log_level"]? || "::Logger::INFO"}})
   s.puts %(@color = #{settings["color"]? == nil ? true : settings["color"]})
   s.puts %(@redis_url = "#{settings["redis_url"]? || "redis://localhost:6379"}")
+  s.puts %(@database = "#{settings["database"]?}")
   s.puts %(@port = #{settings["port"]? || 3000})
   s.puts %(@host = "#{settings["host"]? || "127.0.0.1"}")
   s.puts %(@secret_key_base = "#{settings["secret_key_base"]? || SecureRandom.urlsafe_base64(32)}")
@@ -57,7 +58,7 @@ str = String.build do |s|
     @session = {
       :key => "#{settings["session"]["key"]? ? settings["session"]["key"] : "amber.session"}",
       :store => #{settings["session"]["store"]? ? settings["session"]["store"] : ":signed_cookie"},
-      :expires => #{settings["session"]["expires"]? ? settings["session"]["expires"] : 0}, 
+      :expires => #{settings["session"]["expires"]? ? settings["session"]["expires"] : 0},
     }
     SESSION
   else

--- a/src/amber/server/settings.cr
+++ b/src/amber/server/settings.cr
@@ -16,6 +16,7 @@ module Amber
     property ssl_key_file : String? = nil
     property ssl_cert_file : String? = nil
     property redis_url = ""
+    property database = ""
     property session : Hash(Symbol, Symbol | String | Int32)
 
     # Loads environment yml settings from the current AMBER_ENV environment variable


### PR DESCRIPTION
[CLI] Moves DB settings to config/environments  …
Currently database settings reside in the config/database.yml this is
redundant since Amber has settings per environment.

This PR removes the `config/database.yml` and uses the environment yamls
files to load the database settings.

There is a couple of benefits for doing this:
1. Database settings are loaded per environment.
2. It is more intuitive to know where to put DB settings.

[ENV LOADER] Add database settings to environment_loader

- Adds database property to Amber::Settings
- Adds database property to spec test.yml
- Load database settings from environment yml
- Updates settings specs to check for database settings
- Updates environment loader specs to check for database settings

[CLI] Updates init spec file

- Updates amber spec file to check for database key
- Tidy init_spec connection string validation
- Add `expected_db_url(db_key, env)` method to cleanup specs

Issue https://github.com/amberframework/amber/issues/293