### PR TITLE
Update dependency and move sentry_helper to helper dir

### DIFF
--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -1,6 +1,6 @@
 require "cli"
 require "shell-table"
-require "../helper/sentry"
+require "../helpers/sentry"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -1,6 +1,6 @@
 require "cli"
 require "shell-table"
-require "../sentry_command_helper"
+require "../helper/sentry"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand

--- a/src/amber/cli/commands/watch.cr
+++ b/src/amber/cli/commands/watch.cr
@@ -1,5 +1,5 @@
 require "cli"
-require "../sentry_command_helper"
+require "../helper/sentry"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand

--- a/src/amber/cli/commands/watch.cr
+++ b/src/amber/cli/commands/watch.cr
@@ -1,5 +1,5 @@
 require "cli"
-require "../helper/sentry"
+require "../helpers/sentry"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand

--- a/src/amber/cli/helpers/sentry.cr
+++ b/src/amber/cli/helpers/sentry.cr
@@ -1,6 +1,5 @@
-require "yaml"
 require "cli"
-
+require "yaml"
 require "sentry"
 
 module Sentry

--- a/src/amber/cli/helpers/sentry.cr
+++ b/src/amber/cli/helpers/sentry.cr
@@ -58,14 +58,14 @@ module Sentry
 
     def run
       if options.info?
-        puts "
-      name:       #{options.name?}
-      build:      #{options.build?}
-      build args: #{options.build_args?}
-      run:        #{options.run?}
-      run args:   #{options.run_args?}
-      files:      #{options.watch}
-    "
+        puts <<-INFO
+          name:       #{options.name?}
+          build:      #{options.build?}
+          build args: #{options.build_args?}
+          run:        #{options.run?}
+          run args:   #{options.run_args?}
+          files:      #{options.watch}
+        INFO
         exit! code: 0
       end
 

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -32,7 +32,7 @@ dependencies:
 
   quartz_mailer:
     github: amberframework/quartz-mailer
-    version: ~> 0.2.0
+    version: ~> 0.3.0
 
   jasper_helpers:
     github: amberframework/jasper-helpers


### PR DESCRIPTION
### Description of the Change

- Update amber dependency, depends on https://github.com/amberframework/quartz-mailer/pull/8 **(Done!)**
- Moves `sentry_command_helper.cr` to `helpers/sentry.cr`

### Alternate Designs

No

### Benefits

Use latest version, fixes this 👉 https://github.com/crystal-lang/shards/issues/183

### Possible Drawbacks

No, this time no more version mismatch 🎉 people using old projects can install dependencies without issues because `~> 0.2.0` is equal to `0.2.0 <= version < 0.3.0`

So `v0.3.0` will apply only for new amber projects 👍  
