### PR TITLE
RFC: Proposing a new url router for amber.

### DIFF
--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -28,7 +28,7 @@ class HTTP::Server::Context
   setter cookies : Amber::Router::Cookies::Store?
   setter session : Amber::Router::Session::AbstractStore?
   property content : String?
-  property route : Radix::Result(Amber::Route)
+  property route : Amber::Route
 
   def initialize(@request : HTTP::Request, @response : HTTP::Server::Response)
     @router = Amber::Server.router

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -1,6 +1,13 @@
 module Amber
   class Route
-    property :handler, :action, :verb, :resource, :valve, :params, :scope, :controller
+    property handler
+    property action
+    property verb
+    property resource
+    property valve
+    property params : Amber::Router::Params
+    property scope
+    property controller
 
     def initialize(@verb : String,
                    @resource : String,
@@ -9,6 +16,8 @@ module Amber
                    @valve : Symbol = :web,
                    @scope : String = "",
                    @controller : String = "")
+
+      @params = Amber::Router::Params.new
     end
 
     def to_json
@@ -22,6 +31,14 @@ module Amber
           json.field "resource", resource
         end
       end
+    end
+
+    def payload
+      self
+    end
+
+    def payload?
+      self
     end
 
     def trail

--- a/src/amber/router/route_set.cr
+++ b/src/amber/router/route_set.cr
@@ -1,0 +1,285 @@
+module Amber
+  module Router
+    class RouteSet
+      @trunk : RouteSet?
+      @route : Route?
+
+      property segment : String
+      property segment_type = 0
+      property full_path : String?
+
+      ROOT = 1
+      FIXED = 2
+      VARIABLE = 4
+      GLOB = 8
+
+      # A tree data structure (recursive). The initial construction has an segment
+      # of "root" and no trunk. Subtrees must pass in these details upon creation.
+      def initialize(@segment = "#", @trunk = nil)
+        @branches = Array(RouteSet).new
+
+        if @trunk
+          @segment_type = FIXED
+
+          if @segment.starts_with? ':'
+            @segment_type = VARIABLE
+          end
+
+          if @segment.starts_with? '*'
+            @segment_type = GLOB
+          end
+
+        else
+          @segment_type = ROOT
+        end
+      end
+
+      def deep_clone : RouteSet
+        clone = {{@type}}.allocate
+        clone.initialize_copy(self)
+        clone
+      end
+
+      protected def initialize_copy(other) : Nil
+        @route = other.@route
+        @trunk = nil
+        @segment = other.@segment
+
+        @segment_type = other.@segment_type
+        @full_path = other.@full_path
+
+        @branches = other.@branches.map { |s| s.deep_clone.as(RouteSet) }
+      end
+
+      # Look for or create a subtree matching a given segment.
+      def find_subtree!(segment : String) : RouteSet
+        if subtree = find_subtree segment
+          subtree
+        else
+          RouteSet.new(segment, self).tap do |subtree|
+            @branches.push subtree
+          end
+        end
+      end
+
+      # Look for and return a subtree matching a given segment.
+      def find_subtree(segment : String) : RouteSet?
+        @branches.each do |subtree|
+          break subtree if subtree.segment_match? segment
+        end
+      end
+
+      def segment_match?(segment : String) : Bool
+        segment == @segment
+      end
+
+      def root? : Bool
+        @segment_type == ROOT
+      end
+
+      def fixed? : Bool
+        @segment_type == FIXED
+      end
+
+      def variable? : Bool
+        @segment_type == VARIABLE
+      end
+
+      def glob? : Bool
+        @segment_type == GLOB
+      end
+
+      def leaf? : Bool
+        @branches.size == 0
+      end
+
+      def routes? : Bool
+        @branches.any?
+      end
+
+      # Recursively count the number of discrete paths remaining in the tree.
+      def size
+        return 1 if leaf?
+
+        @branches.reduce 0 do |count, branch|
+          count += branch.size
+        end
+      end
+
+      # Recursively descend to find the attached application route.
+      # Weakness: assumes only one path remains in the tree.
+      def route
+        return @route if leaf?
+        @branches.first.route
+      end
+
+      # Recursively _prunes_ the route tree by matching segments
+      # against path segment strings.
+      #
+      # A destructive breadth first search.
+      #
+      # return true if any routes matched.
+      def select_routes!(path : String) : Bool
+        first_segment, remaining_path = split_path path
+
+        reverse_match = false
+
+        case
+        when root?
+          # select all branches that match the full path
+          remaining_path = path
+        when fixed?
+          # select branches only if this segment matches
+          segment_match? first_segment
+        when variable?
+          # always match
+        when glob?
+          reverse_match = true
+        end
+
+        if reverse_match
+          match, _ = reverse_select_routes! path
+          return match
+        else
+          @branches.select! do |subtree|
+            subtree.select_routes! remaining_path
+          end
+        end
+
+        @branches.any? || (leaf? && remaining_path == "")
+      end
+
+      # Recursively matches the right hand side of a glob segment.
+      # Allows for routes like /a/b/*/d/e and /a/b/*/f/g to coexist.
+      # This is a modified version of a destructive depth first search.
+      #
+      # Importantly, each subtree must pass back up the remaining part
+      # of the path so it can be matched against the parent, so this
+      # method somewhat awkwardly returns:
+      #
+      #   Tuple(subtree_match : Bool, path_for_trunk_to_match : String)
+      #
+      def reverse_select_routes!(path : String) : Tuple(Bool, String)
+        remnant_path = ""
+        was_leaf = leaf?
+
+        @branches.select! do |subtree|
+          match, remaining_path = subtree.reverse_select_routes! path
+          if match
+
+            if remnant_path != ""
+              raise "warning: overwriting remnant path"
+            end
+
+            remnant_path = remaining_path
+          end
+        end
+
+        # If this segment started as a leaf, no remant path exists. Match against the whole path.
+        remnant_path = path if was_leaf
+
+        # If this wasn't a leaf and there are no branches left, it's not a match.
+        return Tuple(Bool, String).new(false, "") unless @branches.any? || was_leaf
+
+        # If this node is the glob, at least one subtree matched (or there are none).
+        return Tuple(Bool, String).new(true, "") if glob?
+
+        remaining_path, last_segment = reverse_split_path remnant_path
+
+        matched = case
+        when fixed?
+          segment_match? last_segment
+        when variable?
+          true
+        else
+          false
+        end
+
+        Tuple(Bool, String).new(matched, remaining_path)
+      end
+
+      # Add a route to the tree.
+      def add(path, route : Route) : Nil
+        add(path, route, path)
+      end
+
+      # Recursively find or create subtrees matching a given path, and store the
+      # application route at the leaf.
+      protected def add(path : String, route : Route, full_path : String) : Nil
+        if path == ""
+          if @route.nil?
+            @route = route
+            @full_path = full_path
+            return
+          else
+            raise "Unable to store route: #{full_path}, route is already defined as #{@full_path}"
+          end
+        end
+
+        first_segment, remaining_path = split_path path
+
+        subtree = find_subtree! first_segment
+        subtree.add(remaining_path, route, full_path)
+      end
+
+      # Find a route which has been assigned to a matching path
+      # Weakness: assumes only one route will match the path query.
+      def find(path) : Amber::Route?
+        matches = deep_clone
+        matches.select_routes!(path)
+
+        if matches.size > 1
+          raise "Warning: matched multiple routes"
+        end
+
+        matches.route
+      end
+
+      # Produces a readable indented rendering of the tree, though
+      # not really compatible with the other components of a deep object inspection
+      def inspect(*, ts = 0)
+        tab = "  " * ts
+        @branches.reduce("#{@segment} :\n") do |s, subtree|
+          if subtree.routes?
+            s += "#{tab}- #{subtree.inspect(ts: ts + 1)}"
+          else
+            s += "#{tab}- #{subtree.segment} (#{subtree.full_path})\n"
+          end
+
+          s
+        end
+      end
+
+      # Split a path by slashes, and return the first segment and the rest untouched.
+      #
+      # E.g. split_path("/a/b/c/d") => "a", "b/c/d"
+      private def split_path(path : String) : Tuple(String, String)
+        first_segment = path.split("/").first
+
+        if path.size >= first_segment.size + 1
+          remaining_path = path[first_segment.size + 1..-1]
+        else
+          remaining_path = ""
+        end
+
+        Tuple(String, String).new(first_segment, remaining_path)
+      end
+
+      # Split a path by slashes, and return the last segment and the rest untouched.
+      #
+      # E.g. split_path("/a/b/c/d") => "a/b/c", "d"
+      private def reverse_split_path(path : String) : Tuple(String, String)
+        last_segment = path.split("/").last
+
+        if path.size >= last_segment.size + 1
+          remaining_path = path[0...last_segment.size * -1 - 1]
+        else
+          remaining_path = ""
+        end
+
+        Tuple(String, String).new(remaining_path, last_segment)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
At its current state, this is an MVP spike. The code is as yet incomplete, but before filling out the edge cases and ancillary features I want to get some feedback from @amberframework/core. It may not be worth putting the extra time into it if there's not enough admin buy in to use the thing :] (I had fun building it either way).

