### PR TITLE
Avoid minor error in 'db status' if there are no migrations (#522)

### DIFF
--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -44,7 +44,12 @@ module Amber::CLI
           when "redo"
             Micrate::Cli.run_redo
           when "status"
-            Micrate::Cli.run_status
+            dir = "./db/migrations"
+            if Dir.exists?(dir)
+              Micrate::Cli.run_status
+            else
+              exit! "Directory #{dir} does not exist. Please run `amber db create migrate` in project root directory."
+            end
           when "version"
             Micrate::Cli.run_dbversion
           else


### PR DESCRIPTION
Small change, according to guidelines in https://github.com/amberframework/amber/issues/522