### PR TITLE
Adds environment changes to amber deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,7 @@ This will generate scaffolding for a Post:
 ## Running App Locally
 To test the generated App locally:
 
-1. Make sure your app has the right credentials via the following methods: 
-  * Add it in `config/database.yml`
-  or
-  * Run `export DATABASE_URL=postgres://[username]:[password]@localhost:5432/[your_app]_development`
-    which overrides the `config/database.yml`.
-2. Migrate the database: `amber db create migrate`. You should see output like
+2. Create and Migrate the database: `amber db create migrate`. You should see output like
     `Migrating db, current version: 0, target: [datetimestamp]OK   [datetimestamp]_create_shop.sql`
 3. Run the specs: `crystal spec`
 4. Start your app: `amber watch`

--- a/src/amber/cli/commands/deploy.cr
+++ b/src/amber/cli/commands/deploy.cr
@@ -23,6 +23,8 @@ module Amber::CLI
           deploy
         end
         spinner.stop
+      rescue e
+        exit! e.message, error: true
       end
 
       class Help
@@ -107,6 +109,7 @@ module Amber::CLI
         repo = gets
         remote_cmd(%Q("ssh-keyscan github.com >> ~/.ssh/known_hosts"))
         remote_cmd(%Q(bash -c "yes yes | git clone #{repo} amberproject"))
+        remote_cmd(%Q(echo "#{Support::FileEncryptor.encryption_key}" > amberproject/.encryption_key))
       end
 
       def setup_project


### PR DESCRIPTION
### Description of the Change

1. Adds .encryption_key to deployed project so `.production.enc` can be decrypted and used.
1. Adds a flag to not use a local database in docker.
1. Adds the ability to use `environment` files to use any database or redis settings you want.
1. Adds `--environment` option so you could specify staging or something instead of production.

### Benefits

Makes amber deploy more useful.
