### PR TITLE
Improved generated config/application.cr commented code to work once uncommented.

### DIFF
--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -58,14 +58,14 @@ Amber::Server.configure do |settings|
   #
   # > Read more about Linux PORT REUSE https://lwn.net/Articles/542629/
   #
-  # settings.port_reuse = ENV["PORT_REUSE"] if ENV["PORT_REUSE"]?
+  # settings.port_reuse = true
   #
   #
   # Process Count: This will enable Amber to be used in cluster mode,
   # spinning an instance for each number of process specified here.
   # Rule of thumb, always leave at least 1 core available for system processes/resources.
   #
-  # settings.process_count = ENV["PROCESS_COUNT"] if ENV["PROCESS_COUNT"]?
+  # settings.process_count = ENV["PROCESS_COUNT"].to_i if ENV["PROCESS_COUNT"]?
   #
   #
   # PORT: This is the port that you're application will run on. Examples would be (80, 443, 3000, 8080)

--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -41,14 +41,14 @@ Amber::Server.configure do |settings|
   # initialized to a random key present in `ENV["AMBER_SECRET_KEY"]` or
   # `.amber_secret_key` in this order.
   #
-  # settings.secret_key_base= ENV["SECRET_KEY_BASE"]
+  # settings.secret_key_base= <%= SecureRandom.urlsafe_base64(32) %>
   #
   #
   # Host: is the application server host address or ip address. Useful for when
   # deploying Amber to a PAAS and likely the assigned server IP is either
   # known or unknown. Defaults to an environment variable HOST
   #
-  # settings.host = ENV["HOST"]
+  # settings.host = ENV["HOST"] if ENV["HOST"]?
   #
   #
   # Port Reuse: Amber supports clustering mode which allows to spin
@@ -58,20 +58,25 @@ Amber::Server.configure do |settings|
   #
   # > Read more about Linux PORT REUSE https://lwn.net/Articles/542629/
   #
-  # settings.port_reuse = ENV["PORT_REUSE"]
+  # settings.port_reuse = ENV["PORT_REUSE"] if ENV["PORT_REUSE"]?
   #
   #
   # Process Count: This will enable Amber to be used in cluster mode,
   # spinning an instance for each number of process specified here.
   # Rule of thumb, always leave at least 1 core available for system processes/resources.
   #
-  # settings.port = (ENV["PORT"] ||= 80).to_i
+  # settings.process_count = ENV["PROCESS_COUNT"] if ENV["PROCESS_COUNT"]?
+  #
+  #
+  # PORT: This is the port that you're application will run on. Examples would be (80, 443, 3000, 8080)
+  #
+  settings.port = ENV["PORT"].to_i if ENV["PORT"]?
   #
   #
   # Redis URL: Redis is an in memory key value storag. Amber utilizes redis as
   # a storing option for session information.
   #
-  # settings.redis_url = ENV["REDIS_URL"]
+  # settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?
   #
   #
   # Database URL: This is the database connection string or data file url.
@@ -79,7 +84,7 @@ Amber::Server.configure do |settings|
   # database or the data file. Defaults to the database provider you chose at
   # at app generation.
   #
-  # settings.database_url = ENV["DATABASE_URL"]
+  # settings.database_url = ENV["DATABASE_URL"] if ENV["DATABASE_URL"]?
   #
   #
   # SSL Key File: The private key is a text file used initially to generate a
@@ -88,7 +93,7 @@ Amber::Server.configure do |settings|
   # a digital signature as you might imagine from the name, the private key should be
   # ``closely guarded.
   #
-  # settings.ssl_key_file = ENV["SSL_KEY_FILE"]
+  # settings.ssl_key_file = ENV["SSL_KEY_FILE"] if ENV["SSL_KEY_FILE"]?
   #
   #
   # SSL Cert File: This represents the signed certificate file. SSL Certificates are
@@ -96,7 +101,7 @@ Amber::Server.configure do |settings|
   # details. When installed on a web server, it activates the padlock and the https
   # protocol and allows secure connections from a web server to a browser.
   #
-  # settings.ssl_cert_file  = ENV["SSL_CERT_FILE"]
+  # settings.ssl_cert_file = ENV["SSL_CERT_FILE"] if ENV["SSL_CERT_FILE"]?
   #
   #
   # Session: A Hash that specifies the session storage mechanism, expiration and key to be used


### PR DESCRIPTION
### Description of the Change

1. Uncommented PORT env logic by default and converted to int32.
1. Added valid secret_key_base to commented out secret_key_base settings code.
1. Added checks so that ENV vars are only applied if they exist. That way the standard practice of using default settings in development and test but ENV vars in production will still work without constant code changes. 
1. Changed example settings values to match correct type for setting (bool, int32) etc. ENV vars are all strings and fail by default.

### Benefits

Within Rails and Phoenix every ENV override has default values that are used instead if they're not set.

For example: If a PORT isn't set it goes to 3000, if an RAILS_ENV isn't set it goes to development, if DATABASE_URL isn't set it uses settings from database.yml.
I don't think that it's clear to users that uncommenting the code in application.cr will work differently.
For instance if settings port is 3000, ENV["PORT"] should only override that if ENV["PORT"] has a value. Otherwise we just end up with a project that doesn't work.

`settings.port = ENV["PORT"]` will fail in too many situations that aren't expected by people coming from rails/laravel, pheonix, hanami.

Instead it should be `settings.port = ENV["PORT"].to_i if ENV["PORT"]?`.

Otherwise we just end up with a weird situation were we load values in and immediately overwrite them with values that may not even exist.

***We now end up with example code that will work out of the box, which will result in fewer complaints.***
