### PR TITLE
Update README template

### DIFF
--- a/src/amber/cli/templates/app/README.md.ecr
+++ b/src/amber/cli/templates/app/README.md.ecr
@@ -1,14 +1,13 @@
 # <%= @name %>
 
-A new project using [Amber Framework](https://amberframework.org/)
+<%= @name %> is a new project using [Amber Framework](https://amberframework.org/)
 
 ## Installation
 
-Install back-end and front-end dependencies.
+Install shard dependencies.
 
 ```
 shards install
-npm install
 ```
 
 Configure the `config/environments/development.yml` and set the `database_url` with your credentials to your database.
@@ -23,16 +22,10 @@ amber db create migrate
 
 ### Development
 
-To build crystal files:
+To run amber development server:
 
 ```
 amber watch
-```
-
-To build assets:
-
-```
-npm run watch
 ```
 
 ### Production


### PR DESCRIPTION
### Description of the Change

Currenty `npm install && npm run watch` are embedded inside `amber watch`, so this PR removes those commands from app README template.

### Alternate Designs

When #476 is fixed we would need to add a section explaining about `amber watch` configuration

### Benefits

Shows right commands on README

### Possible Drawbacks

Maybe we neeed to explain that NPM is running inside `amber watch`, WDYT?
