### PR TITLE
removed npm from docker

### DIFF
--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -12,14 +12,6 @@
 version: '2'
 
 services:
-  web:
-    build: .
-    image: <%= @name %>
-    command: bash -c 'npm install && npm run watch'
-    working_dir: /app/local
-    volumes:
-      - '.:/app/local'
-
   app:
     build: .
     image: <%= @name %>


### PR DESCRIPTION
### Description of the Change

Removed npm from docker since it's part of amber w now.

