### PR TITLE
Fix amber watcher

### DIFF
--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -37,9 +37,6 @@ module Sentry
       elsif !@app_running
         log "Compile time errors detected. Shutting down..."
         exit 1
-      else
-        log "Unknown error occurred, Shutting down..."
-        exit 1
       end
     end
 


### PR DESCRIPTION
### Description of the Change

Currently `amber watcher` stops if an error is found during development, it should stop only if an error is found at begining

A side effect is that an amber background process is never killed so the project keep running silently showing unexpected outputs when you run `amber watch` again.

Good (stopping server if there is any error at beginning of development)

```
➜  forum amber w                             
10:47:48 Watcher    | Watching 36 files (server reload)...
10:47:48 Watcher    | Building project Forum...
Error in src/forum.cr:1: while requiring "../config/*"

require "../config/*"
^

Syntax error in config/routes.cr:45: for empty hashes use '{} of KeyType => ValueType'

{}
^

10:47:49 Watcher    | Compile time errors detected. Shutting down..
```

Bad (stopping if an error is found **during** development, server should keep running, waiting for a possible fix) 

```
10:46:00 Watcher    | File changed: ./config/routes.cr
10:46:00 Watcher    | Watching 1 files (server reload)...
10:46:00 Watcher    | Building project Forum...
10:46:08 Watcher    | Terminating app Forum...
10:46:08 Watcher    | Starting Forum...
10:46:08 Server     | (INFO) [Amber 0.6.3] serving application "Forum" at http://0.0.0.0:3000
10:46:08 Server     | (INFO) Server started in development.
10:46:08 Server     | (INFO) Startup Time 00:00:00.000369000
10:46:08 Watcher    | Watching 7 files (browser reload)...
10:46:11 Request    | Started 2018-01-14 10:46:11 -05:00
10:46:11 Request    | Status: 200  Method: GET  Pipeline: web Format: html
10:46:11 Request    | Requested Url: /
10:46:11 Request    | Time Elapsed: 641.0µs
10:46:11 Headers    | Host: ["0.0.0.0:3000"]
10:46:11 Headers    | Connection: ["keep-alive"]
10:46:11 Headers    | Cache-Control: ["max-age=0"]
10:46:11 Headers    | Upgrade-Insecure-Requests: ["1"]
10:46:11 Headers    | User-Agent: ["Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"]
10:46:11 Headers    | Accept: ["text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8"]
10:46:11 Headers    | DNT: ["1"]
10:46:11 Headers    | Referer: ["http://0.0.0.0:3000/"]
10:46:11 Headers    | Accept-Encoding: ["gzip, deflate"]
10:46:11 Headers    | Accept-Language: ["es,en-US;q=0.9,en;q=0.8,es-419;q=0.7"]
10:46:11 Headers    | Cookie: ["amber.session=eyJfZmxhc2giOiJ7fSIsImNzcmYudG9rZW4iOiIwZnJWbWxXMElfWDdsYkhXTXFtRXhjeTIxcHpuV3V6azdva3NLNXNlTU80In0%3D--Mc%2Bv6uNizy%2Bd2WkMYdNyZexr4f0%3D"]
10:46:11 Cookies    | amber.session: #<HTTP::Cookie:0x564dd94bad20>
10:46:11 Session    | _flash: {}
10:46:11 Session    | csrf.token: 0frVmlW0I_X7lbHWMqmExcy21pznWuzk7oksK5seMO4
10:46:16 Watcher    | File changed: ./config/routes.cr
10:46:16 Watcher    | Watching 1 files (server reload)...
10:46:16 Watcher    | Building project Forum...
Error in src/forum.cr:1: while requiring "../config/*"

require "../config/*"
^

Syntax error in config/routes.cr:45: for empty hashes use '{} of KeyType => ValueType'

{}
^

10:46:17 Watcher    | Unknown error occurred, Shutting down...
```

### Alternate Designs

No

### Benefits

We avoid the need of executing `amber watch` again and again after every code error. Also we can kill amber server properly avoiding unexpected background processes.

### Possible Drawbacks

No