### Description of the Change

This replaces the router code which decides which decides which `Amber::Route` should be executed for a given url. 

### Alternate Designs

The current shard, https://github.com/luislavena/radix . I decided to prototype a router for Amber after running into two weaknesses in the design of this router in a single day of work. I think the efficiency of radix can be improved upon as well.

Radix doesn't support similar paths with different parameter names:

`/a/b/:foo/c` and `/a/b/:bar/z` cannot coexist because radix enforces that the variable names match. This poses problems with routes like this:

```
GET /widgets/:id => WidgetsController
GET /widgets/:widget_id/components => ComponentsController
```

Radix doesn't deal well with route trees which produce false matches. Given the current generated Amber project produces a `public/dist` folder and wires up StaticController to render files in there, Routes sometimes cannot begin with a d__. Eg: `GET /domain/` prevents static files from being rendered. (sometimes: it depends on how radix builds out the character tree).

Documented on radix issues, globs are always greedy. There is no way for `/foo/*/bar` and `/foo/*/baz` routes to match as expected because `*` greedily gobbles up the rest of the route.

Perhaps most importantly, I think a library as important as this should be community maintained. I believe that either the Kemal project or Amber should own a dedicated repository and shard for this code. It can be shared from there if projects desire.

### Benefits

This prototype router:
- Navigates urls based off of strings, not characters. I haven't run a benchmark but I believe this would have performance impacts and I'm not aware of any drawbacks to this.
- Allows for both greedy globs: `GET /*` and restrained globs: `GET /foo/*/bar` by switching to an end-first search when a glob segment is matched.
- Allows for diverse variable names in similar positions: `GET /widgets/:id` and `GET /widgets/:widget_id/components`
- Most importantly, doesn't get hung up on trees which produce false traversals as in the example above.

### Possible Drawbacks

- It's a big change, and this is the type of code that will run a lot. Performance needs to be considered, as does feature scope.
- Community pushback from the broader crystal community? I considered submitting a pull to radix to address the bug I found, but the bug may be a modeling problem in the algorithm. I am new enough to the crystal community that I don't have a good pulse on this.

### TODO list:

Assuming the amber project wants to move forward with this change, this is a list of things still needed to move forward:

- [ ] write a bunch of test cases
  - [ ] short globs: `GET /*`
  - [ ] long globs: `GET /foo/*/bar`
  - [ ] etc. (feel free to add to this list)
- [ ] benchmarks
- [ ] verify a top-down order to routes?
- [ ] move to a separate repository and make it generically typed
- [ ] handle returning route parameters (currently not handled at all)
- [ ] Get `params` for the matched route. Something like `matched_route.params` (Updated by @eliasjpr)
- [ ] decide what to do at edge cases:
  - [ ] when more than one route matches a url
  - [ ] when routes are declared that are functionally identical
  - [ ] _perhaps others_
- [ ] _additions welcome_