### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ $(AMBER): $(AMBER_SOURCES) | $(OUT_DIR)
 	@echo "Building amber in $@"
 	@crystal build -o $@ src/amber/cli.cr -p --no-debug
 
-$(OUT_DIR):
-	@mkdir -p $(OUT_DIR)
+$(OUT_DIR) $(INSTALL_DIR):
+	 @mkdir -p $@
 
 run:
 	$(AMBER)
@@ -34,9 +34,6 @@ link: build | $(INSTALL_DIR)
 force_link: build | $(INSTALL_DIR)
 	@echo "Symlinking $(AMBER) to $(AMBER_SYSTEM)"
 	@ln -sf $(AMBER) $(AMBER_SYSTEM)
-
-$(INSTALL_DIR):
-	 @mkdir -p $@
 
 clean:
 	rm -rf $(AMBER)

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,45 @@
-OUT_DIR=$(shell pwd)/bin
 PREFIX=/usr/local
+INSTALL_DIR=$(PREFIX)/bin
+AMBER_SYSTEM=$(INSTALL_DIR)/amber
+
+OUT_DIR=$(shell pwd)/bin
+AMBER=$(OUT_DIR)/amber
+AMBER_SOURCES=$(shell find src/ -type f -name '*.cr')
 
 all: build
 
-build: lib $(OUT_DIR)/amber
-
-$(OUT_DIR)/amber:
-	@echo "Building amber in $(shell pwd)"
-	@mkdir -p $(OUT_DIR)
-	@crystal build -o $(OUT_DIR)/amber src/amber/cli.cr -p --no-debug
+build: lib $(AMBER)
 
 lib:
 	@crystal deps
 
-install: build
-	@mkdir -p $(PREFIX)/bin
-	@rm $(PREFIX)/bin/amber
-	@cp $(OUT_DIR)/amber $(PREFIX)/bin/amber
+$(AMBER): $(AMBER_SOURCES) | $(OUT_DIR)
+	@echo "Building amber in $@"
+	@crystal build -o $@ src/amber/cli.cr -p --no-debug
+
+$(OUT_DIR):
+	@mkdir -p $(OUT_DIR)
 
 run:
-	$(OUT_DIR)/amber
+	$(AMBER)
 
-link: build
-	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
-	@ln -s $(OUT_DIR)/amber $(PREFIX)/bin/amber
+install: build | $(INSTALL_DIR)
+	@-rm $(INSTALL_DIR)/amber
+	@cp $(AMBER) $(AMBER_SYSTEM)
 
-force_link: build
-	@echo "Symlinking $(OUT_DIR)/amber to $(PREFIX)/bin/amber"
-	@ln -sf $(OUT_DIR)/amber $(PREFIX)/bin/amber
+link: build | $(INSTALL_DIR)
+	@echo "Symlinking $(AMBER) to $(AMBER_SYSTEM)"
+	@ln -s $(AMBER) $(AMBER_SYSTEM)
+
+force_link: build | $(INSTALL_DIR)
+	@echo "Symlinking $(AMBER) to $(AMBER_SYSTEM)"
+	@ln -sf $(AMBER) $(AMBER_SYSTEM)
+
+$(INSTALL_DIR):
+	 @mkdir -p $@
 
 clean:
-	rm -rf $(OUT_DIR) .crystal .shards libs lib
+	rm -rf $(AMBER)
+
+distclean:
+	rm -rf $(AMBER) .crystal .shards libs lib


### PR DESCRIPTION
- Amber binary now depends on all its source files (src/**cr). If any file
  changes, just running 'make' will rebuild Amber. If no source files have
  changed, running 'make' will have no effect and will exit quickly.
  (One can always force make execution with 'make -B [target]', in case that
  forced recompilation is required.)

- Structure of the Makefile is now such that adding more binaries later is
  easier

- A couple "stylistic" improvements were made which don't affect previous
  behavior, but use more standard Makefile syntax and variables

- When running 'make install', if previous copy or symlink doesn't exist
  (as is the case on a first install), 'rm' doesn't fail with critical error

- 'make clean' now only deletes amber-specific files, not shards etc.
  This makes it easier/quicker to invoke 'make' afterwards and recompile
  amber without having to go through shards downloading again

- 'make distclean' deletes all files and brings source tree close to original
  state as would be after git clone. (I.e. it deletes lib/ and all other directories
  that 'make clean' previously did)

- Both variants of clean now only delete bin/amber and not bin/ as a whole,
  so they now correctly preserve 'ameba' binary which comes from shards and
  also lives in bin
  