### PR TITLE
Use more Crystal's API, improve error message

### DIFF
--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -54,7 +54,7 @@ module Amber::CLI
       rescue e : Micrate::UnorderedMigrationsException
         exit! Micrate::Cli.report_unordered_migrations(e.versions), error: true
       rescue e : DB::ConnectionRefused
-        exit! "Connection refused: #{Micrate::DB.connection_url.colorize(:light_blue)}", error: true
+        exit! "Connection unsuccessful: #{Micrate::DB.connection_url.colorize(:light_blue)}", error: true
       rescue e : Exception
         exit! e.message, error: true
       end

--- a/src/amber/cli/templates/controller.cr
+++ b/src/amber/cli/templates/controller.cr
@@ -1,3 +1,4 @@
+require "file_utils"
 require "./field.cr"
 
 module Amber::CLI
@@ -28,8 +29,8 @@ module Amber::CLI
 
     def add_views
       @actions.each do |action, verb|
-        `mkdir -p src/views/#{@name}`
-        `touch src/views/#{@name}/#{action}.#{language}`
+        FileUtils.mkdir_p("src/views/#{@name}")
+        File.touch("src/views/#{@name}/#{action}.#{language}")
       end
     end
   end


### PR DESCRIPTION
  Use more of Crystal's API, improve error message
  
Say "Connection unsuccessful" in case of CLI database errors rather than
"Connection refused". "Connection refused" was misleading because the
error may be application-based (e.g. wrong username or password, or
missing database) and so it is not related to system's ECONNREFUSED error.