### PR TITLE
move database initializer to `new` command

### DIFF
--- a/src/amber/cli/templates/app/config/initializers/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/initializers/database.cr.ecr
@@ -1,4 +1,4 @@
-<% if @model == "granite" %>
+<% if @model == "granite" -%>
 require "granite_orm/adapter/<%= @database %>"
 
 Granite::ORM.settings.database_url = Amber.settings.database_url

--- a/src/amber/cli/templates/app/config/initializers/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/initializers/database.cr.ecr
@@ -1,5 +1,9 @@
 <% if @model == "granite" %>
+require "granite_orm/adapter/<%= @database %>"
+
 Granite::ORM.settings.database_url = Amber.settings.database_url
+Granite::ORM.settings.logger = Amber.settings.logger
+
 <% else -%>
 require "<%= @database %>"
 require "crecto"
@@ -22,5 +26,5 @@ module Repo
   end
 end
 
-Crecto::DbLogger.set_handler(STDOUT)
+Crecto::DbLogger.set_handler(Amber.settings.logger)
 <% end -%>

--- a/src/amber/cli/templates/app/config/initializers/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/initializers/database.cr.ecr
@@ -1,3 +1,6 @@
+<% if @model == "granite" %>
+Granite::ORM.settings.database_url = Amber.settings.database_url
+<% else -%>
 require "<%= @database %>"
 require "crecto"
 Query = Crecto::Repo::Query
@@ -20,3 +23,4 @@ module Repo
 end
 
 Crecto::DbLogger.set_handler(STDOUT)
+<% end -%>

--- a/src/amber/cli/templates/auth/config/initializers/granite.cr.ecr
+++ b/src/amber/cli/templates/auth/config/initializers/granite.cr.ecr
@@ -1,1 +1,0 @@
-Granite::ORM.settings.database_url = Amber.settings.database_url

--- a/src/amber/cli/templates/migration/granite/config/initializers/granite.cr.ecr
+++ b/src/amber/cli/templates/migration/granite/config/initializers/granite.cr.ecr
@@ -1,1 +1,0 @@
-Granite::ORM.settings.database_url = Amber.settings.database_url


### PR DESCRIPTION
### Description of the Change

This addresses issue https://github.com/amberframework/granite-orm/issues/107

This moves the database initializer to `new`.   There were several users that did not use generators and either copied their models over or created them by hand.  The initializer was not generated for them so it created confusion.

### Alternate Designs

The original thought was that if someone didn't want to use a database, then we shouldn't generate the initializer.  However since the `new` command already assumes an MVC model, it makes sense that this initializer should be created on new instead of when a model is generated.  

### Benefits

This also eliminates some duplicate code between `auth` and `migrate`.

### Possible Drawbacks

If the developer doesn't want to use granite or crectco, an extra file is generated that they will need to remove or change.