### PR TITLE
Only restarts server if it crashed due to File handler error.

### DIFF
--- a/src/amber/server/server.cr
+++ b/src/amber/server/server.cr
@@ -74,8 +74,14 @@ module Amber
           server.listen(settings.port_reuse)
           exit
         rescue e : Errno
-          logger.error e.message
-          logger.info "Restarting server..."
+          if e.message == "accept: Too many open files"
+            logger.error e.message
+            logger.info "Restarting server..."
+            sleep 1
+          else
+            logger.error e.message
+            exit
+          end
         end
       end
     end


### PR DESCRIPTION
### Description of the Change

Check message and restart if its a file descriptor issue. Exist otherwise. There may be other errors we want to restart on as well but this is a good start.

Fixes https://github.com/amberframework/amber/issues/469

