### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ install: build
 run:
 	$(OUT_DIR)/amber
 
-link:
+link: build
 	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
 	@ln -s $(OUT_DIR)/amber $(PREFIX)/bin/amber
 
-force_link:
+force_link: build
 	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
 	@ln -sf $(OUT_DIR)/amber $(PREFIX)/bin/amber
 

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,33 @@
-OUT_DIR=bin
-PREFIX ?=/usr/local
+OUT_DIR=$(shell pwd)/bin
+PREFIX=/usr/local
 
-all: build force_link
+all: build
+
+build: lib $(OUT_DIR)/amber
+
+$(OUT_DIR)/amber:
+	@echo "Building amber in $(shell pwd)"
+	@mkdir -p $(OUT_DIR)
+	@crystal build -o $(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
+
+lib:
+	@crystal deps
 
 install: build
 	@mkdir -p $(PREFIX)/bin
-	cp `pwd`/bin/amber  $(PREFIX)/bin/amber
-
-build:
-	@echo "Building amber in $(shell pwd)"
-	@mkdir -p `pwd`/$(OUT_DIR)
-	@crystal build -o `pwd`/$(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
+	@rm $(PREFIX)/bin/amber
+	@cp $(OUT_DIR)/amber $(PREFIX)/bin/amber
 
 run:
-	`pwd`/$(OUT_DIR)/amber
-
-clean:
-	rm -rf `pwd`/$(OUT_DIR) .crystal .shards libs lib
+	$(OUT_DIR)/amber
 
 link:
-	@ln -s ./bin/amber $(PREFIX)/bin/amber
+	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
+	@ln -s $(OUT_DIR)/amber $(PREFIX)/bin/amber
 
 force_link:
-	@echo "Symlinking `pwd`/bin/amber to $(PREFIX)/bin/amber"
-	@ln -sf `pwd`/bin/amber $(PREFIX)/bin/amber
+	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
+	@ln -sf $(OUT_DIR)/amber $(PREFIX)/bin/amber
+
+clean:
+	rm -rf $(OUT_DIR) .crystal .shards libs lib


### PR DESCRIPTION
- Remove invocations of `pwd` where not necessary
- Add invocations of `pwd` where necessary
- Replace PREFIX?= with PREFIX=

(The removal of ? in PREFIX?= makes this setting not susceptible to
unintentionally taking the value from the environment variable.
The correct way to set PREFIX is by doing 'make install
PREFIX=/path'
(as opposed to 'PREFIX=/path make install').)

- Do not run link (which requires admin privileges) in default
  target (build)
- On install, remove destination file before copying the binary
  (solves problem when a symlink already exists and copying fails)
- Make build depend on lib/
- Run shards only once, if lib/ doesn't exist
- Better qualify $OUT_DIR
- Add missing echo