### PR TITLE
Allows amber exec to work in more situations.

### DIFF
--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -12,8 +12,8 @@ module Amber::CLI
       `shards`
 
       it "executes one-liners from the first command-line argument" do
-        expected_result = "[:a, :b, :c, :d]\n"
-        MainCommand.run(["exec", "[:a, :b, :c] + [:d]"])
+        expected_result = "3000\n"
+        MainCommand.run(["exec", "Amber::Server.settings.port"])
         logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
         File.read(logs.last?.to_s).should eq expected_result
       end
@@ -43,13 +43,18 @@ module Amber::CLI
     end
 
     context "outside of project" do
-      it "complains if not in the root of a project" do
-        expected_result = "Error: 'amber exec' can only be used from the root of a valid amber project"
+      it "executes outside of project but without including project" do
+        expected_result = ":hello\n"
         MainCommand.run(["exec", ":hello"])
         logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
         File.read(logs.last?.to_s).should eq expected_result
       end
 
+      it "errors outside of project if referencing amber specific code" do
+        MainCommand.run(["exec", "Amber::Server.settings"])
+        logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
+        File.read(logs.last?.to_s).should contain "undefined constant Amber::Server"
+      end
       cleanup
     end
   end

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -39,10 +39,11 @@ module Amber::CLI
         end
 
         result = ""
-        result = `crystal eval 'require "./config/*"; require "#{@filename}"'` if File.exists?(@filename)
-
-        if result.includes?("while requiring \"./config/*\": can't find file './config/*' relative to '.'")
-          result = "Error: 'amber exec' can only be used from the root of a valid amber project"
+        if File.exists?(@filename)
+          eval_cmd = Array(String).new
+          eval_cmd << %(require "./config/*";) if Dir.exists?("config")
+          eval_cmd << %(require "#{@filename}";)
+          result = `crystal eval '#{eval_cmd.join(" ")}'`
         end
 
         File.write(@filename.sub("console.cr", "console_result.log"), result) unless result.blank?


### PR DESCRIPTION
### Description of the Change

If `amber exec` is called from outside of an amber project it doesn't attempt to load amber config.

This is really useful since crystal doesn't have IRB or PRY. 

I made this change last night while working within amber core to quickly test results.

### Benefits

Amber exec is even more useful.

### Possible Drawbacks

None what-so-ever.
