### PR TITLE
[Params] Appends Files to params hash

### DIFF
--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -174,8 +174,10 @@ describe HTTP::Server::Context do
     request = HTTP::Request.new("POST", "/", headers, body)
 
     context = create_context(request)
+    file = context.params["picture"].as(Amber::Router::Files::File)
 
-    context.files["picture"].filename.should eq "index.html"
+    file.should be_a Amber::Router::Files::File
+    file.filename.should eq "index.html"
     context.params["title"].should eq "title field"
     context.params["_csrf"].should eq "PcCFp4oKJ1g-hZ-P7-phg0alC51pz7Pl12r0ZOncgxI"
   end

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -174,10 +174,8 @@ describe HTTP::Server::Context do
     request = HTTP::Request.new("POST", "/", headers, body)
 
     context = create_context(request)
-    file = context.params["picture"].as(Amber::Router::Files::File)
 
-    file.should be_a Amber::Router::Files::File
-    file.filename.should eq "index.html"
+    context.params.files["picture"].filename.should eq "index.html"
     context.params["title"].should eq "title field"
     context.params["_csrf"].should eq "PcCFp4oKJ1g-hZ-P7-phg0alC51pz7Pl12r0ZOncgxI"
   end

--- a/src/amber/router/files.cr
+++ b/src/amber/router/files.cr
@@ -24,13 +24,5 @@ module Amber::Router
         @size = upload.size
       end
     end
-
-    def clear_files
-      @files = {} of String => File
-    end
-
-    def files
-      @files ||= {} of String => File
-    end
   end
 end

--- a/src/amber/router/params.cr
+++ b/src/amber/router/params.cr
@@ -1,13 +1,7 @@
 module Amber::Router
-  # The Parameters module will parse parameters from a URL, a form post or a JSON
-  # post and provide them in the self params hash.  This unifies access to
-  # parameters into one place to simplify access to them.
-  # Note: other params from the router will be handled in the router handler
-  # instead of here.  This removes a dependency on the router in case it is
-  # replaced or not needed.
-
-  class Params < Hash(String, String | Amber::Router::Files::File)
+  class Params < Hash(String, String)
     alias KeyType = String | Symbol
+    property files = {} of String => Amber::Router::Files::File
 
     def json(key : KeyType)
       JSON.parse(self[key]?.to_s)

--- a/src/amber/router/params.cr
+++ b/src/amber/router/params.cr
@@ -6,7 +6,7 @@ module Amber::Router
   # instead of here.  This removes a dependency on the router in case it is
   # replaced or not needed.
 
-  class Params < Hash(String, String)
+  class Params < Hash(String, String | Amber::Router::Files::File)
     alias KeyType = String | Symbol
 
     def json(key : KeyType)

--- a/src/amber/router/params_parser.cr
+++ b/src/amber/router/params_parser.cr
@@ -115,10 +115,18 @@ module Amber::Router
     def parse_multipart
       HTTP::FormData.parse(request) do |upload|
         next unless upload
+        # Note:
+        # Filename is followed by a string containing the original name of the file transmitted.
+        # The filename is always optional and must not be used blindly by the application:
+        # path information should be stripped, and conversion to the server file system rules
+        # should be done. This parameter provides mostly indicative information.
+        #
+        # See https://tools.ietf.org/html/rfc7578#section-4.2
         filename = upload.filename
         if filename.is_a?(String) && !filename.empty?
-          params[upload.name] = Files::File.new(upload: upload)
+          params.files[upload.name] = Files::File.new(upload: upload)
         else
+          # Parses form fields
           params[upload.name] = upload.body.gets_to_end
         end
       end

--- a/src/amber/router/params_parser.cr
+++ b/src/amber/router/params_parser.cr
@@ -117,7 +117,7 @@ module Amber::Router
         next unless upload
         filename = upload.filename
         if filename.is_a?(String) && !filename.empty?
