### PR TITLE
Move "X-Powered-By: Amber" header to its own pipe

### DIFF
--- a/spec/amber/router/pipe/pipeline_spec.cr
+++ b/spec/amber/router/pipe/pipeline_spec.cr
@@ -73,12 +73,6 @@ module Amber
           response.headers["Content-Length"].should eq "0"
           response.body.empty?.should be_true
         end
-
-        it "initializes context with X-Powered-By: Amber" do
-          request = HTTP::Request.new("GET", "/index/faustino")
-          response = create_request_and_return_io(pipeline, request)
-          response.headers["X-Powered-By"].should eq "Amber"
-        end
       end
     end
   end

--- a/spec/amber/router/pipe/powered_by_amber_spec.cr
+++ b/spec/amber/router/pipe/powered_by_amber_spec.cr
@@ -11,13 +11,13 @@ module Amber
         end
 
         Amber::Server.router.draw :web do
-          options "/test", HelloController, :world
+          options "/poweredbyamber", HelloController, :world
         end
 
         pipeline.prepare_pipelines
 
         it "should contain X-Powered-By in response" do
-          request = HTTP::Request.new("OPTIONS", "/test")
+          request = HTTP::Request.new("OPTIONS", "/poweredbyamber")
           response = create_request_and_return_io(pipeline, request)
 
           response.status_code.should eq 200

--- a/spec/amber/router/pipe/powered_by_amber_spec.cr
+++ b/spec/amber/router/pipe/powered_by_amber_spec.cr
@@ -1,0 +1,29 @@
+require "../../../../spec_helper"
+
+module Amber
+  module Pipe
+    describe PoweredByAmber do
+      context "Adds X-Powered-By: Amber to response" do
+        pipeline = Pipeline.new
+
+        pipeline.build :web do
+          plug PoweredByAmber.new
+        end
+
+        Amber::Server.router.draw :web do
+          options "/test", HelloController, :world
+        end
+
+        pipeline.prepare_pipelines
+
+        it "should contain X-Powered-By in response" do
+          request = HTTP::Request.new("OPTIONS", "/test")
+          response = create_request_and_return_io(pipeline, request)
+
+          response.status_code.should eq 200
+          response.headers["X-Powered-By"].should eq "Amber"
+        end
+      end
+    end
+  end
+end

--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -2,6 +2,7 @@ Amber::Server.configure do |app|
   pipeline :web do
     # Plug is the method to use connect a pipe (middleware)
     # A plug accepts an instance of HTTP::Handler
+    plug Amber::Pipe::PoweredByAmber.new
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Logger.new
     plug Amber::Pipe::Session.new
@@ -13,6 +14,7 @@ Amber::Server.configure do |app|
 
   # All static content will run these transformations
   pipeline :static do
+    plug Amber::Pipe::PoweredByAmber.new
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Static.new("./public")
   end

--- a/src/amber/router/pipe/pipeline.cr
+++ b/src/amber/router/pipe/pipeline.cr
@@ -14,7 +14,6 @@ module Amber
       end
 
       def call(context : HTTP::Server::Context)
-        context.response.headers["X-Powered-By"] = "Amber"
         raise Amber::Exceptions::RouteNotFound.new(context.request) if context.invalid_route?
         if context.websocket?
           context.process_websocket_request

--- a/src/amber/router/pipe/powered_by_amber.cr
+++ b/src/amber/router/pipe/powered_by_amber.cr
@@ -1,0 +1,11 @@
+module Amber
+  module Pipe
+    # Adds header "X-Powered-By: Amber" to the response
+    class PoweredByAmber < Base
+
+      def call(context : HTTP::Server::Context)
+        context.response.headers["X-Powered-By"] = "Amber"
+      end
+    end
+  end
+end

--- a/src/amber/router/pipe/powered_by_amber.cr
+++ b/src/amber/router/pipe/powered_by_amber.cr
@@ -1,6 +1,5 @@
 module Amber
   module Pipe
-    # Adds header "X-Powered-By: Amber" to the response
     class PoweredByAmber < Base
 
       def call(context : HTTP::Server::Context)


### PR DESCRIPTION
Moves automatically-added "X-Powered-By: Amber" response header into its own pipe.

Can be enabled/disabled at will, with the enabled state being default to not cause any visible differences compared to previous behavior.