### PR TITLE
Convert router's define_action macro to private

### DIFF
--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -45,7 +45,7 @@ module Amber::DSL
       {% end %}
     end
 
-    macro define_action(path, controller, action)
+    private macro define_action(path, controller, action)
       {% if action == :index %}
         get "{{path.id}}", {{controller}}, :index
       {% elsif action == :show %}


### PR DESCRIPTION
Convert router's define_action macro to private.

There does not appear to be a reason why this would be
called outside of where it currently is, and can be private.