### PR TITLE
fix docker binding to host

### DIFF
--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -16,7 +16,7 @@ logging:
     - cookies
     - params
 
-host: localhost
+host: 0.0.0.0
 port_reuse: true
 process_count: 1
 # ssl_key_file:

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -16,7 +16,7 @@ logging:
     - cookies
     - params
 
-host: localhost
+host: 0.0.0.0
 port_reuse: false
 process_count: 1
 # ssl_key_file:


### PR DESCRIPTION
### Description of the Change

running `docker-compose up -d` is failing to bind to the external interface.

If you bind to "localhost" or 127.0.0.1, you are binding to the docker's internal 127.0.0.1.  This is different than the external interface.  By setting host binding to 0.0.0.0, this will bind to all interfaces and will be available to the external interface as well.
