### PR TITLE
[Pipe] Add support client reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,7 @@ To test the generated app locally:
 4. Start your app: `amber watch`
 5. Then visit `http://0.0.0.0:3000/`
 
-<<<<<<< HEAD
-Note: `amber watch` uses [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
-||||||| parent of 7c3a6b4... Cleanup
-Note: The `amber watch` command uses [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
-=======
 Note: The `amber watch` command is based on [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
->>>>>>> 7c3a6b4... Cleanup
 
 If you don't want to use Sentry, you can compile and run manually:
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,13 @@ To test the generated app locally:
 4. Start your app: `amber watch`
 5. Then visit `http://0.0.0.0:3000/`
 
+<<<<<<< HEAD
 Note: `amber watch` uses [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
+||||||| parent of 7c3a6b4... Cleanup
+Note: The `amber watch` command uses [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
+=======
+Note: The `amber watch` command is based on [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
+>>>>>>> 7c3a6b4... Cleanup
 
 If you don't want to use Sentry, you can compile and run manually:
 

--- a/shard.yml
+++ b/shard.yml
@@ -27,7 +27,7 @@ dependencies:
 
   slang:
     github: jeromegn/slang
-    branch: master 
+    branch: master
 
   redis:
     github: stefanwille/crystal-redis
@@ -40,10 +40,6 @@ dependencies:
   teeplate:
     github: amberframework/teeplate
     version: ~> 0.5.0
-
-  sentry:
-    github: samueleaton/sentry
-    version: ~> 0.1.0
 
   micrate:
     github: juanedi/micrate
@@ -67,8 +63,18 @@ dependencies:
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
+<<<<<<< HEAD
     version: ~> 0.9.0
 
 development_dependencies:
   ameba:
     github: veelenga/ameba
+||||||| parent of 7c3a6b4... Cleanup
+    version: ~> 0.8.3
+
+  watcher:
+    github: faustinoaq/watcher
+    version: ~> 0.2.0
+=======
+    version: ~> 0.8.3
+>>>>>>> 7c3a6b4... Cleanup

--- a/shard.yml
+++ b/shard.yml
@@ -63,18 +63,9 @@ dependencies:
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-<<<<<<< HEAD
     version: ~> 0.9.0
 
 development_dependencies:
   ameba:
     github: veelenga/ameba
-||||||| parent of 7c3a6b4... Cleanup
-    version: ~> 0.8.3
-
-  watcher:
-    github: faustinoaq/watcher
-    version: ~> 0.2.0
-=======
-    version: ~> 0.8.3
->>>>>>> 7c3a6b4... Cleanup
+    version: ~> 0.4.0

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -221,8 +221,16 @@ describe HTTP::Server::Context do
      ics:   "text/calendar"}.each do |format, content_type|
       it "gets request format for #{content_type}" do
         headers = HTTP::Headers.new
-        headers[HTTP::Server::Context::FORMAT_HEADER] = content_type
+        headers[Amber::Support::MimeTypes::FORMAT_HEADER] = content_type
         request = HTTP::Request.new("GET", "/", headers)
+        context = create_context(request)
+        context.format.should eq format.to_s
+      end
+    end
+
+    %w(html json txt text xml).each do |format|
+      it "get format #{format} from path extension" do
+        request = HTTP::Request.new("GET", "/index.#{format}")
         context = create_context(request)
         context.format.should eq format.to_s
       end

--- a/spec/amber/router/pipe/error_spec.cr
+++ b/spec/amber/router/pipe/error_spec.cr
@@ -16,8 +16,15 @@ module Amber
         error = Error.new
         pipeline = Pipeline.new
         request = HTTP::Request.new("GET", "/")
-        Amber::Server.router.draw :web { get "/", HelloController, :index }
-        pipeline.build :web { plug Amber::Pipe::Logger.new }
+
+        Amber::Server.router.draw :web do
+          get "/", HelloController, :index
+        end
+
+        pipeline.build :web do
+          plug Amber::Pipe::Logger.new
+        end
+
         error.next = ->(context : HTTP::Server::Context) { raise "Oops!" }
         response = create_request_and_return_io(error, request)
 

--- a/spec/amber/router/pipe/reload_spec.cr
+++ b/spec/amber/router/pipe/reload_spec.cr
@@ -1,0 +1,26 @@
+require "../../../../spec_helper"
+
+module Amber
+  module Pipe
+    describe Reload do
+      it "client should contain injected code" do
+        reload = Reload.new
+        pipeline = Pipeline.new
+        request = HTTP::Request.new("GET", "/reload")
+
+        Amber::Server.router.draw :web do
+          get "/reload", HelloController, :index
+        end
+
+        pipeline.build :web do
+          plug Amber::Pipe::Reload.new
+        end
+
+        reload.next = ->(context : HTTP::Server::Context) { "Hello World!" }
+        response = create_request_and_return_io(reload, request)
+
+        response.body.should contain "Code injected by Amber Framework"
+      end
+    end
+  end
+end

--- a/spec/amber/router/pipe/reload_spec.cr
+++ b/spec/amber/router/pipe/reload_spec.cr
@@ -1,25 +1,48 @@
 require "../../../../spec_helper"
 
+class FakeEnvironment < Amber::Environment::Env
+  def development?
+    true
+  end
+end
+
 module Amber
   module Pipe
     describe Reload do
-      it "client should contain injected code" do
-        reload = Reload.new
+      headers = HTTP::Headers.new
+      headers["Accept"] = "text/html"
+      request = HTTP::Request.new("GET", "/reload", headers)
+
+      Amber::Server.router.draw :web do
+        get "/reload", HelloController, :index
+      end
+
+      context "when environment is in development mode" do
         pipeline = Pipeline.new
-        request = HTTP::Request.new("GET", "/reload")
-
-        Amber::Server.router.draw :web do
-          get "/reload", HelloController, :index
+        pipeline.build :web do
+          plug Amber::Pipe::Reload.new(FakeEnvironment.new)
         end
+        pipeline.prepare_pipelines
 
+        it "contains injected code in response.body" do
+          response = create_request_and_return_io(pipeline, request)
+
+          response.body.should contain "Code injected by Amber Framework"
+        end
+      end
+
+      context "when environment is NOT in development mode" do
+        pipeline = Pipeline.new
         pipeline.build :web do
           plug Amber::Pipe::Reload.new
         end
+        pipeline.prepare_pipelines
 
-        reload.next = ->(context : HTTP::Server::Context) { "Hello World!" }
-        response = create_request_and_return_io(reload, request)
+        it "does not have injected reload code in response.body" do
+          response = create_request_and_return_io(pipeline, request)
 
-        response.body.should contain "Code injected by Amber Framework"
+          response.body.should_not contain "Code injected by Amber Framework"
+        end
       end
     end
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,6 +13,8 @@ CURRENT_DIR       = Dir.current
 Amber.path = "./spec/support/config"
 Amber.env=(ENV["AMBER_ENV"])
 Amber.settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?
+Amber::CLI.logger.level = Logger::UNKNOWN
+Amber.logger.level = Logger::UNKNOWN
 
 require "http"
 require "spec"

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -1,11 +1,10 @@
-require "sentry"
-
 module Sentry
   class ProcessRunner
     property processes = [] of Process
     property process_name : String
     property files = [] of String
     @logger : Amber::Environment::Logger
+    FILE_TIMESTAMPS = {} of String => String
 
     def initialize(
                    @process_name : String,
@@ -16,6 +15,8 @@ module Sentry
                    files = [] of String,
                    @logger = Amber::CLI.logger)
       @files = files
+      @npm_process = false
+      @app_running = false
     end
 
     def run
@@ -26,34 +27,35 @@ module Sentry
     end
 
     # Compiles and starts the application
-    #
     def start_app
-      stop_all_processes
-      start_all_processes
+      build_result = build_app_process
+      if build_result && build_result.success?
+        stop_all_processes
+        create_all_processes
+        @app_running = true
+      elsif !@app_running
+        log "Compile time errors detected. Shutting down..."
+        exit 1
+      else
+        log "Unknown error occurred, Shutting down..."
+        exit 1
+      end
     end
 
     private def scan_files
       file_changed = false
-
       Dir.glob(files) do |file|
         timestamp = get_timestamp(file)
-        if FILE_TIMESTAMPS[file]? && FILE_TIMESTAMPS[file] != timestamp
+        msg_prefix = FILE_TIMESTAMPS[file]? ? "" : "Watching file: "
+
+        if FILE_TIMESTAMPS[file]? != timestamp
           FILE_TIMESTAMPS[file] = timestamp
+          log "#{msg_prefix}./#{file.colorize(:light_gray)}"
           file_changed = true
-          log "#{file.capitalize.colorize(:light_gray)}"
-        elsif FILE_TIMESTAMPS[file]?.nil?
-          FILE_TIMESTAMPS[file] = timestamp
-          file_changed = true
-          log "Watching file: #{file.capitalize.colorize(:light_gray)}"
         end
       end
 
-      start_app if (file_changed)
-    end
-
-    private def start_all_processes
-      log "Compiling #{project_name}..."
-      create_all_processes
+      start_app if file_changed
     end
 
     private def stop_all_processes
@@ -65,10 +67,11 @@ module Sentry
     end
 
     private def create_all_processes
-      build_app_process
       @processes << create_watch_process
-      sleep 3
-      create_npm_process
+      unless @npm_process
+        create_npm_process
+        @npm_process = true
+      end
     end
 
     private def build_app_process
@@ -83,7 +86,7 @@ module Sentry
 
     private def create_npm_process
       node_log "Installing dependencies..."
-      Process.new("npm install && npm run watch", shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      Process.new("npm install --loglevel=error && npm run watch", shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
       node_log "Watching public directory"
     end
 

--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -7,6 +7,11 @@ Amber::Server.configure do |app|
     plug Amber::Pipe::Session.new
     plug Amber::Pipe::Flash.new
     plug Amber::Pipe::CSRF.new
+
+    # Reload clients browsers (development only)
+    if Amber.env.development?
+      plug Amber::Pipe::Reload.new
+    end
   end
 
   # All static content will run these transformations

--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -9,9 +9,7 @@ Amber::Server.configure do |app|
     plug Amber::Pipe::CSRF.new
 
     # Reload clients browsers (development only)
-    if Amber.env.development?
-      plug Amber::Pipe::Reload.new
-    end
+    plug Amber::Pipe::Reload.new
   end
 
   # All static content will run these transformations

--- a/src/amber/environment/logger.cr
+++ b/src/amber/environment/logger.cr
@@ -4,12 +4,12 @@ require "colorize"
 module Amber::Environment
   class Logger < ::Logger
     def puts(message, progname = progname, color = :magenta)
-      log(self.level, message, "#{progname}\t|".colorize(color))
+      log(self.level, message, "#{progname} |".colorize(color))
     end
 
     {% for name in Severity.constants %}
       def {{name.id.downcase}}(message, color = :light_cyan)
-        log(Severity::{{name.id}}, message, "#{progname}\t|".colorize(color))
+        log(Severity::{{name.id}}, message, "#{progname} |".colorize(color))
       end
     {% end %}
   end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -15,7 +15,6 @@ end
 # response object.  Params and Session hash can be accessed from the Context.
 class HTTP::Server::Context
   METHODS            = %i(get post put patch delete head)
-  FORMAT_HEADER      = "Accept"
   IP_ADDRESS_HEADERS = %w(REMOTE_ADDR CLIENT_IP X_FORWARDED_FOR X_FORWARDED X_CLUSTER_CLIENT_IP FORWARDED)
 
   include Amber::Router::Files
@@ -70,20 +69,7 @@ class HTTP::Server::Context
   {% end %}
 
   def format
-    content_type = request.headers[FORMAT_HEADER]?
-
-    if content_type
-      content_type = content_type.split(",").first
-      type = if content_type.includes?(";")
-        content_type.split(";").first
-      else
-        content_type
-      end
-
-      Amber::Support::MimeTypes.format(type)
-    else
-      Amber::Support::MimeTypes.default
-    end
+    Amber::Support::MimeTypes.get_request_format(request)
   end
 
   def port

--- a/src/amber/router/params_parser.cr
+++ b/src/amber/router/params_parser.cr
@@ -14,6 +14,7 @@ module Amber::Router
     METHOD           = "_method"
     OVERRIDE_HEADER  = "X-HTTP-Method-Override"
     OVERRIDE_METHODS = %w(PATCH PUT DELETE)
+    TYPE_EXT_REGEX   = Amber::Support::MimeTypes::TYPE_EXT_REGEX
 
     property params = Amber::Router::Params.new
 
@@ -84,7 +85,7 @@ module Amber::Router
       rparams = route.params
       unless rparams.empty?
         key = rparams.keys.last
-        rparams[key] = rparams[key].sub(Controller::Base::Content::TYPE_EXT_REGEX, "")
+        rparams[key] = rparams[key].sub(TYPE_EXT_REGEX, "")
       end
       route.params
     end

--- a/src/amber/router/pipe/base.cr
+++ b/src/amber/router/pipe/base.cr
@@ -8,7 +8,7 @@ module Amber
 
       # Execution of this handler.
       def call(context : HTTP::Server::Context)
-        call_next context
+        call_next(context)
       end
     end
   end

--- a/src/amber/router/pipe/reload.cr
+++ b/src/amber/router/pipe/reload.cr
@@ -1,0 +1,27 @@
+require "../../support/client_reload"
+
+module Amber
+  module Pipe
+    # Reload clients browsers using `ClientReload`.
+    #
+    # NOTE: Amber::Pipe::Reload is intended for use in a development environment.
+    # ```
+    # pipeline :web do
+    #   plug Amber::Pipe::Reload.new
+    # end
+    # ```
+    class Reload < Base
+      def initialize
+        Support::ClientReload.new
+        super
+      end
+
+      def call(context : HTTP::Server::Context)
+        if context.format == "html"
+          context.response.print Support::ClientReload::INJECTED_CODE
+        end
+        call_next(context)
+      end
+    end
+  end
+end

--- a/src/amber/router/pipe/reload.cr
+++ b/src/amber/router/pipe/reload.cr
@@ -11,14 +11,13 @@ module Amber
     # end
     # ```
     class Reload < Base
-      def initialize
+      def initialize(@env : Amber::Environment::Env = Amber.env)
         Support::ClientReload.new
-        super
       end
 
       def call(context : HTTP::Server::Context)
-        if context.format == "html"
-          context.response.print Support::ClientReload::INJECTED_CODE
+        if @env.development? && context.format == "html"
+          context.response << Support::ClientReload::INJECTED_CODE
         end
         call_next(context)
       end

--- a/src/amber/server/server.cr
+++ b/src/amber/server/server.cr
@@ -70,7 +70,7 @@ module Amber
       loop do
         begin
           logger.info "Server started in #{Amber.env.colorize(:yellow)}."
-          logger.info "Startup Time #{Time.now - time}\n\n".colorize(:white)
+          logger.info "Startup Time #{Time.now - time}".colorize(:white)
           server.listen(settings.port_reuse)
           exit
         rescue e : Errno

--- a/src/amber/support/client_reload.cr
+++ b/src/amber/support/client_reload.cr
@@ -1,0 +1,106 @@
+module Amber::Support
+  # Used by `Amber::Pipe::Reload`
+  #
+  # Allow clients browser reloading using WebSockets and file watchers.
+  struct ClientReload
+    FILE_TIMESTAMPS = {} of String => String
+    WEBSOCKET_PATH  = rand(0x10000000).to_s(36)
+    SESSIONS        = [] of HTTP::WebSocket
+
+    def initialize
+      create_reload_server
+      spawn do
+        loop do
+          scan_files
+          sleep 1
+        end
+      end
+    end
+
+    private def create_reload_server
+      Amber::WebSockets::Server::Handler.new "/#{WEBSOCKET_PATH}" do |session|
+        SESSIONS << session
+        session.on_close do
+          SESSIONS.delete session
+        end
+      end
+    end
+
+    private def reload_clients(msg)
+      SESSIONS.each do |session|
+        session.@ws.send msg
+      end
+    end
+
+    private def check_file(file)
+      case file
+      when .ends_with? ".css"
+        reload_clients(msg: "refreshcss")
+      else
+        reload_clients(msg: "reload")
+      end
+    end
+
+    private def get_timestamp(file : String)
+      File.stat(file).mtime.to_s("%Y%m%d%H%M%S")
+    end
+
+    private def scan_files
+      Dir.glob(["public/**/*"]) do |file|
+        timestamp = get_timestamp(file)
+        msg_prefix = FILE_TIMESTAMPS[file]? ? "" : "Watching file: "
+
+        if FILE_TIMESTAMPS[file]? != timestamp
+          FILE_TIMESTAMPS[file] = timestamp
+          Amber.logger.puts "#{msg_prefix}./#{file.colorize(:light_gray)}", "Watcher", :light_gray
+          check_file(file)
+        end
+      end
+    end
+
+    # Code from https://github.com/tapio/live-server/blob/master/injected.html
+    INJECTED_CODE = <<-HTML
+    <!-- Code injected by Amber Framework -->
+    <script type="text/javascript">
+      // <![CDATA[  <-- For SVG support
+      if ('WebSocket' in window) {
+        (function() {
+          function refreshCSS() {
+            console.log('Reloading CSS...');
+            var sheets = [].slice.call(document.getElementsByTagName('link'));
+            var head = document.getElementsByTagName('head')[0];
+            for (var i = 0; i < sheets.length; ++i) {
+              var elem = sheets[i];
+              var rel = elem.rel;
+              if (elem.href && typeof rel != 'string' || rel.length == 0 || rel.toLowerCase() == 'stylesheet') {
+                head.removeChild(elem);
+                var url = elem.href.replace(/(&|\\?)_cacheOverride=\\d+/, '');
+                elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
+                head.appendChild(elem);
+              }
+            }
+          }
+          var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';
+          var address = protocol + window.location.host + '/#{WEBSOCKET_PATH}';
+          var socket = new WebSocket(address);
+          socket.onmessage = function(msg) {
+            if (msg.data == 'reload') {
+              window.location.reload();
+            } else if (msg.data == 'refreshcss') {
+              refreshCSS();
+            }
+          };
+          socket.onclose = function() {
+            console.log('Conection closed!');
+            setTimeout(function() {
+                window.location.reload();
+            }, 1000);
+          }
+          console.log('Live reload enabled.');
+        })();
+      }
+      // ]]>
+    </script>\n
+    HTML
+  end
+end

--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -1,9 +1,13 @@
 module Amber
   module Support
     module MimeTypes
-      DEFAULT_MIME_TYPE   = "application/octet-stream"
-      ZIP_FILE_EXTENSIONS = %w(.htm .html .txt .css .js .svg .json .xml .otf .ttf .woff .woff2)
-      MIME_TYPES          = {
+      DEFAULT_MIME_TYPE      = "application/octet-stream"
+      ZIP_FILE_EXTENSIONS    = %w(.htm .html .txt .css .js .svg .json .xml .otf .ttf .woff .woff2)
+      ACCEPT_SEPARATOR_REGEX = /,|,\s/
+      TYPE_EXT_REGEX         = /\.(#{MIME_TYPES.keys.join("|")})$/
+      FORMAT_HEADER          = "Accept"
+
+      MIME_TYPES = {
         "123"       => "application/vnd.lotus-1-2-3",
         "3dml"      => "text/vnd.in3d.3dml",
         "3g2"       => "video/3gpp2",
@@ -635,6 +639,19 @@ module Amber
 
       def self.default
         DEFAULT_MIME_TYPE
+      end
+
+      def self.get_request_format(request)
+        path_ext = request.path.match(TYPE_EXT_REGEX).try(&.[1])
+        return path_ext if path_ext
+
+        accept = request.headers[FORMAT_HEADER]?
+        if accept && !accept.empty?
+          accept = accept.split(";").first?.try(&.split(ACCEPT_SEPARATOR_REGEX)).try &.first
+          return format(accept) if accept
+        end
+
+        "html"
       end
     end
   end


### PR DESCRIPTION
### Description of the Change

Hi team 😄 Happy Christmas! 🎉 

- Add Hot reloading for CSS
- Add reloading for files on public folder
- Allow reloading browser after server reload

![ezgif-5-1c180670af](https://user-images.githubusercontent.com/3067335/34326676-126266d6-e881-11e7-89d9-015868d02729.gif)

_`Backend reloading, client reloading and hot reloading (preserving state)`_

### Alternate Designs

Using `Amber::Tasks` ¿? @eliasjpr 

### Benefits

Fix  #347 definitely

### Possible Drawbacks

- ~~`Amber::Pipe::Reload` keeps enabled on production environments~~
- `Amber::Pipe::Reload` modifies `"content-type"`, so json/text/other responses will have injected code too, a posible solution would be adding `Pipe::Reload` after Controllers processing, then injected code only exists if `"content-type"` is equal to `"text/html"` instead of enforcing `"text/html"`
