### PR TITLE
Added node_modules to .gitignore

### DIFF
--- a/src/amber/cli/templates/app/.gitignore.ecr
+++ b/src/amber/cli/templates/app/.gitignore.ecr
@@ -9,3 +9,4 @@
 production.yml
 .DS_Store
 /bin/
+/node_modules


### PR DESCRIPTION
### Description of the Change

node_modules are added to the amber/.gitignore but not to the generated project .gitignore.

This is unfortunate as modules are installed differently for osx and linux so if you create a project on one it won't work on the other unless you delete it first and run `npm install` again.

The solution is to add it to the gitignore the same as .shards and lib folders.
