### PR TITLE
Change webpack logs to errors-only

### DIFF
--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -49,7 +49,7 @@ module Sentry
         timestamp = get_timestamp(file)
         if FILE_TIMESTAMPS[file]? != timestamp
           if @app_running
-            log "File changed: ./#{file.colorize(:light_gray)}"
+            log "File changed: #{file.colorize(:light_gray)}"
           end
           FILE_TIMESTAMPS[file] = timestamp
           file_counter += 1

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -56,7 +56,7 @@ module Sentry
         end
       end
       if file_counter > 0
-        log "Watching #{file_counter} files..."
+        log "Watching #{file_counter} files (server reload)..."
         start_app
       end
     end

--- a/src/amber/cli/templates/app/config/webpack/common.js
+++ b/src/amber/cli/templates/app/config/webpack/common.js
@@ -61,7 +61,9 @@ let config = {
   },
   plugins: [
     new ExtractTextPlugin('main.bundle.css'),
-  ]
+  ],
+  // For more info about webpack logs see: https://webpack.js.org/configuration/stats/
+  stats: 'errors-only'
 };
 
 module.exports = config;

--- a/src/amber/environment/logger.cr
+++ b/src/amber/environment/logger.cr
@@ -4,12 +4,12 @@ require "colorize"
 module Amber::Environment
   class Logger < ::Logger
     def puts(message, progname = progname, color = :magenta)
-      log(self.level, message, "#{progname} |".colorize(color))
+      log(self.level, message, ("#{progname}".ljust(10) + " |").colorize(color))
     end
 
     {% for name in Severity.constants %}
       def {{name.id.downcase}}(message, color = :light_cyan)
-        log(Severity::{{name.id}}, message, "#{progname} |".colorize(color))
+        log(Severity::{{name.id}}, message, ("#{progname}".ljust(10) + " |").colorize(color))
       end
     {% end %}
   end

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -87,9 +87,9 @@ module Amber::Environment
       @logger.progname = "Server"
       @logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
         io << datetime.to_s("%I:%M:%S")
-        io << " (#{severity})" if severity > Logger::DEBUG
         io << " "
         io << progname
+        io << " (#{severity})" if severity > Logger::DEBUG
         io << " "
         io << message
       end

--- a/src/amber/support/client_reload.cr
+++ b/src/amber/support/client_reload.cr
@@ -63,7 +63,7 @@ module Amber::Support
         end
       end
       if file_counter > 0
-        log "Watching #{file_counter} files..."
+        log "Watching #{file_counter} files (browser reload)..."
       end
     end
 


### PR DESCRIPTION
### Description of the Change

Currently webpack and watcher are showing a lot of logs, this PR change that to only show errors and file counter.

#### Logs currently:

```
09:53:21 Watcher | Watching file: ././src/blog.cr
09:53:21 Watcher | Watching file: ././src/controllers/home_controller.cr
09:53:21 Watcher | Watching file: ././src/controllers/post_controller.cr
09:53:21 Watcher | Watching file: ././src/controllers/application_controller.cr
09:53:21 Watcher | Watching file: ././src/models/post.cr
09:53:21 Watcher | Watching file: ././config/routes.cr
09:53:21 Watcher | Watching file: ././config/application.cr
09:53:21 Watcher | Watching file: ././config/initializers/granite.cr
09:53:21 Watcher | Watching file: ././src/views/layouts/application.slang
09:53:21 Watcher | Watching file: ././src/views/layouts/_nav.slang
09:53:21 Watcher | Watching file: ././src/views/post/_form.slang
09:53:21 Watcher | Watching file: ././src/views/post/new.slang
09:53:21 Watcher | Watching file: ././src/views/post/edit.slang
09:53:21 Watcher | Watching file: ././src/views/post/index.slang
09:53:21 Watcher | Watching file: ././src/views/post/show.slang
09:53:21 Watcher | Watching file: ././src/views/home/index.slang
09:53:21 Watcher | Building project Blog...
09:53:27 Watcher | Terminating app Blog...
09:53:27 Watcher | Starting Blog...
09:53:27 NodeJS | Installing dependencies...
09:53:27 NodeJS | Watching public directory
09:53:27 (INFO) Server | [Amber 0.6.2] serving application "Blog" at http://0.0.0.0:3000
09:53:27 (INFO) Server | Server started in development.
09:53:27 (INFO) Server | Startup Time 00:00:00.003865000
09:53:27 Watcher | Watching 7 files (browser reload)...
up to date in 7.827s

> blog@0.1.0 watch /home/main/Projects/blog
> webpack -w --config config/webpack/development.js


Webpack is watching the files…

Hash: 277f26c819c914c18608
Version: webpack 3.10.0
Time: 1972ms
           Asset     Size  Chunks             Chunk Names
/images/logo.png    18 kB          [emitted]  
  main.bundle.js  28.7 kB       0  [emitted]  main.bundle.js
 main.bundle.css   1.6 kB    1, 1  [emitted]  main.bundle.css, main.bundle.css
   [0] ./src/assets/javascripts/main.js 189 bytes {0} [built]
   [1] ./lib/amber/assets/js/amber.js 8.14 kB {0} [built]
   [2] ./src/assets/stylesheets/main.scss 41 bytes {1} [built]
   [3] ./node_modules/css-loader!./node_modules/sass-loader/lib/loader.js!./src/assets/stylesheets/main.scss 1.76 kB [built]
   [6] ./src/assets/images/logo.png 62 bytes [built]
    + 4 hidden modules
Child extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/index.js!node_modules/sass-loader/lib/loader.js!src/assets/stylesheets/main.scss:
     1 asset
       [0] ./node_modules/css-loader!./node_modules/sass-loader/lib/loader.js!./src/assets/stylesheets/main.scss 1.76 kB {0} [built]
       [3] ./src/assets/images/logo.png 62 bytes {0} [built]
        + 2 hidden modules
09:53:40 Watcher | File changed: ./public/dist/main.bundle.css
09:53:40 Watcher | File changed: ./public/dist/images/logo.png
09:53:40 Watcher | File changed: ./public/dist/main.bundle.js
09:53:40 Watcher | Watching 3 files (browser reload)...
```

#### With this PR:

```
09:51:14 Watcher    | Watching 16 files (server reload)...
09:51:14 Watcher    | Building project Blog...
09:51:19 Watcher    | Terminating app Blog...
09:51:19 Watcher    | Starting Blog...
09:51:19 NodeJS     | Installing dependencies...
09:51:19 NodeJS     | Watching public directory
09:51:19 Server     | (INFO) [Amber 0.6.2] serving application "Blog" at http://0.0.0.0:3000
09:51:19 Server     | (INFO) Server started in development.
09:51:19 Server     | (INFO) Startup Time 00:00:00.000645000
09:51:19 Watcher    | Watching 7 files (browser reload)...
up to date in 7.531s

> blog@0.1.0 watch /home/main/Projects/blog
> webpack -w --config config/webpack/development.js


Webpack is watching the files…

09:51:31 Watcher    | File changed: ./public/dist/main.bundle.css
09:51:31 Watcher    | File changed: ./public/dist/images/logo.png
09:51:31 Watcher    | File changed: ./public/dist/main.bundle.js
09:51:31 Watcher    | Watching 3 files (browser reload)...
```

### Alternate Designs

No

### Benefits

Cleanup `amber watcher` logs

### Possible Drawbacks

No
