### PR TITLE
Fix Static's fallthrough and directory_listing options

### DIFF
--- a/spec/amber/router/pipe/static_spec.cr
+++ b/spec/amber/router/pipe/static_spec.cr
@@ -9,7 +9,7 @@ module Amber
     describe Static do
       it "renders html" do
         request = HTTP::Request.new("GET", "/index.html")
-        static = Static.new PUBLIC_PATH, false
+        static = Static.new PUBLIC_PATH
 
         response = create_request_and_return_io(static, request)
 
@@ -18,7 +18,7 @@ module Amber
 
       it "returns Not Found when file doesn't exist" do
         request = HTTP::Request.new("GET", "/not_found.html")
-        static = Static.new PUBLIC_PATH, false
+        static = Static.new PUBLIC_PATH
 
         response = create_request_and_return_io(static, request)
 
@@ -27,7 +27,7 @@ module Amber
 
       it "delivers index.html if path ends with /" do
         request = HTTP::Request.new("GET", "/index.html")
-        static = Static.new PUBLIC_PATH, false
+        static = Static.new PUBLIC_PATH
 
         response = create_request_and_return_io(static, request)
 
@@ -39,11 +39,23 @@ module Amber
           file = File.expand_path(TEST_PUBLIC_PATH) + "/fake.#{ext}"
           File.write(file, "")
           request = HTTP::Request.new("GET", "/fake.#{ext}")
-          static = Static.new PUBLIC_PATH, false
+          static = Static.new PUBLIC_PATH
           response = create_request_and_return_io(static, request)
           response.headers["content-type"].should eq(Amber::Support::MimeTypes.mime_type(ext))
           File.delete(file)
         end
+      end
+
+      it "returns Not Found when directory_listing is disabled" do
+        request = HTTP::Request.new("GET", "/dist")
+        static_true = Static.new PUBLIC_PATH, directory_listing: true
+        static_false = Static.new PUBLIC_PATH # Listing is off by default in Amber
+
+        response_true = create_request_and_return_io(static_true, request)
+        response_false = create_request_and_return_io(static_false, request)
+
+        response_true.body.should match(/index/)
+        response_false.status_code.should eq 404
       end
     end
   end

--- a/spec/support/sample/public/dist/index.html
+++ b/spec/support/sample/public/dist/index.html
@@ -1,0 +1,1 @@
+<head></head><body>Hello World from dist/!</body>

--- a/src/amber/router/pipe/static.cr
+++ b/src/amber/router/pipe/static.cr
@@ -3,8 +3,9 @@ require "zlib"
 module Amber
   module Pipe
     class Static < HTTP::StaticFileHandler
-      @directory_listing = false
-      @fallthrough = false
+      def initialize(public_dir : String, fallthrough = false, directory_listing = false)
+        super
+      end
 
       def call(context : HTTP::Server::Context)
         unless context.request.method == "GET" || context.request.method == "HEAD"


### PR DESCRIPTION
Amber::Pipe::Static's initializer is inherited from parent class
and setting @fallthrough and @directory_listing options to false
in Amber did not have the desired effect of disabling them.

The solution is to override the initializer to have them set to
off by default as intended.

Spec for Pipe::Static's directory_listing:

- When directory_listing is off (default in Amber), response is 404
- When directory_listing is on, listing is allowed

- Specifying 'false' explicitly for option 'fallthrough' is not
  needed because the default false is now properly applied
