### PR TITLE
[Specs] Supresses Log Outputs in Specs

### DIFF
--- a/spec/amber/cli/commands/database_spec.cr
+++ b/spec/amber/cli/commands/database_spec.cr
@@ -9,7 +9,6 @@ module Amber::CLI
   describe "database" do
     ENV["AMBER_ENV"] = "test"
 
-    Amber::CLI.settings.database_url
     describe "sqlite" do
       context ENV["AMBER_ENV"] do
         it "has connection settings in config/environments/env.yml" do
@@ -27,6 +26,7 @@ module Amber::CLI
           cleanup
           scaffold_app("#{TESTING_APP}", "-d", "sqlite")
           Amber::CLI.env = "development"
+          Amber::CLI.settings.logger = Amber::Environment::Logger.new(nil)
           env_yml = prepare_test_app
           MainCommand.run ["generate", "model", "Post"]
           MainCommand.run ["db", "migrate"]

--- a/spec/build_spec.cr
+++ b/spec/build_spec.cr
@@ -28,6 +28,7 @@ module Amber::CLI
       prepare_yaml(Dir.current)
       prepare_db_yml(CLIHelper::BASE_ENV_PATH) if ENV["CI"]? == "true"
       Amber::CLI.env = "test"
+      Amber::CLI.settings.logger = Amber::Environment::Logger.new(nil)
 
       puts "====== START Creating database for #{TEST_APP_NAME} ======"
       MainCommand.run ["db", "drop"]

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,8 +13,8 @@ CURRENT_DIR       = Dir.current
 Amber.path = "./spec/support/config"
 Amber.env=(ENV["AMBER_ENV"])
 Amber.settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?
-Amber::CLI.logger.level = Logger::UNKNOWN
-Amber.logger.level = Logger::UNKNOWN
+Amber::CLI.settings.logger = Amber::Environment::Logger.new(nil)
+Amber.settings.logger = Amber::Environment::Logger.new(nil)
 
 require "http"
 require "spec"

--- a/spec/support/helpers/cli_helper.cr
+++ b/spec/support/helpers/cli_helper.cr
@@ -5,13 +5,11 @@ module CLIHelper
   ENVIRONMENTS        = %w(development test)
 
   def cleanup
-    puts "cleaning up..."
     Dir.cd CURRENT_DIR
     `rm -rf ./tmp/`
   end
 
   def prepare_test_app
-    puts "Environment: #{ENV["AMBER_ENV"]}"
     cleanup
     scaffold_app("#{TESTING_APP}", "-d", "sqlite")
     environment_yml(ENV["AMBER_ENV"], "#{Dir.current}/config/environments/")


### PR DESCRIPTION
Right now when running amber crystal specs it creates a lot of log
outputs which are not necessary.

- Disables the logging for specs

With these changes we should see tests run more cleanly.

See Travis spec run to see results