### PR TITLE
Ability to configure 'cors' pipe at initialization (#171)

### DIFF
--- a/spec/amber/router/pipe/cors_spec.cr
+++ b/spec/amber/router/pipe/cors_spec.cr
@@ -4,26 +4,52 @@ module Amber
   module Pipe
     describe CORS do
       context "allowed headers" do
-        pipeline = Pipeline.new
 
+        # Pipeline with default settings
+        pipeline = Pipeline.new
         pipeline.build :cors do
           plug CORS.new
         end
+        pipeline.prepare_pipelines
+
+        # Pipeline with custom settings
+        pipeline_custom = Pipeline.new
+        pipeline_custom.build :cors do
+          plug CORS.new(allow_headers: "max-age")
+        end
+        pipeline_custom.prepare_pipelines
 
         Amber::Server.router.draw :cors do
           options "/test", HelloController, :world
         end
 
-        pipeline.prepare_pipelines
-
         it "should allow a case-insensitive header values" do
-          cors = CORS.new
           request = HTTP::Request.new("OPTIONS", "/test")
           request.headers["Access-Control-Request-Method"] = "OPTIONS"
           request.headers["Access-Control-Request-Headers"] = "cOnTeNt-TyPe"
           response = create_request_and_return_io(pipeline, request)
 
           response.status_code.should eq 200
+        end
+
+        it "allows headers 'accept, content-type' by default" do
+          request = HTTP::Request.new("OPTIONS", "/test")
+          request.headers["Access-Control-Request-Method"] = "OPTIONS"
+          request.headers["Access-Control-Request-Headers"] = "accept"
+          response = create_request_and_return_io(pipeline, request)
+
+          response.status_code.should eq 200
+          response.headers["Access-Control-Allow-Headers"].should eq "accept, content-type"
+        end
+
+        it "can override settings at initialization" do
+          request = HTTP::Request.new("OPTIONS", "/test")
+          request.headers["Access-Control-Request-Method"] = "OPTIONS"
+          request.headers["Access-Control-Request-Headers"] = "max-age"
+          response = create_request_and_return_io(pipeline_custom, request)
+
+          response.status_code.should eq 200
+          response.headers["Access-Control-Allow-Headers"].should eq "max-age"
         end
       end
     end

--- a/src/amber/router/pipe/cors.cr
+++ b/src/amber/router/pipe/cors.cr
@@ -5,12 +5,26 @@ module Amber
       property allow_origin, allow_headers, allow_methods, allow_credentials,
         max_age
 
+      ALLOW_METHODS = %w(GET HEAD POST DELETE OPTIONS PUT PATCH)
+      ALLOW_HEADERS = %w(accept content-type)
+
       def initialize(
         @allow_origin = "*",
-        @allow_headers = "accept, content-type",
-        @allow_methods = "GET, HEAD, POST, DELETE, OPTIONS, PUT, PATCH",
+        @allow_methods = ALLOW_METHODS,
+        @allow_headers = ALLOW_HEADERS,
         @allow_credentials = false,
         @max_age = 0)
+      end
+
+      def initialize(
+        @allow_origin = "*",
+        allow_methods : String = ALLOW_METHODS.join(", "),
+        allow_headers : String = ALLOW_HEADERS.join(", "),
+        @allow_credentials = false,
+        @max_age = 0)
+
+        @allow_methods = allow_methods.split /[\s,]+/
+        @allow_headers = allow_headers.split /[\s,]+/
       end
 
       def call(context : HTTP::Server::Context)
@@ -37,7 +51,7 @@ module Amber
 
           if requested_method = context.request.headers["Access-Control-Request-Method"]
             if allow_methods.includes? requested_method.strip
-              context.response.headers["Access-Control-Allow-Methods"] = allow_methods
+              context.response.headers["Access-Control-Allow-Methods"] = allow_methods.join(", ")
             else
               context.response.status_code = 403
               response = "Method #{requested_method} not allowed."
@@ -47,7 +61,7 @@ module Amber
           if requested_headers = context.request.headers["Access-Control-Request-Headers"]
             requested_headers.split(",").each do |requested_header|
               if allow_headers.includes? requested_header.strip.downcase
-                context.response.headers["Access-Control-Allow-Headers"] = allow_headers
+                context.response.headers["Access-Control-Allow-Headers"] = allow_headers.join(", ")
               else
                 context.response.status_code = 403
                 response = "Headers #{requested_headers} not allowed."

--- a/src/amber/router/pipe/cors.cr
+++ b/src/amber/router/pipe/cors.cr
@@ -23,8 +23,8 @@ module Amber
         @allow_credentials = false,
         @max_age = 0)
 
-        @allow_methods = allow_methods.split /[\s,]+/
-        @allow_headers = allow_headers.split /[\s,]+/
+        @allow_methods = allow_methods.strip.split /[\s,]+/
+        @allow_headers = allow_headers.strip.split /[\s,]+/
       end
 
       def call(context : HTTP::Server::Context)

--- a/src/amber/router/pipe/cors.cr
+++ b/src/amber/router/pipe/cors.cr
@@ -5,12 +5,12 @@ module Amber
       property allow_origin, allow_headers, allow_methods, allow_credentials,
         max_age
 
-      def initialize
-        @allow_origin = "*"
-        @allow_headers = "accept, content-type"
-        @allow_methods = "GET, HEAD, POST, DELETE, OPTIONS, PUT, PATCH"
-        @allow_credentials = false
-        @max_age = 0
+      def initialize(
+        @allow_origin = "*",
+        @allow_headers = "accept, content-type",
+        @allow_methods = "GET, HEAD, POST, DELETE, OPTIONS, PUT, PATCH",
+        @allow_credentials = false,
+        @max_age = 0)
       end
 
       def call(context : HTTP::Server::Context)

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -6,7 +6,7 @@ module Amber
       getter pipeline
       getter valve : Symbol
 
-      def initialize( @valve = :web)
+      def initialize(@valve = :web)
         @pipeline = {} of Symbol => Array(HTTP::Handler)
         @pipeline[@valve] = [] of HTTP::Handler
         @drain = {} of Symbol => (HTTP::Handler | (HTTP::Server::Context ->))

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -6,8 +6,7 @@ module Amber
       getter pipeline
       getter valve : Symbol
 
-      def initialize
-        @valve = :web
+      def initialize( @valve = :web)
         @pipeline = {} of Symbol => Array(HTTP::Handler)
         @pipeline[@valve] = [] of HTTP::Handler
         @drain = {} of Symbol => (HTTP::Handler | (HTTP::Server::Context ->))


### PR DESCRIPTION
Makes 'cors' pipe configurable at initialization.
Also removes one unused variable.
Specs are included.

Other pipes will be modified and added to this PR.
When all pipes are checked, I will follow up with the final comment.

fixes #540 