-          files[upload.name] = Files::File.new(upload: upload)
+          params[upload.name] = Files::File.new(upload: upload)
         else
           params[upload.name] = upload.body.gets_to_end
         end

--- a/src/amber/validations/params.cr
+++ b/src/amber/validations/params.cr
@@ -4,11 +4,11 @@ module Amber::Validators
 
   # This struct holds the validation rules to be performed
   class BaseRule
-    getter predicate : (String | Amber::Router::Files::File -> Bool)
+    getter predicate : (String -> Bool)
     getter field : String
-    getter value : String? | Amber::Router::Files::File
+    getter value : String?
 
-    def initialize(field : String | Symbol, @msg : String?, &block : String | Amber::Router::Files::File -> Bool)
+    def initialize(field : String | Symbol, @msg : String?, &block : String -> Bool)
       @field = field.to_s
       @predicate = block
     end
@@ -42,11 +42,11 @@ module Amber::Validators
       _validator.add_rule BaseRule.new(param, msg)
     end
 
-    def required(param : String | Symbol, msg : String? = nil, &b : String | Amber::Router::Files::File -> Bool)
+    def required(param : String | Symbol, msg : String? = nil, &b : String -> Bool)
       _validator.add_rule BaseRule.new(param, msg, &b)
     end
 
-    def optional(param : String | Symbol, msg : String? = nil, &b : String | Amber::Router::Files::File -> Bool)
+    def optional(param : String | Symbol, msg : String? = nil, &b : String -> Bool)
       _validator.add_rule OptionalRule.new(param, msg, &b)
     end
   end
@@ -55,7 +55,7 @@ module Amber::Validators
     getter raw_params = Amber::Router::Params.new
     getter errors = [] of Error
     getter rules = [] of BaseRule
-    getter params = {} of String => String? | Amber::Router::Files::File
+    getter params = {} of String => String?
     getter errors = [] of Error
 
     def initialize(@raw_params); end

--- a/src/amber/validations/params.cr
+++ b/src/amber/validations/params.cr
@@ -4,11 +4,11 @@ module Amber::Validators
 
   # This struct holds the validation rules to be performed
   class BaseRule
-    getter predicate : (String -> Bool)
+    getter predicate : (String | Amber::Router::Files::File -> Bool)
     getter field : String
-    getter value : String?
+    getter value : String? | Amber::Router::Files::File
 
-    def initialize(field : String | Symbol, @msg : String?, &block : String -> Bool)
+    def initialize(field : String | Symbol, @msg : String?, &block : String | Amber::Router::Files::File -> Bool)
       @field = field.to_s
       @predicate = block
     end
@@ -42,11 +42,11 @@ module Amber::Validators
       _validator.add_rule BaseRule.new(param, msg)
     end
 
-    def required(param : String | Symbol, msg : String? = nil, &b : String -> Bool)
+    def required(param : String | Symbol, msg : String? = nil, &b : String | Amber::Router::Files::File -> Bool)
       _validator.add_rule BaseRule.new(param, msg, &b)
     end
 
-    def optional(param : String | Symbol, msg : String? = nil, &b : String -> Bool)
+    def optional(param : String | Symbol, msg : String? = nil, &b : String | Amber::Router::Files::File -> Bool)
       _validator.add_rule OptionalRule.new(param, msg, &b)
     end
   end
@@ -55,7 +55,7 @@ module Amber::Validators
     getter raw_params = Amber::Router::Params.new
     getter errors = [] of Error
     getter rules = [] of BaseRule
-    getter params = {} of String => String?
+    getter params = {} of String => String? | Amber::Router::Files::File
     getter errors = [] of Error
 
     def initialize(@raw_params); end


### PR DESCRIPTION
Currently there is `context.files` and `context.params` having two
scopes to what is considered params can be confusing.

The changes in this PR consolidates files with params

- Adds Amber::Router::Files::File to params hash
- Updates Specs and files

With this change files are now part of the `context.params`