### PR TITLE
Basic fix to get HEAD requests working (#233)

### DIFF
--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -130,6 +130,6 @@ class HTTP::Server::Context
   protected def finalize_response
     response.headers["Connection"] = "Keep-Alive"
     response.headers.add("Keep-Alive", "timeout=5, max=10000")
-    response.print(@content)
+    response.print(@content) if request.method != "HEAD"
   end
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -130,6 +130,6 @@ class HTTP::Server::Context
   protected def finalize_response
     response.headers["Connection"] = "Keep-Alive"
     response.headers.add("Keep-Alive", "timeout=5, max=10000")
-    response.print(@content) if request.method != "HEAD"
+    response.print(@content) unless request.method == "HEAD"
   end
 end

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -32,7 +32,7 @@ module Amber
         trail = build_node(route.verb, route.resource)
         node = @routes.add(route.trail, route)
         @routes_hash["#{route.controller.downcase}##{route.action.to_s.downcase}"] = route
-        add_head(route) if route.verb == :GET
+        add_head(route) if route.verb == "GET"
         node
       rescue Radix::Tree::DuplicateError
         raise Amber::Exceptions::DuplicateRouteError.new(route)


### PR DESCRIPTION
It appears some support for HEAD requests existed. This commit fixes it to get basic functionality
working in accordance to HTTP RFC.

Example response headers for HEAD are now:

HTTP/1.1 200 OK
Connection: Keep-Alive
X-Powered-By: Amber
Set-Cookie: app.session=...
Keep-Alive: timeout=5, max=10000
Content-Length: 0
