### PR TITLE
Fix woff2 font mime type

### DIFF
--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -569,7 +569,7 @@ module Amber
         "wmx"       => "video/x-ms-wmx",
         "wmz"       => "application/x-ms-wmz",
         "woff"      => "application/font-woff",
-        "woff2"     => "application/font-woff2",
+        "woff2"     => "application/font-woff",
         "wpd"       => "application/vnd.wordperfect",
         "wpl"       => "application/vnd.ms-wpl",
         "wps"       => "application/vnd.ms-works",


### PR DESCRIPTION
This solves error that was being printed in the browser for woff2 fonts:

"Resource interpreted as Font but transferred with MIME type application/font-woff2"
