### PR TITLE
Add support for PORT environment variable

### DIFF
--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -1,5 +1,5 @@
 secret_key_base: <%= SecureRandom.urlsafe_base64(32) %>
-port: 3000
+port: (ENV["PORT"]? || 3000).to_i
 name: <%= @name %>
 colorize_logging: true
 host: localhost

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -1,5 +1,5 @@
 secret_key_base: <%= SecureRandom.urlsafe_base64(32) %>
-port: 8080
+port: (ENV["PORT"]? || 8080).to_i
 name: <%= @name %>
 colorize_logging: false
 host: 0.0.0.0

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -1,5 +1,5 @@
 secret_key_base: <%= SecureRandom.urlsafe_base64(32) %>
-port: 3000
+port: (ENV["PORT"]? || 3000).to_i
 name: <%= @name %>
 colorize_logging: true
 host: localhost


### PR DESCRIPTION
### Description of the Change

Add support for PORT environment variable, 3000 is used by default.

```yaml
port: (ENV["PORT"]? || 3000).to_i
```

### Alternate Designs

No

### Benefits

- Allow to use [heroku-buildpack-amber](https://github.com/amberframework/heroku-buildpack-amber/blob/master/bin/release#L3)
- Allow to change PORT easier on services with random port like Heroku

### Possible Drawbacks

No, if PORT isn't defined port 3000 is used
