### PR TITLE
Fix spelling of view templates for newly generated app

### DIFF
--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -1,7 +1,7 @@
 <div id="logo" class="col-sm-6"></div>
 <div class="col-sm-6">
   <h2>Welcome to Amber Framework!</h2>
-  <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used too but not sacrificing the speed.</p>
+  <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.</p>
   <div class="list-group">
     <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>
     <a class="list-group-item list-group-item-action" target="_blank" href="https://github.com/veelenga/awesome-crystal">List of Awesome Crystal projects and shards</a>

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -1,7 +1,7 @@
 div#logo.col-sm-6
 div.col-sm-6
   h2 Welcome to Amber Framework!
-  p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used too but not sacrificing the speed.
+  p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.
   div.list-group
     a.list-group-item.list-group-item-action target="_blank" href="https://docs.amberframework.org" Getting Started with Amber Framework
     a.list-group-item.list-group-item-action target="_blank" href="https://github.com/veelenga/awesome-crystal" List of Awesome Crystal projects and shards


### PR DESCRIPTION
### Description of the Change

Changed wording of the view templates
* `index.ecr.ecr`
* `index.slang.ecr`
to fix a typo and modify to proper English grammar. 

Changed welcome sentence from

`Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used too but not sacrificing the speed.`

to

`Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.`

### Alternate Designs

Not Applicable.

### Benefits

This may only be a small wording change but it adds to the overall polish of the already great framework. The first page users see in a newly generated app should probably not contain spelling mistakes.

### Possible Drawbacks

Not Applicable