### PR TITLE
CLI exceptions show up as readable return values instead of backtrace.

### DIFF
--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -97,6 +97,8 @@ module Amber::CLI
         ENV["DATABASE_URL"]? || begin
           CLI.settings.database_url
         end
+      rescue e
+        puts e.message 
       end
     end
   end

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -23,36 +23,34 @@ module Amber::CLI
         args.commands.each do |command|
           Micrate::Cli.setup_logger
           Micrate::DB.connection_url = database_url
-          begin
-            case command
-            when "drop"
-              drop_database
-            when "create"
-              create_database
-            when "seed"
-              `crystal db/seeds.cr`
-              puts "Seeded database"
-            when "migrate"
-              Micrate::Cli.run_up
-            when "rollback"
-              Micrate::Cli.run_down
-            when "redo"
-              Micrate::Cli.run_redo
-            when "status"
-              Micrate::Cli.run_status
-            when "version"
-              Micrate::Cli.run_dbversion
-            else
-              Micrate::Cli.print_help
-            end
-          rescue e : Micrate::UnorderedMigrationsException
-            exit! Micrate::Cli.report_unordered_migrations(e.versions), error: true
-          rescue e : DB::ConnectionRefused
-            exit! "Connection refused: #{Micrate::DB.connection_url}", error: true
-          rescue e : Exception
-            exit! e.message, error: true
+          case command
+          when "drop"
+            drop_database
+          when "create"
+            create_database
+          when "seed"
+            `crystal db/seeds.cr`
+            puts "Seeded database"
+          when "migrate"
+            Micrate::Cli.run_up
+          when "rollback"
+            Micrate::Cli.run_down
+          when "redo"
+            Micrate::Cli.run_redo
+          when "status"
+            Micrate::Cli.run_status
+          when "version"
+            Micrate::Cli.run_dbversion
+          else
+            Micrate::Cli.print_help
           end
         end
+      rescue e : Micrate::UnorderedMigrationsException
+        exit! Micrate::Cli.report_unordered_migrations(e.versions), error: true
+      rescue e : DB::ConnectionRefused
+        exit! "Connection refused: #{Micrate::DB.connection_url}", error: true
+      rescue e : Exception
+        exit! e.message, error: true
       end
 
       private def drop_database
@@ -89,7 +87,7 @@ module Amber::CLI
           Micrate::DB.connection_url = url.gsub(path, "/#{uri.scheme}")
           return path.gsub("/", "")
         else
-          raise "could not determine database name"
+          raise "Could not determine database name"
         end
       end
 
@@ -97,8 +95,6 @@ module Amber::CLI
         ENV["DATABASE_URL"]? || begin
           CLI.settings.database_url
         end
-      rescue e
-        puts e.message 
       end
     end
   end

--- a/src/amber/cli/commands/encrypt.cr
+++ b/src/amber/cli/commands/encrypt.cr
@@ -32,8 +32,8 @@ module Amber::CLI
           Support::FileEncryptor.write(encrypted_file, File.read(unencrypted_file))
           File.delete(unencrypted_file)
         end
-      rescue e
-        puts e.message 
+      rescue e : Exception
+        exit! e.message, error: true
       end
     end
   end

--- a/src/amber/cli/commands/encrypt.cr
+++ b/src/amber/cli/commands/encrypt.cr
@@ -19,6 +19,10 @@ module Amber::CLI
         encrypted_file = "config/environments/.#{env}.enc"
         unencrypted_file = "config/environments/#{env}.yml"
 
+        unless File.exists?(unencrypted_file) || File.exists?(encrypted_file)
+          raise Exceptions::Environment.new("./config/environments/", env)
+        end
+
         if File.exists?(encrypted_file)
           File.write(unencrypted_file, Support::FileEncryptor.read(encrypted_file))
           system("#{options.editor} #{unencrypted_file}") unless options.noedit?
@@ -27,11 +31,9 @@ module Amber::CLI
         if File.exists?(unencrypted_file)
           Support::FileEncryptor.write(encrypted_file, File.read(unencrypted_file))
           File.delete(unencrypted_file)
-        else
-          puts "#{env}.yml doesn't exist. Loading defaults!"
         end
-      rescue
-        puts "Failed! Make sure to set AMBER_ENCRYPTION_KEY env or add hidden file .encryption_key"
+      rescue e
+        puts e.message 
       end
     end
   end

--- a/src/amber/exceptions/exceptions.cr
+++ b/src/amber/exceptions/exceptions.cr
@@ -12,9 +12,9 @@ module Amber
       end
     end
 
-    class Environment < Base
+    class Environment < Exception
       def initialize(path, environment)
-        super("environment file not found for #{path}#{environment}")
+        super("Environment file not found for #{path}#{environment}")
       end
     end
 


### PR DESCRIPTION
### Description of the Change

Makes error messages look better by using CLI `exit!` command.

