### PR TITLE
Checks the current path a project name to make sure it doesn't contain a space.

### DIFF
--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -24,7 +24,7 @@ module Amber::CLI
         Amber::CLI.color = !options.no_color?
         full_path_name = File.join(Dir.current, args.name)
         if full_path_name =~ /\s+/
-          CLI.logger.error "Path and project name can't contain a space." 
+          CLI.logger.error "Path and project name can't contain a space."
           CLI.logger.error "Replace spaces with underscores or dashes."
           CLI.logger.error "#{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
           exit 1

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -22,6 +22,11 @@ module Amber::CLI
 
       def run
         Amber::CLI.color = !options.no_color?
+        full_path_name = `pwd`.sub("\n", "") + "/name"
+        if full_path_name.includes?(" ")
+          puts "Error: #{full_path_name} must not contain a space.\nUnderscores are fine though."
+          exit 1
+        end
         name = File.basename(args.name)
         template = Template.new(name, "./#{args.name}")
         template.generate("app", options)

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -22,10 +22,11 @@ module Amber::CLI
 
       def run
         Amber::CLI.color = !options.no_color?
-        full_path_name = File.join(`pwd`.sub("\n", ""), args.name)
-        if full_path_name.includes?(" ")
-          puts "Error:  Path and project name can't contain a space. Underscores are fine though."
-          puts "Error: #{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
+        full_path_name = File.join(Dir.current, args.name)
+        if full_path_name =~ /\s+/
+          CLI.logger.error "Path and project name can't contain a space." 
+          CLI.logger.error "Replace spaces with underscores or dashes."
+          CLI.logger.error "#{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
           exit 1
         end
         name = File.basename(args.name)

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -22,7 +22,7 @@ module Amber::CLI
 
       def run
         Amber::CLI.color = !options.no_color?
-        full_path_name = `pwd`.sub("\n", "") + "/name"
+        full_path_name = File.join(`pwd`.sub("\n", ""), args.name)
         if full_path_name.includes?(" ")
           puts "Error: #{full_path_name} must not contain a space.\nUnderscores are fine though."
           exit 1

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -24,7 +24,8 @@ module Amber::CLI
         Amber::CLI.color = !options.no_color?
         full_path_name = File.join(`pwd`.sub("\n", ""), args.name)
         if full_path_name.includes?(" ")
-          puts "Error: #{full_path_name} must not contain a space.\nUnderscores are fine though."
+          puts "Error:  Path and project name can't contain a space. Underscores are fine though."
+          puts "Error: #{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
           exit 1
         end
         name = File.basename(args.name)


### PR DESCRIPTION
### Description of the Change

Checks pwd and project name to determine if the path is valid or will break.
Exits with error if invalid.


Could I get some input on the error message and formatting?
```
12:02:45 Class      | Error: /Users/isaac/workspace/amber/stupid path/name must not contain a space.
Underscores are fine though.
```