### PR TITLE
Change slang from master to last release

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -28,7 +28,7 @@ dependencies:
 
   slang:
     github: jeromegn/slang
-    branch: master
+    version: ~> 1.7.1 
 
   redis:
     github: stefanwille/crystal-redis


### PR DESCRIPTION
### Description of the Change
Slang was temporarily pointed to master because the last version didn't work with crystal 0.24.1. 

It's since been updated so I added the right version.