### PR TITLE
Remove redundant pipe from project template

### DIFF
--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -13,7 +13,6 @@ Amber::Server.configure do |app|
   pipeline :static do
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Static.new("./public")
-    plug HTTP::CompressHandler.new
   end
 
   routes :static do


### PR DESCRIPTION
### Description of the Change

I removed `HTTP::CompressHandler` because 
`Amber::Pipe::Static` do the same job. You can check it https://github.com/amberframework/amber/blob/master/src/amber/router/pipe/static.cr#L99
