### PR TITLE
[Cluster] Sets the correct environment when Forking

### DIFF
--- a/src/amber/server/cluster.cr
+++ b/src/amber/server/cluster.cr
@@ -2,6 +2,7 @@ module Amber
   class Cluster
     def self.fork(env : Hash)
       env["FORKED"] = "1"
+      env["AMBER_ENV"] = Amber.env.to_s
       Process.fork { Process.run(PROGRAM_NAME, nil, env, true, false, input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit) }
     end
 


### PR DESCRIPTION
Issue: https://github.com/amberframework/amber/issues/488

Current when using cluster mode is not passing the correct Amber environment 
to the forked processes. 

- Ensures forked processes start in the correct environment.

We this change forked processes will start in the correct environment.
![screen shot 2018-01-11 at 4 42 59 pm](https://user-images.githubusercontent.com/1685772/34848912-936c2692-f6ee-11e7-8388-c98dd6b3e686.png)