### PR TITLE
Add 'help' option to CLI commands

### DIFF
--- a/src/amber/cli/commands.cr
+++ b/src/amber/cli/commands.cr
@@ -50,6 +50,7 @@ module Amber::CLI
       string ["-t", "--template"], desc: "# Preconfigure for selected template engine. Options: slang | ecr", default: "slang"
       string ["-d", "--database"], desc: "# Preconfigure for selected database. Options: pg | mysql | sqlite", default: "pg"
       string ["-m", "--model"], desc: "# Preconfigure for selected model. Options: granite | crecto", default: "granite"
+      help
     end
   end
 end

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -15,6 +15,7 @@ module Amber::CLI
 
       class Options
         arg_array "commands", desc: "drop create migrate rollback redo status version seed"
+        help
       end
 
       class Help

--- a/src/amber/cli/commands/deploy.cr
+++ b/src/amber/cli/commands/deploy.cr
@@ -37,6 +37,7 @@ module Amber::CLI
         string ["-t", "--tag"], desc: "# Tag to use. Overrides branch."
         string ["-b", "--branch"], desc: "# Branch to use. Default master.", default: "master"
         bool "--no-color", desc: "# Disable colored output", default: false
+        help
       end
 
       def provision

--- a/src/amber/cli/commands/encrypt.cr
+++ b/src/amber/cli/commands/encrypt.cr
@@ -9,6 +9,7 @@ module Amber::CLI
         arg "env", desc: "environment file to encrypt", default: "production"
         string ["-e", "--editor"], desc: "Prefered Editor: [vim, nano, pico, etc]", default: "vim"
         bool ["--noedit"], desc: "Skip editing and just encrypt", default: false
+        help
       end
 
       class Help

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -12,6 +12,7 @@ module Amber::CLI
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
         string ["-e", "--editor"], desc: "Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
         string ["-b", "--back"], desc: "Runs previous command files: 'amber exec -b [times_ago]'", default: "0"
+        help
       end
 
       class Help

--- a/src/amber/cli/commands/generate.cr
+++ b/src/amber/cli/commands/generate.cr
@@ -10,6 +10,7 @@ module Amber::CLI
         arg "name", desc: "name of resource", required: true
         arg_array "fields", desc: "user:reference name:string body:text age:integer published:bool"
         bool "--no-color", desc: "Disable colored output", default: false
+        help
       end
 
       def run

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -12,6 +12,7 @@ module Amber::CLI
         string "-m", desc: "model type", any_of: %w(granite crecto), default: "granite"
         bool "--deps", desc: "installs deps, (shards update)", default: false
         bool "--no-color", desc: "Disable colored output", default: false
+        help
       end
 
       class Help

--- a/src/amber/cli/commands/perform.cr
+++ b/src/amber/cli/commands/perform.cr
@@ -11,6 +11,7 @@ module Amber::CLI
       class Options
         bool ["-l", "--list"], desc: "# Displays all tasks available", default: false
         arg "task", desc: "Name of the task to execute", required: true
+        help
       end
 
       class Help

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -27,6 +27,7 @@ module Amber::CLI
 
       class Options
         bool "--no-color", desc: "Disable colored output", default: false
+        help
       end
 
       def run

--- a/src/amber/cli/commands/run.cr
+++ b/src/amber/cli/commands/run.cr
@@ -11,6 +11,7 @@ module Amber::CLI
         string %w(-p --port), desc: "# PORT number to listen.", default: "3000"
         string %w(-e --environment), desc: "# AMBER_ENV environment (Production, Development, Staging).", default: "development"
         bool "--no-color", desc: "# Disable colored output", default: false
+        help
       end
 
       class Help

--- a/src/amber/cli/commands/watch.cr
+++ b/src/amber/cli/commands/watch.cr
@@ -8,6 +8,10 @@ module Amber::CLI
     class Watch < Sentry::SentryCommand
       command_name "watch"
 
+      class Options
+        help
+      end
+
       class Help
         caption "# Starts amber server and rebuilds on file changes"
       end


### PR DESCRIPTION
### Description of the Change

Allows using `-h` or `--help` with the CLI commands

### Alternate Designs

None considered, this is built into the cli shard, you just have to opt-in by calling `help` in the `Options` class.

### Benefits

You don't have to create a parse error to see the help for a command.

### Possible Drawbacks

None known.