### PR TITLE
Fix fonts path in auto-generated webpack template

### DIFF
--- a/src/amber/cli/templates/app/config/webpack/common.js
+++ b/src/amber/cli/templates/app/config/webpack/common.js
@@ -46,7 +46,7 @@ let config = {
         test: /\.(woff|woff2|eot|ttf|otf)$/,
         exclude: /node_modules/,
         use: [
-          'file-loader'
+          'file-loader?name=/[name].[ext]'
         ]
       },
       {


### PR DESCRIPTION
Without this addition, any fonts processed by webpack got an URL
of /dist[font] and a "/" in between was missing.

  