### PR TITLE
[CLI] Updates Router Template

### DIFF
--- a/spec/amber/router/pipe/static_spec.cr
+++ b/spec/amber/router/pipe/static_spec.cr
@@ -5,7 +5,7 @@ include RouterHelper
 
 module Amber
   module Pipe
-    TEST_PUBLIC_PATH = "src/support/sample/public"
+    TEST_PUBLIC_PATH = "spec/support/sample/public"
     describe Static do
       it "renders html" do
         request = HTTP::Request.new("GET", "/index.html")
@@ -32,6 +32,18 @@ module Amber
         response = create_request_and_return_io(static, request)
 
         response.body.should eq "<head></head><body>Hello World!</body>\n"
+      end
+
+      it "serves the correct content type for serve file" do
+        %w(png svg css js).each do |ext|
+          file = File.expand_path(TEST_PUBLIC_PATH) + "/fake.#{ext}"
+          File.write(file, "")
+          request = HTTP::Request.new("GET", "/fake.#{ext}")
+          static = Static.new PUBLIC_PATH, false
+          response = create_request_and_return_io(static, request)
+          response.headers["content-type"].should eq(Amber::Support::MimeTypes.mime_type(ext))
+          File.delete(file)
+        end
       end
     end
   end

--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -12,7 +12,7 @@ Amber::Server.configure do |app|
   # All static content will run these transformations
   pipeline :static do
     plug Amber::Pipe::Error.new
-    plug HTTP::StaticFileHandler.new("./public")
+    plug Amber::Pipe::Static.new("./public")
     plug HTTP::CompressHandler.new
   end
 


### PR DESCRIPTION
Updates config/router.cr to use Amber::Pipe:Static instead of Crystals
Static handler. Users are receiving the incorrect content type for
static files served. 

Using the Amber::Pipe::Static results in returning the correct content type for documents served by Amber Server.

### Benefits

It serves static documents and sets the correct content type for the response header.