### PR TITLE
[Authors] Sets the list of authors

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -3,11 +3,7 @@ name: amber
 version: 0.6.4
 
 authors:
-  - Elias Perez <<eliasjpr@gmail.com>>
-  - Isaac Sloan <<isaac@isaacsloan.com>>
-  - Dru Jensen <<drujensen@gmail.com>>
-  - Nick Franken <<shnick@gmail.com>>
-  - Benoit de Chezelles <<benoit.dechezelles@gmail.com>>
+  - Amber Core Team and Contributors
 
 crystal: 0.24.1
 


### PR DESCRIPTION
Generalizes the list of authors to Amber Core Team and Contributors
this lowers maintenance of this list and still attributes everyone who in some way has contributed.
