### PR TITLE
Prevent server side error with invalid base64 csrf token

### DIFF
--- a/spec/amber/router/pipe/csrf_spec.cr
+++ b/spec/amber/router/pipe/csrf_spec.cr
@@ -103,7 +103,7 @@ module Amber
           end
         end
 
-        it "raises a forbidden error for not valid base64 token" do
+        it "raises a forbidden error for an invalid base64 token" do
           csrf = CSRF.new
           request = HTTP::Request.new("PUT", "/")
           context = create_context(request)

--- a/spec/amber/router/pipe/csrf_spec.cr
+++ b/spec/amber/router/pipe/csrf_spec.cr
@@ -102,6 +102,19 @@ module Amber
             csrf.call(context)
           end
         end
+
+        it "raises a forbidden error for not valid base64 token" do
+          csrf = CSRF.new
+          request = HTTP::Request.new("PUT", "/")
+          context = create_context(request)
+
+          context.session["csrf.token"] = "good_token"
+          context.params["_csrf"] = "invalid_token"
+
+          expect_raises Exceptions::Forbidden do
+            csrf.call(context)
+          end
+        end
       end
 
       context "generator" do

--- a/src/amber/router/pipe/csrf.cr
+++ b/src/amber/router/pipe/csrf.cr
@@ -66,14 +66,16 @@ module Amber
 
         def valid_token?(context)
           if request_token(context) && real_session_token(context)
-            decoded_request = Base64.decode(request_token(context).to_s) rescue nil
-            return false if decoded_request.nil? || decoded_request.size != TOKEN_LENGTH * 2
+            decoded_request = Base64.decode(request_token(context).to_s)
+            return false unless decoded_request.size == TOKEN_LENGTH * 2
 
             unmasked = TokenOperations.unmask(decoded_request)
             session_token = Base64.decode(real_session_token(context))
             return Crypto::Subtle.constant_time_compare(unmasked, session_token)
           end
-          return false
+          false
+        rescue Base64::Error
+          false
         end
 
         def token(context) : String

--- a/src/amber/router/pipe/csrf.cr
+++ b/src/amber/router/pipe/csrf.cr
@@ -66,8 +66,8 @@ module Amber
 
         def valid_token?(context)
           if request_token(context) && real_session_token(context)
-            decoded_request = Base64.decode(request_token(context).to_s)
-            return false unless decoded_request.size == TOKEN_LENGTH * 2
+            decoded_request = Base64.decode(request_token(context).to_s) rescue nil
+            return false if decoded_request.nil? || decoded_request.size != TOKEN_LENGTH * 2
 
             unmasked = TokenOperations.unmask(decoded_request)
             session_token = Base64.decode(real_session_token(context))


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

It is possible to trigger a server side error (error code 500) using some wrong csrf token. Exception happens while decoding binary data using [Base64](https://crystal-lang.org/api/0.24.1/Base64.html) module:

```crystal
Base64.decode("different_token") # => Bytes[118, 39, 223, 122, 183, 167, 183, 251, 104, 145, 233]
Base64.decode("invalid_token")   # => Wrong size (Base64::Error)
                                 #       from Base64@Base64::decode<String>:Slice(UInt8)
```

This PR is about to catch such a case and correctly process invalid token (error code 403)

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
