### PR TITLE
[Static Handler] Adds support for root path

### DIFF
--- a/spec/amber/router/pipe/static_spec.cr
+++ b/spec/amber/router/pipe/static_spec.cr
@@ -5,7 +5,7 @@ include RouterHelper
 
 module Amber
   module Pipe
-    TEST_PUBLIC_PATH = "src/support/sample/public"
+    TEST_PUBLIC_PATH = "spec/support/sample/public"
     describe Static do
       it "renders html" do
         request = HTTP::Request.new("GET", "/index.html")


### PR DESCRIPTION
This improves the static handler by implicitly rendering an index file if found. 

Adds support for rendering default HTML file in path when the request path ends with '/' checks if the public directory has an `index.html` document to be rendered, if found this file would be serve.
