### PR TITLE
[Route] Makes Routes a Struct instead of Class

### DIFF
--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -1,5 +1,5 @@
 module Amber
-  class Route
+  struct Route
     property :handler, :action, :verb, :resource, :valve, :params, :scope, :controller
 
     def initialize(@verb : String,


### PR DESCRIPTION
This is a small enhancement change to follow Crystal Lang guidelines to
avoid unecessary memory allowcation.

See https://crystal-lang.org/docs/guides/performance.html for details
