### PR TITLE
ECR template fixes

### DIFF
--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -12,7 +12,7 @@
     <div class="masthead">
       <div class="container">
         <nav class="nav">
-          <%="<"%>%= render(partial: "layouts/_nav.<%= @language %>") %>
+          <%="<"%>%= render(partial: "layouts/_nav.ecr") %>
         </nav>
       </div>
     </div>

--- a/src/amber/cli/templates/auth/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/{{name}}_controller.cr.ecr
@@ -18,7 +18,7 @@ class <%= class_name %>Controller < ApplicationController
       redirect_to "/profile"
     elsif <%= @name %>
       flash[:danger] = "Could not update Profile!"
-      render("edit.slang")
+      render("edit.<%= @language %>")
     else
       flash[:info] = "Must be logged in"
       redirect_to "/signin"

--- a/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/layouts/+_nav.ecr.ecr
@@ -1,10 +1,10 @@
 <%="<"%>%- if (current_<%= @name %> = context.current_<%= @name %>) %>
-  <a class="nav-item pull-right" href="/signout">Sign Out</a>
+  <a class="nav-item pull-right" href="/signout">| Sign Out</a>
   <%="<"%>%- active = context.request.path == "/profile" ? "active" : "" %>
-  <a class="nav-item pull-right" href="/profile"><%="<"%>%= context.current_<%= @name %>.email %></div>
+  <a class="nav-item <%="<"%>%= active %> pull-right" href="/profile"><%="<"%>%= current_<%= @name %>.email %></div>
 <%="<"%>%- else %>
   <%="<"%>%- active = context.request.path == "/signup" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %> pull-right" href="/signup">Sign Up</a>
+  <a class="nav-item <%="<"%>%= active %> pull-right" href="/signup">| Sign Up</a>
   <%="<"%>%- active = context.request.path == "/signin" ? "active" : "" %>
-  <a class="nav-item <%="<"%>%= active %> pull-right" href="/signin">Sign In</a>
+  <a class="nav-item <%="<"%>%= active %> pull-right" href="/signin">| Sign In</a>
 <%="<"%>%- end %>

--- a/src/amber/cli/templates/auth/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/auth/src/views/{{name}}/edit.ecr.ecr
@@ -8,11 +8,11 @@
   </ul>
 <%="<"%>%- end %>
 
-<%="<"%>%= form(action: "/profile", method: :patch) do %>
+<form action="/profile" method="patch">
   <%="<"%>%= csrf_tag %>
   <div class="form-group">
     <input class="form-control" type="email" name="email" placeholder="Email" value="<%="<"%>%= <%= @name %>.email %>" />
   </div>
   <%="<"%>%= submit("Update", class: "btn btn-primary btn-xs") %>
   <%="<"%>%= link_to("profile", "/profile", class: "btn btn-default btn-xs") %>
-<%="<"%>%- end %>
+</form>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -22,9 +22,7 @@
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
     <div class="checkbox">
-      <%="<"%>%= label(<%=":#{field.name}"%>) do -%>
-        <%="<"%>%= check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>) -%>
-      <%="<"%>%- end %>
+      <%="<"%>%= label(<%=":#{field.name}"%>) { check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>) } -%>
     </div>
 <% when "reference" -%>
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>


### PR DESCRIPTION
### Description of the Change

There were several small bugs found in the ECR templates. 

Note: ECR templates do not support implicit `do end` blocks.  This causes issues with some of the helper methods we have.  A work around was to inline the block.  We can't do this for the form helper though.
