### PR TITLE
Fix Static's fallthrough and directory_listing options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,25 @@
 OUT_DIR=bin
-PREFIX ?=/usr/local
+PREFIX=/usr/local
 
 all: build force_link
 
 install: build
 	@mkdir -p $(PREFIX)/bin
-	cp `pwd`/bin/amber  $(PREFIX)/bin/amber
+	cp ./bin/amber $(PREFIX)/bin/amber
 
 build:
 	@echo "Building amber in $(shell pwd)"
-	@mkdir -p `pwd`/$(OUT_DIR)
-	@crystal build -o `pwd`/$(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
+	@mkdir -p ./$(OUT_DIR)
+	@crystal build -o ./$(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
 
 run:
-	`pwd`/$(OUT_DIR)/amber
+	./$(OUT_DIR)/amber
 
 clean:
-	rm -rf `pwd`/$(OUT_DIR) .crystal .shards libs lib
+	rm -rf ./$(OUT_DIR) .crystal .shards libs lib
 
 link:
-	@ln -s ./bin/amber $(PREFIX)/bin/amber
+	@ln -s `pwd`/bin/amber $(PREFIX)/bin/amber
 
 force_link:
 	@echo "Symlinking `pwd`/bin/amber to $(PREFIX)/bin/amber"

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,32 @@
-OUT_DIR=bin
+OUT_DIR=$(shell pwd)/bin
 PREFIX=/usr/local
 
-all: build force_link
+all: build
+
+build: lib $(OUT_DIR)/amber
+
+$(OUT_DIR)/amber:
+	@echo "Building amber in $(shell pwd)"
+	@mkdir -p $(OUT_DIR)
+	@crystal build -o $(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
+
+lib:
+	@shards
 
 install: build
 	@mkdir -p $(PREFIX)/bin
-	cp ./bin/amber $(PREFIX)/bin/amber
-
-build:
-	@echo "Building amber in $(shell pwd)"
-	@mkdir -p ./$(OUT_DIR)
-	@crystal build -o ./$(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
+	cp $(OUT_DIR)/amber $(PREFIX)/bin/amber
 
 run:
-	./$(OUT_DIR)/amber
-
-clean:
-	rm -rf ./$(OUT_DIR) .crystal .shards libs lib
+	$(OUT_DIR)/amber
 
 link:
-	@ln -s `pwd`/bin/amber $(PREFIX)/bin/amber
+	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
+	@ln -s $(OUT_DIR)/amber $(PREFIX)/bin/amber
 
 force_link:
-	@echo "Symlinking `pwd`/bin/amber to $(PREFIX)/bin/amber"
-	@ln -sf `pwd`/bin/amber $(PREFIX)/bin/amber
+	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
+	@ln -sf $(OUT_DIR)/amber $(PREFIX)/bin/amber
+
+clean:
+	rm -rf $(OUT_DIR) .crystal .shards libs lib

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ $(OUT_DIR)/amber:
 	@crystal build -o $(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
 
 lib:
-	@shards
+	@crystal deps
 
 install: build
 	@mkdir -p $(PREFIX)/bin

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@
 
 **Amber** is a web application framework written in [Crystal](http://www.crystal-lang.org) inspired by Kemal, Rails, Phoenix and other popular application frameworks.
 
-The purpose of Amber is not to create yet another framework, but to take advantage of the beautiful Crystal language capabilities and provide engineers an efficient, cohesive, and well maintained web framework for the crystal community that embraces the language philosophies, conventions, and guides.
+The purpose of Amber is not to create yet another framework, but to take advantage of the beautiful Crystal language capabilities and provide engineers and the Crystal community with an efficient, cohesive, well maintained web framework that embraces the language philosophies, conventions, and guidelines.
 
-Amber Crystal borrows concepts that already have been battle tested, successful, and embrace new concepts through team and community collaboration and analysis, that aligns with Crystal philosophies.
+Amber borrows concepts that have already been battle tested and successful, and embraces new concepts through team and community collaboration and analysis, which also aligns with Crystal's philosophy.
 
 ## Read the Docs
 
 Documentation https://docs.amberframework.org
 
 
-## Benchmark
+## Benchmarks
 
 Latest Results **968,824.35 requests per second: 32 cores at 2.7Ghz**
 
@@ -46,7 +46,7 @@ Requests/sec: 968824.35
 Transfer/sec:     68.37MB
 ```
 
-> Disclaimer: We share these benchmark results with the understanding they may vary depending on configurations and environment settings and by no means we are making any comparison claims with other web application frameworks.
+> Disclaimer: We share these benchmark results with the understanding they may vary depending on configuration and environment settings. By no means are we making any comparison claims in regards to other web application frameworks.
 
 ## Installation
 
@@ -58,20 +58,22 @@ Ensure you have the necessary dependencies:
 - `crystal`: Follow the instructions to get `crystal` on this page: <https://crystal-lang.org/docs/installation/index.html>
 
 ##### For Debian & Ubuntu
-- These are necessary to compile the CLI:
-- `sudo apt-get install build-essential libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev`
+
+These are necessary to compile the CLI:
+
+- apt-get install build-essential libreadline-dev libsqlite3-dev libpq-dev libmysqlclient-dev libssl-dev`
 
 <!-- WIP: ##### For RedHat & CentOS
 - `sudo yum groupinstall 'Development Tools' `
 - `sudo yum install readline-devel sqlite-devel openssl-devel libyaml-devel gc-devel libevent-devel` -->
 
-Once you have these dependencies, You can build the `amber` tool from source:
+Once you have these dependencies, you can build `amber` from source:
 
 
 ```shellsession
 $ git clone git@github.com:amberframework/amber.git
-$ cd amber/
-$ shards install
+$ cd amber
+$ make
 $ make install
 ```
 
@@ -154,11 +156,11 @@ options: `-d` defaults to pg. `-t` defaults to slang. `-m` defaults to `granite`
 `--deps` will run `crystal deps` for you.
 
 This will generate a traditional web application:
- - **/config** - Application and HTTP::Handler config's goes here.  The database.yml and routes.cr are here.
- - **/lib** - shards are installed here.
- - **/public** - Default location for html/css/js files.  The static handler points to this directory.
- - **/spec** - all the crystal specs go here.
- - **/src** - all the source code goes here.
+ - **/config** - Application and HTTP::Handler config's goes here. The database.yml and routes.cr are here.
+ - **/lib** - Shards are installed here.
+ - **/public** - Default location for HTML/CSS/js files. The static handler points to this directory.
+ - **/spec** - All crystal specs go here.
+ - **/src** - All source code goes here.
 
 ## Scaffolding
 Generate scaffolding for a resource:
@@ -166,7 +168,7 @@ Generate scaffolding for a resource:
 amber generate scaffold Post name:string body:text draft:bool
 ```
 
-This will generate scaffolding for a Post:
+This will generate scaffolding for Post:
  - src/controllers/post_controller.cr
  - src/models/post.cr
  - src/views/post/*
@@ -177,15 +179,15 @@ This will generate scaffolding for a Post:
  - appends navigation to src/layouts/_nav.slang
 
 ## Running App Locally
-To test the generated App locally:
+To test the generated app locally:
 
-2. Create and Migrate the database: `amber db create migrate`. You should see output like
+2. Create and migrate the database: `amber db create migrate`. You should see output like
     `Migrating db, current version: 0, target: [datetimestamp]OK   [datetimestamp]_create_shop.sql`
 3. Run the specs: `crystal spec`
 4. Start your app: `amber watch`
 5. Then visit `http://0.0.0.0:3000/`
 
-Note: The `amber watch` command uses [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
+Note: `amber watch` uses [Sentry](https://github.com/samueleaton/sentry) to watch for any changes in your source files, recompiling automatically.
 
 If you don't want to use Sentry, you can compile and run manually:
 
@@ -213,7 +215,7 @@ It's not enough to be brilliant when you're alone in your programming lair. You 
 
 We have adopted the Contributor Covenant to be our [CODE OF CONDUCT](.github/CODE_OF_CONDUCT.md) guidelines for Amber.
 
-## Have a Amber based project?
+## Have an Amber-based Project?
 
 Use Amber badge ![Amber Framework](https://img.shields.io/badge/using-amber%20framework-orange.svg)
 
@@ -225,9 +227,9 @@ Use Amber badge ![Amber Framework](https://img.shields.io/badge/using-amber%20fr
 
 Contributing to Amber can be a rewarding way to learn, teach, and build experience in just about any skill you can imagine. You don’t have to become a lifelong contributor to enjoy participating in Amber.
 
-Amber is a community effort and we want You to be part of ours [Join Amber Community!](https://github.com/amberframework/amber/blob/master/.github/CONTRIBUTING.md)
+Amber is a community effort and we want You to be part of it. [Join Amber Community!](https://github.com/amberframework/amber/blob/master/.github/CONTRIBUTING.md)
 
-1. Fork it ( https://github.com/amberframework/amber/fork )
+1. Fork it (https://github.com/amberframework/amber/fork)
 2. Create your feature branch (git checkout -b my-new-feature)
 3. Commit your changes (git commit -am 'Add some feature')
 4. Push to the branch (git push origin my-new-feature)

--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -34,7 +34,7 @@ describe Amber do
 
   describe Amber::Server do
     describe ".configure" do
-      it "overrides current enviroment settings" do
+      it "overrides current environment settings" do
         Amber.env = :test
 
         Amber::Server.configure do |server|

--- a/spec/amber/extensions/number_extension_spec.cr
+++ b/spec/amber/extensions/number_extension_spec.cr
@@ -15,7 +15,7 @@ module Amber::Extensions
       (10/5 - 2).zero?.should eq(true)
     end
 
-    it "returns true when number is divisable by X" do
+    it "returns true when number is divisible by X" do
       (10).div?(5).should eq(true)
     end
 

--- a/spec/amber/extensions/string_extension_spec.cr
+++ b/spec/amber/extensions/string_extension_spec.cr
@@ -21,7 +21,7 @@ module Amber::Extensions
       "https://crystal-lang.org/?page=demo&id=17".url?.should eq(true)
     end
 
-    it "returns true for valid ALPHA charecters" do
+    it "returns true for valid ALPHA characters" do
       "WeLoveCrystal".alpha?.should eq(true)
       "İzniBurakDemirtaş".alpha?("tr-TR").should eq(true)
     end

--- a/spec/amber/router/cookies_spec.cr
+++ b/spec/amber/router/cookies_spec.cr
@@ -197,7 +197,7 @@ module Amber::Router
       cookie_header(cookies).should eq "user_name=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT"
     end
 
-    it "allow deleting a unexisting cookie" do
+    it "allow deleting a nonexistent cookie" do
       cookies = new_cookie_store
 
       cookies.delete "invalid"

--- a/spec/amber/router/pipe/csrf_spec.cr
+++ b/spec/amber/router/pipe/csrf_spec.cr
@@ -79,7 +79,7 @@ module Amber
       end
 
       context "when tokens don't match" do
-        it "raises a forbbiden error for params token" do
+        it "raises a forbidden error for params token" do
           csrf = CSRF.new
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)
@@ -92,7 +92,7 @@ module Amber
           end
         end
 
-        it "raises a forbbiden error for header token" do
+        it "raises a forbidden error for header token" do
           csrf = CSRF.new
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)

--- a/spec/amber/router/pipe/static_spec.cr
+++ b/spec/amber/router/pipe/static_spec.cr
@@ -9,7 +9,7 @@ module Amber
     describe Static do
       it "renders html" do
         request = HTTP::Request.new("GET", "/index.html")
-        static = Static.new PUBLIC_PATH, false
+        static = Static.new PUBLIC_PATH
 
         response = create_request_and_return_io(static, request)
 
@@ -18,7 +18,7 @@ module Amber
 
       it "returns Not Found when file doesn't exist" do
         request = HTTP::Request.new("GET", "/not_found.html")
-        static = Static.new PUBLIC_PATH, false
+        static = Static.new PUBLIC_PATH
 
         response = create_request_and_return_io(static, request)
 
@@ -27,7 +27,7 @@ module Amber
 
       it "delivers index.html if path ends with /" do
         request = HTTP::Request.new("GET", "/index.html")
-        static = Static.new PUBLIC_PATH, false
+        static = Static.new PUBLIC_PATH
 
         response = create_request_and_return_io(static, request)
 
@@ -39,11 +39,23 @@ module Amber
           file = File.expand_path(TEST_PUBLIC_PATH) + "/fake.#{ext}"
           File.write(file, "")
           request = HTTP::Request.new("GET", "/fake.#{ext}")
-          static = Static.new PUBLIC_PATH, false
+          static = Static.new PUBLIC_PATH
           response = create_request_and_return_io(static, request)
           response.headers["content-type"].should eq(Amber::Support::MimeTypes.mime_type(ext))
           File.delete(file)
         end
+      end
+
+      it "returns Not Found when directory_listing is disabled" do
+        request = HTTP::Request.new("GET", "/dist")
+        static_true = Static.new PUBLIC_PATH, directory_listing: true
+        static_false = Static.new PUBLIC_PATH # Listing is off by default in Amber
+
+        response_true = create_request_and_return_io(static_true, request)
+        response_false = create_request_and_return_io(static_false, request)
+
+        response_true.body.should match(/index/)
+        response_false.status_code.should eq 404
       end
     end
   end

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -5,7 +5,7 @@ module Amber
     handler = ->(context : HTTP::Server::Context) {}
     subject = Route.new("GET", "/fake/action/:id/:name", handler, :action, :web, "", "FakeController")
 
-    it "Initializes correctly with Decendant controller" do
+    it "Initializes correctly with Descendant controller" do
       request = HTTP::Request.new("GET", "/?test=test")
       context = create_context(request)
 

--- a/spec/amber/router/session/redis_store_spec.cr
+++ b/spec/amber/router/session/redis_store_spec.cr
@@ -1,7 +1,7 @@
 require "../../../../spec_helper"
 require "redis"
 
-# TODO: This test can't run on it's own because it needs the EXPIRES contant which is set elsewhere.
+# TODO: This test can't run on it's own because it needs the EXPIRES constant which is set elsewhere.
 module Amber::Router::Session
   REDIS_STORE = Redis.new(url: Amber.settings.redis_url)
 

--- a/spec/amber/support/file_encryptor.cr
+++ b/spec/amber/support/file_encryptor.cr
@@ -5,7 +5,7 @@ describe Amber::Support::FileEncryptor do
   context "#encryption_key" do
     it "load encryption_key from ENV variable" do
       ENV[Amber::SECRET_KEY] = "fake encryption key"
-      Amber::Support::FileEncryptor.encryption_key.should eq "fake encription key"
+      Amber::Support::FileEncryptor.encryption_key.should eq "fake encryption key"
     end
 
     it "load encryption_key from .encryption_key file" do

--- a/spec/support/sample/public/dist/index.html
+++ b/spec/support/sample/public/dist/index.html
@@ -1,0 +1,1 @@
+<head></head><body>Hello World from dist/!</body>

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -54,7 +54,7 @@ module Amber::CLI
       rescue e : Micrate::UnorderedMigrationsException
         exit! Micrate::Cli.report_unordered_migrations(e.versions), error: true
       rescue e : DB::ConnectionRefused
-        exit! "Connection refused: #{Micrate::DB.connection_url.colorize(:light_blue)}", error: true
+        exit! "Connection unsuccessful: #{Micrate::DB.connection_url.colorize(:light_blue)}", error: true
       rescue e : Exception
         exit! e.message, error: true
       end

--- a/src/amber/cli/commands/encrypt.cr
+++ b/src/amber/cli/commands/encrypt.cr
@@ -5,7 +5,7 @@ module Amber::CLI
     class Encrypt < Command
       class Options
         arg "env", desc: "environment file to encrypt", default: "production"
-        string ["-e", "--editor"], desc: "Prefered Editor: [vim, nano, pico, etc]", default: "vim"
+        string ["-e", "--editor"], desc: "Referred Editor: [vim, nano, pico, etc]", default: "vim"
         bool ["--noedit"], desc: "Skip editing and just encrypt", default: false
         help
       end

--- a/src/amber/cli/commands/encrypt.cr
+++ b/src/amber/cli/commands/encrypt.cr
@@ -5,7 +5,7 @@ module Amber::CLI
     class Encrypt < Command
       class Options
         arg "env", desc: "environment file to encrypt", default: "production"
-        string ["-e", "--editor"], desc: "Referred Editor: [vim, nano, pico, etc]", default: "vim"
+        string ["-e", "--editor"], desc: "Preferred Editor: [vim, nano, pico, etc]", default: "vim"
         bool ["--noedit"], desc: "Skip editing and just encrypt", default: false
         help
       end

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -10,7 +10,7 @@ module Amber::CLI
 
       class Options
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
-        string ["-e", "--editor"], desc: "Prefered editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
+        string ["-e", "--editor"], desc: "Referred editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
         string ["-b", "--back"], desc: "Runs previous command files: 'amber exec -b [times_ago]'", default: "0"
         help
       end

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -10,7 +10,7 @@ module Amber::CLI
 
       class Options
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
-        string ["-e", "--editor"], desc: "Referred editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
+        string ["-e", "--editor"], desc: "Preferred editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
         string ["-b", "--back"], desc: "Runs previous command files: 'amber exec -b [times_ago]'", default: "0"
         help
       end

--- a/src/amber/cli/templates/app/README.md.ecr
+++ b/src/amber/cli/templates/app/README.md.ecr
@@ -55,7 +55,7 @@ To build production assets:
 npm run release
 ```
 
-To use encrypted enviroment settings see [documentation](https://github.com/amberframework/online-docs/blob/master/getting-started/cli/encrypt.md#encrypt-command)
+To use encrypted environment settings see [documentation](https://github.com/amberframework/online-docs/blob/master/getting-started/cli/encrypt.md#encrypt-command)
 
 ## Docker Compose
 

--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -82,7 +82,7 @@ Amber::Server.configure do |settings|
   settings.port = ENV["PORT"].to_i if ENV["PORT"]?
   #
   #
-  # Redis URL: Redis is an in memory key value storag. Amber utilizes redis as
+  # Redis URL: Redis is an in memory key value storage. Amber utilizes redis as
   # a storing option for session information.
   #
   # settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?

--- a/src/amber/cli/templates/controller.cr
+++ b/src/amber/cli/templates/controller.cr
@@ -1,3 +1,4 @@
+require "file_utils"
 require "./field.cr"
 
 module Amber::CLI
@@ -28,8 +29,8 @@ module Amber::CLI
 
     def add_views
       @actions.each do |action, verb|
-        `mkdir -p src/views/#{@name}`
-        `touch src/views/#{@name}/#{action}.#{language}`
+        FileUtils.mkdir_p("src/views/#{@name}")
+        File.touch("src/views/#{@name}/#{action}.#{language}")
       end
     end
   end

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -19,7 +19,7 @@ module Amber::Controller::Helpers
       def initialize(@requested_responses)
       end
 
-      # TODO: add JS type simlar to rails.
+      # TODO: add JS type similar to rails.
       def html(html : String)
         @available_responses[TYPE[:html]] = html; self
       end

--- a/src/amber/environment/loader.cr
+++ b/src/amber/environment/loader.cr
@@ -1,7 +1,7 @@
 module Amber::Environment
   class Loader
     def initialize(@environment : Amber::Environment::EnvType = Amber.env.to_s,
-                   @path : String = Amber.environemnt_path)
+                   @path : String = Amber.environment_path)
       raise Exceptions::Environment.new(@path, @environment) unless settings_file_exist?
     end
 

--- a/src/amber/exceptions/exceptions.cr
+++ b/src/amber/exceptions/exceptions.cr
@@ -18,7 +18,7 @@ module Amber
       end
     end
 
-    # NOTE: Any exeptions which aren't part of and http request cycle shouldn't inherit from Base.
+    # NOTE: Any exceptions which aren't part of and http request cycle shouldn't inherit from Base.
     class EncryptionKeyMissing < Exception
       def initialize(file_path, encrypt_env)
         super(%(Encryption key not found. Please set it via '#{file_path}' or 'ENV[#{encrypt_env}]'.\n\n).colorize(:yellow).to_s)

--- a/src/amber/extensions/core.cr
+++ b/src/amber/extensions/core.cr
@@ -2,7 +2,7 @@ require "./*"
 require "../support/locale_formats"
 
 # We are patching the String class and Number struct to extend the predicates
-# available this will allow to add friendlier methods for validation cases.
+# available. This will allow to add friendlier methods for validation cases.
 class String
   include Amber::Extensions::StringExtension
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -94,7 +94,7 @@ class HTTP::Server::Context
     request.url
   end
 
-  # Attemps to retrieve client IP Address from headers
+  # Attempts to retrieve client IP Address from headers
   #
   # REMOTE_ADDR contains the real IP address of the connecting party.
   # That is the most reliable value you can find. However, they can be

--- a/src/amber/router/cookies.cr
+++ b/src/amber/router/cookies.cr
@@ -1,7 +1,7 @@
 require "http"
 require "../support/*"
 
-# Defines a betterr cookie store for the request
+# Defines a better cookie store for the request
 # The cookies being read are the ones received along with the request,
 # the cookies being written will be sent out with the response.
 # Reading a cookie does not get the cookie object itself back, just the value it holds.
@@ -221,7 +221,7 @@ module Amber::Router
 
       private def verify(message)
         @verifier.verify(message)
-      rescue e # TODO: This should probably actually raise the exception instead of rescueing from it.
+      rescue e # TODO: This should probably actually raise the exception instead of rescuing from it.
         ""
       end
     end

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -163,7 +163,7 @@ module Amber
           IO.copy(file, env.response, content_length)
         else
           env.response.content_length = fileb
-          env.response.status_code = 200 # Range not satisfable, see 4.4 Note
+          env.response.status_code = 200 # Range not satisfiable, see 4.4 Note
           IO.copy(file, env.response)
         end
       end

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -3,8 +3,9 @@ require "zlib"
 module Amber
   module Pipe
     class Static < HTTP::StaticFileHandler
-      @directory_listing = false
-      @fallthrough = false
+      def initialize(public_dir : String, fallthrough = false, directory_listing = false)
+        super
+      end
 
       def call(context : HTTP::Server::Context)
         unless context.request.method == "GET" || context.request.method == "HEAD"

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -66,12 +66,12 @@ module Amber
         all_routes
       end
 
-      def add_children(node, accomulator = {} of String => String)
+      def add_children(node, accumulator = {} of String => String)
         node.children.each do |c|
           if c.payload?
-            accomulator[c.payload.verb + c.payload.resource] = c.payload.to_json
+            accumulator[c.payload.verb + c.payload.resource] = c.payload.to_json
           end
-          add_children(c, accomulator)
+          add_children(c, accumulator)
         end
       end
 

--- a/src/amber/validations/params.cr
+++ b/src/amber/validations/params.cr
@@ -89,7 +89,7 @@ module Amber::Validators
       raise Amber::Exceptions::Validator::ValidationFailed.new errors
     end
 
-    # Returns True or false wether the validation passed
+    # Returns True or false whether the validation passed
     #
     # ```crystal
     # unless params.valid?

--- a/src/amber/websockets/channel.cr
+++ b/src/amber/websockets/channel.cr
@@ -1,6 +1,6 @@
 module Amber
   module WebSockets
-    # Sockets subscribe to Channel's, where the communication log is handled.  The channel provides funcionality
+    # Sockets subscribe to Channels, where the communication log is handled.  The channel provides functionality
     # to handle socket join `handle_joined` and socket messages `handle_message(msg)`.
     #
     # Example:
@@ -8,7 +8,7 @@ module Amber
     # ```crystal
     # class ChatChannel < Amber::Websockets::Channel
     #   def handle_joined(client_socket)
-    #     # functionality when the user joines the channel, optional
+    #     # functionality when the user joins the channel, optional
     #   end
     #
     #   def handle_leave(client_socket)
@@ -40,7 +40,7 @@ module Amber
         handle_message(client_socket, message)
       end
 
-      # Helper method for retrieving the apdater not nillable
+      # Helper method for retrieving the adapter not nillable
       protected def adapter
         if pubsub_adapter = @@adapter
           pubsub_adapter

--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -46,7 +46,7 @@ module Amber
         return topic_channels[0][:channel] if topic_channels.any?
       end
 
-      # Broadcast a message to all subscribres of the topic
+      # Broadcast a message to all subscribers of the topic
       #
       # ```crystal
       # UserSocket.broadcast("message", "chats_room:1", "msg:new", {"message" => "test"})


### PR DESCRIPTION
Amber::Pipe::Static's initializer is inherited from parent class
and setting fallthrough and directory_listing options to false
in Amber did not have the desired effect of disabling them.

The solution is to override the initializer to have them set to
off by default as intended.