### PR TITLE
support modules of code with controller and views in the same folder

### DIFF
--- a/src/amber/cli/commands/watch.cr
+++ b/src/amber/cli/commands/watch.cr
@@ -19,6 +19,8 @@ module Amber::CLI
       def run
         options.watch << "./config/**/*.cr"
         options.watch << "./src/views/**/*.slang"
+        options.watch << "./src/modules/**/*.cr"
+        options.watch << "./src/modules/**/*.slang"
         super
       end
     end

--- a/src/amber/controller/helpers/render.cr
+++ b/src/amber/controller/helpers/render.cr
@@ -2,6 +2,33 @@ module Amber::Controller::Helpers
   module Render
     LAYOUT = "application.slang"
 
+    macro render_module(template = nil, layout = true, partial = nil, path = "src/views", folder = __DIR__)
+      {% if !(template || partial) %}
+        raise "Template or partial required!"
+      {% end %}
+
+      {{ filename = template || partial }}
+
+      {% if filename.id.split("/").size > 1 %}
+        %content = render_template("#{{{filename}}}", {{path}})
+      {% else %}
+        {{ short_path = folder.gsub(/^.+?(?:controllers|views)\//, "") }}
+        {% if folder.id.ends_with?(".ecr") %}
+          %content = render_template("#{{{short_path.gsub(/\/[^\.\/]+\.ecr/, "")}}}/#{{{filename}}}")
+        {% else %}
+          %content = render_template("#{{{short_path.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}")
+        {% end %}
+      {% end %}
+
+      # Render Layout
+      {% if layout && !partial %}
+        content = %content
+        render_template("#{{{path}}}/layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}")
+      {% else %}
+        %content
+      {% end %}
+    end
+
     macro render(template = nil, layout = true, partial = nil, path = "src/views", folder = __FILE__)
       {% if !(template || partial) %}
         raise "Template or partial required!"


### PR DESCRIPTION
### Description of the Change

Adds a render_module macro that renders a view from the same folder as the calling controller in addition to the standard way of separating controllers and views.

E.g. A module of code for a feature contains the following artifacts in src/modules/chart

  _chart_lib.cr  # business logic for charts
  _form.slang
 chart_controller.cr
 chart.cr  # the model
 edit.slang
 index.slang
 new.slang
 show.slang

And config/application.cr has been modified by adding
require "../src/modules/**" 

Methods in the controller call render_module("filename") instead of render("filename").
Partial rendering in views uses render_module("filename") instead of render("filename").

### Alternate Designs

No other design considered, this was the quick and easy solution.

### Benefits

Code that is organised into modules is considered to be a better way to organise code.  Everything related to a particular feature of the app is located in the same folder.

### Possible Drawbacks

Extracting the routes into a route file in the modules folder didn't work, routes still have to be created in config/routes.cr
