### PR TITLE
Emergency Bug Fix: Fixed order dependent CSRF spec.

### DIFF
--- a/spec/amber/router/pipe/csrf_spec.cr
+++ b/spec/amber/router/pipe/csrf_spec.cr
@@ -4,6 +4,7 @@ module Amber
   module Pipe
     describe CSRF do
       Dir.cd CURRENT_DIR
+      Amber.env = :test
 
       context "when requests have HTTP methods" do
         CSRF::CHECK_METHODS.each do |method|
@@ -60,7 +61,6 @@ module Amber
 
       context "across requests" do
         it "is valid across request" do
-          csrf = CSRF.new
           request = HTTP::Request.new("GET", "/")
           context = create_context(request)
 

--- a/spec/amber/router/session_spec.cr
+++ b/spec/amber/router/session_spec.cr
@@ -2,6 +2,7 @@ require "../../../spec_helper"
 include SessionHelper
 
 module Amber::Router
+  Amber.settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?
   describe Session::Store do
     it "creates a cookie session store" do
       session = create_session_config("signed_cookie")

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,7 +12,7 @@ CURRENT_DIR       = Dir.current
 
 Amber.environment_path = "./spec/support/config"
 Amber.env=(ENV[Amber::AMBER_ENV])
-Amber.settings.redis_url = ENV["REDIS_URL"]? || Amber.settings.redis_url
+Amber.settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?
 
 require "http"
 require "spec"


### PR DESCRIPTION
### Description of the Change

CSRF tests randomly fail depending on the system they're ran on. 
This is due to different file systems loading files in different orders.
Fixed by loading settings from env file again at the beginning of crsf_spec.

