### PR TITLE
remove protected from ClientSocket.broadcast

### DIFF
--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -51,7 +51,7 @@ module Amber
       # ```crystal
       # UserSocket.broadcast("message", "chats_room:1", "msg:new", {"message" => "test"})
       # ```
-      protected def self.broadcast(event : String, topic : String, subject : String, payload : Hash)
+      def self.broadcast(event : String, topic : String, subject : String, payload : Hash)
         if channel = get_topic_channel(WebSockets.topic_path(topic))
           channel.rebroadcast!({
             "event"   => event,


### PR DESCRIPTION
### Description of the Change

I misunderstood the usage of `protected` here, that's the only reason its here.  This method should be callable from anywhere, not from within the `Amber` namespace.  There have already been a few complaints about this in the amber gitter.

### Benefits

Allows `ClientSocket.broadcast` to be callable from anywhere.

### Possible Drawbacks

None
