### PR TITLE
Feature/add ws to routes cli

### DIFF
--- a/spec/amber/cli/commands/routes/routes_spec.cr
+++ b/spec/amber/cli/commands/routes/routes_spec.cr
@@ -1,0 +1,56 @@
+require "../../../../spec_helper"
+require "../../../../support/helpers/cli_helper"
+
+require "cli/spec"
+
+include CLIHelper
+include Cli::Spec::Helper
+
+module Amber::CLI
+  describe "amber routes" do
+    begin
+      context "in an `amber new` app with default options" do
+        cleanup
+        scaffold_app(TESTING_APP)
+        output = ""
+        ENV["CRYSTAL_CLI_ENV"] = "test"
+        MainCommand.run %w(routes) do |cmd|
+          output = cmd.out.gets_to_end
+        end
+        output_lines = output.split("\n").reject do |line|
+          line =~ /(─┼─|═╦═|═╩═)/
+        end
+
+        it "outputs the correct headers" do
+          headers = %w(Verb Controller Action Pipeline Scope) << "URI Pattern"
+          headers.each do |header|
+            output.should contain header
+          end
+        end
+
+        it "outputs the static file handler" do
+          expected = "Amber::Controller::Static"
+          output.should contain expected
+          line = output_lines.find(""){ |line| line.includes? expected }
+          expectations = %w(get Amber::Controller::Static index static /*)
+          expectations.each do |expectation|
+            line.should contain expectation
+          end
+        end
+
+        it "outputs the HomeController index action" do
+          expected = "HomeController"
+          output.should contain expected
+          line = output_lines.find(""){ |line| line.includes? expected }
+          expectations = %w(get HomeController index web /)
+          expectations.each do |expectation|
+            line.should contain expectation
+          end
+        end
+
+      end
+    ensure
+      cleanup
+    end
+  end
+end

--- a/spec/amber/cli/commands/routes/routes_spec.cr
+++ b/spec/amber/cli/commands/routes/routes_spec.cr
@@ -10,38 +10,42 @@ module Amber::CLI
   extend Helpers
   describe "amber routes" do
     begin
+      ENV["CRYSTAL_CLI_ENV"] = "test"
       context "in an `amber new` app with default options" do
         cleanup
         scaffold_app(TESTING_APP)
         output = ""
-        ENV["CRYSTAL_CLI_ENV"] = "test"
-        MainCommand.run %w(routes) { |cmd| output = cmd.out.gets_to_end }
-        output_lines = route_table_rows(output)
 
-        it "outputs the correct headers" do
-          headers = %w(Verb Controller Action Pipeline Scope) << "URI Pattern"
-          headers.each do |header|
-            output.should contain header
+        describe "with the default routes" do
+
+          MainCommand.run %w(routes) { |cmd| output = cmd.out.gets_to_end }
+          output_lines = route_table_rows(output)
+
+          it "outputs the correct headers" do
+            headers = %w(Verb Controller Action Pipeline Scope) << "URI Pattern"
+            headers.each do |header|
+              output.should contain header
+            end
           end
-        end
 
-        it "outputs the static file handler" do
-          expected = "Amber::Controller::Static"
-          output.should contain expected
-          line = output_lines.find(""){ |line| line.includes? expected }
-          expectations = %w(get Amber::Controller::Static index static /*)
-          expectations.each do |expectation|
-            line.should contain expectation
+          it "outputs the static file handler" do
+            expected = "Amber::Controller::Static"
+            output.should contain expected
+            line = output_lines.find(""){ |line| line.includes? expected }
+            expectations = %w(get Amber::Controller::Static index static /*)
+            expectations.each do |expectation|
+              line.should contain expectation
+            end
           end
-        end
 
-        it "outputs the HomeController index action" do
-          expected = "HomeController"
-          output.should contain expected
-          line = output_lines.find(""){ |line| line.includes? expected }
-          expectations = %w(get HomeController index web /)
-          expectations.each do |expectation|
-            line.should contain expectation
+          it "outputs the HomeController index action" do
+            expected = "HomeController"
+            output.should contain expected
+            line = output_lines.find(""){ |line| line.includes? expected }
+            expectations = %w(get HomeController index web /)
+            expectations.each do |expectation|
+              line.should contain expectation
+            end
           end
         end
 

--- a/spec/support/helpers/cli_helper.cr
+++ b/spec/support/helpers/cli_helper.cr
@@ -95,4 +95,8 @@ module CLIHelper
   def build_route(controller, action, method)
     %(#{method} "/#{controller.downcase}/#{action}", #{controller.capitalize}Controller, :#{action})
   end
+
+  def route_table_rows(route_table_text)
+    route_table_text.split("\n").reject { |line| line =~ /(─┼─|═╦═|═╩═)/ }
+  end
 end

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -58,17 +58,9 @@ module Amber::CLI
       private def set_route(route_string)
         if route_match = route_string.to_s.match(VERB_ROUTE_REGEX)
           return unless ACTION_MAPPING.keys.includes?(route_match[1]?.to_s)
-          build_route(
-            verb: route_match[1]?, controller: route_match[3]?,
-            action: route_match[4]?, pipeline: current_pipe,
-            scope: current_scope, uri_pattern: route_match[2]?
-          )
+          build_route(route_match)
         elsif route_match = route_string.to_s.match(WEBSOCKET_ROUTE_REGEX)
-          build_route(
-            verb: route_match[1]?, controller: route_match[3]?,
-            action: "", pipeline: current_pipe,
-            scope: current_scope, uri_pattern: route_match[2]?
-          )
+          build_route(route_match)
         end
       end
 
@@ -102,6 +94,14 @@ module Amber::CLI
         route["Pipeline"] = pipeline.to_s
         route["Scope"] = scope.to_s
         routes << route
+      end
+
+      private def build_route(route_match)
+        build_route(
+          verb: route_match[1]?, controller: route_match[3]?,
+          action: route_match[4]? || "", pipeline: current_pipe,
+          scope: current_scope, uri_pattern: route_match[2]?
+        )
       end
 
       private def build_uri_pattern(route, action, scope)

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -35,7 +35,6 @@ module Amber::CLI
       def run
         parse_routes
         print_routes_table
-        exit 0
       rescue
         puts "Error: Not valid project root directory.".colorize(:red)
         puts "Run `amber routes` in project root directory.".colorize(:light_blue)

--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -3,7 +3,7 @@ module Amber::CLI::Helpers
     routes = File.read("./config/routes.cr")
     replacement = <<-ROUTES
     routes :#{pipeline.to_s} do
-      #{route}
+        #{route}
     ROUTES
     File.write("./config/routes.cr", routes.gsub("routes :#{pipeline.to_s} do", replacement))
   end


### PR DESCRIPTION
### Description of the Change

Adds WebSocket routes to `amber routes` table. Also adds Specs for `amber routes` in general.

### Alternate Designs

Non considered

### Benefits

More complete routes table and test suite.

### Possible Drawbacks

Longer running test suite and fuller routes table.
