### PR TITLE
handle the case where there is no accept header

### DIFF
--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -70,14 +70,20 @@ class HTTP::Server::Context
   {% end %}
 
   def format
-    content_type = request.headers[FORMAT_HEADER].split(",").first
-    type = if content_type.includes?(";")
-             content_type.split(";").first
-           else
-             content_type
-           end
+    content_type = request.headers[FORMAT_HEADER]?
 
-    Amber::Support::MimeTypes.format(type)
+    if content_type
+      content_type = content_type.split(",").first
+      type = if content_type.includes?(";")
+        content_type.split(";").first
+      else
+        content_type
+      end
+
+      Amber::Support::MimeTypes.format(type)
+    else
+      Amber::Support::MimeTypes.default
+    end
   end
 
   def port

--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -632,6 +632,10 @@ module Amber
       def self.format(accepts)
         MIME_TYPES.key?(accepts)
       end
+
+      def self.default
+        DEFAULT_MIME_TYPE
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

A HTTP client may not send an Accept header so the content type cannot be determined from the request headers.  This change returns the default content type when there is no Accept request header.

### Alternate Designs

None considered - Amber::Support::MimeTypes already has a default mime type and that is the value returned.

### Benefits

requests without an Accept header will not fail.

### Possible Drawbacks
None forseen