### PR TITLE
WebSockets mini refactoring

### DIFF
--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -75,10 +75,10 @@ module Amber
       protected def setup_pubsub_adapter
         @@adapter = Amber::Server.pubsub_adapter
         if pubsub_adapter = @@adapter
-          listener = Proc(String, JSON::Any, Nil).new do |client_socket_id, message|
+          pubsub_adapter.on_message(@topic_path, ->(client_socket_id : String, message : JSON::Any) {
             self.on_message(client_socket_id, message)
-          end
-          pubsub_adapter.on_message(@topic_path, listener)
+            nil
+          })
         else
           raise "Invalid @@adapter on Amber::WebSockets::Channel"
         end

--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -79,6 +79,7 @@ module Amber
             self.on_message(client_socket_id, message)
             nil
           })
+          pubsub_adapter
         else
           raise "Invalid @@adapter on Amber::WebSockets::Channel"
         end

--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -42,8 +42,11 @@ module Amber
 
       # Helper method for retrieving the apdater not nillable
       protected def adapter
-        setup_pubsub_adapter if @@adapter.nil?
-        @@adapter.not_nil!
+        if pubsub_adapter = @@adapter
+          pubsub_adapter
+        else
+          setup_pubsub_adapter
+        end
       end
 
       # Called when a socket subscribes to a channel
@@ -68,10 +71,17 @@ module Amber
         subscribers.each_value(&.socket.send(message.to_json))
       end
 
-      # Ensure the pubsub adpater instance exists, and set up the on_message proc callback
+      # Ensure the pubsub adapter instance exists, and set up the on_message proc callback
       protected def setup_pubsub_adapter
         @@adapter = Amber::Server.pubsub_adapter
-        @@adapter.not_nil!.on_message(@topic_path, ->(client_socket_id : String, message : JSON::Any) { self.on_message(client_socket_id, message); nil })
+        if pubsub_adapter = @@adapter
+          listener = Proc(String, JSON::Any, Nil).new do |client_socket_id, message|
+            self.on_message(client_socket_id, message)
+          end
+          pubsub_adapter.on_message(@topic_path, listener)
+        else
+          raise "Invalid @@adapter on Amber::WebSockets::Channel"
+        end
       end
     end
   end

--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -75,9 +75,8 @@ module Amber
       protected def setup_pubsub_adapter
         @@adapter = Amber::Server.pubsub_adapter
         if pubsub_adapter = @@adapter
-          pubsub_adapter.on_message(@topic_path, ->(client_socket_id : String, message : JSON::Any) {
+          pubsub_adapter.on_message(@topic_path, Proc(String, JSON::Any, Nil).new { |client_socket_id, message|
             self.on_message(client_socket_id, message)
-            nil
           })
           pubsub_adapter
         else


### PR DESCRIPTION
### Description of the Change

- Fix typo `adpater` by `adapter`
- Unwrap one-line code blocks, making them more readable
- Handle nil case avoiding `not_nil!` preventing `NilAssertion` fail exception

### Alternate Designs

No

### Benefits

1. More readable code
2. Fix typo
3. Remove `.not_nil!`

We only have [10 `not_nil!`](https://github.com/amberframework/amber/search?utf8=%E2%9C%93&q=not_nil&type=) on amber (6 on `src/` and 4 on `spec/`). This PR removes one of them.


### Possible Drawbacks

No
