### PR TITLE
[Pipe] Adds support for head requests

### DIFF
--- a/spec/amber/router/pipe/pipeline_spec.cr
+++ b/spec/amber/router/pipe/pipeline_spec.cr
@@ -67,6 +67,13 @@ module Amber
           response.body.should eq "Destroy"
         end
 
+        it "perform HEAD request" do
+          request = HTTP::Request.new("HEAD", "/hello/1")
+          response = create_request_and_return_io(pipeline, request)
+          response.headers["Content-Length"].should eq "0"
+          response.body.empty?.should be_true
+        end
+
         it "initializes context with X-Powered-By: Amber" do
           request = HTTP::Request.new("GET", "/index/faustino")
           response = create_request_and_return_io(pipeline, request)

--- a/spec/amber/router/pipe/pipeline_spec.cr
+++ b/spec/amber/router/pipe/pipeline_spec.cr
@@ -37,37 +37,37 @@ module Amber
           response.body.should eq "Hello World!"
         end
 
-        it "perform GET request" do
+        it "responds to GET request" do
           request = HTTP::Request.new("GET", "/hello")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Index"
         end
 
-        it "perform PUT request" do
+        it "responds to PUT request" do
           request = HTTP::Request.new("PUT", "/hello/1")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Update"
         end
 
-        it "perform PATCH request" do
+        it "responds to PATCH request" do
           request = HTTP::Request.new("PATCH", "/hello/1")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Update"
         end
 
-        it "perform POST request" do
+        it "responds to POST request" do
           request = HTTP::Request.new("POST", "/hello")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Create"
         end
 
-        it "perform DELETE request" do
+        it "responds to DELETE request" do
           request = HTTP::Request.new("DELETE", "/hello/1")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Destroy"
         end
 
-        it "perform HEAD request" do
+        it "responds to HEAD request" do
           request = HTTP::Request.new("HEAD", "/hello/1")
           response = create_request_and_return_io(pipeline, request)
           response.headers["Content-Length"].should eq "0"

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -116,6 +116,6 @@ class HTTP::Server::Context
   protected def finalize_response
     response.headers["Connection"] = "Keep-Alive"
     response.headers.add("Keep-Alive", "timeout=5, max=10000")
-    response.print(@content)
+    response.print(@content) unless request.method == "HEAD"
   end
 end

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -1,5 +1,5 @@
 module Amber
-  class Route
+  struct Route
     property :handler, :action, :verb, :resource, :valve, :params, :scope, :controller
 
     def initialize(@verb : String,

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -1,5 +1,5 @@
 module Amber
-  struct Route
+  class Route
     property :handler, :action, :verb, :resource, :valve, :params, :scope, :controller
 
     def initialize(@verb : String,

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -32,7 +32,7 @@ module Amber
         trail = build_node(route.verb, route.resource)
         node = @routes.add(route.trail, route)
         @routes_hash["#{route.controller.downcase}##{route.action.to_s.downcase}"] = route
-        add_head(route) if route.verb == :GET
+        add_head(route) if route.verb == "GET"
         node
       rescue Radix::Tree::DuplicateError
         raise Amber::Exceptions::DuplicateRouteError.new(route)


### PR DESCRIPTION
Issue https://github.com/amberframework/amber/issues/233

Currently head requests are returning 404.

- Does not render response.body if the request is of type HEAD
- Converts route.cr from class to struct this should give a performance
improvement
- Changes :get symbol to "get"

With the changes it will be possible to make HEAD requests and the
response.body should be empty

Example:

 ○ http -v HEAD :3000

Request
----------------------------
HEAD / HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: localhost:3000
User-Agent: HTTPie/0.9.9

Response
----------------------------
HTTP/1.1 200 OK
Connection: Keep-Alive
Content-Length: 0
Keep-Alive: timeout=5, max=10000
Set-Cookie: amber.session=eyJfZmxhc2giOiJ7fSJ9--mpOMtKPrJi1R9nRQyYtmlwkX5CY%3D; path=/; HttpOnly
X-Powered-By: Amber

✋ @docelic 