### PR TITLE
Update type of database url setting (#560)

### DIFF
--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -37,7 +37,7 @@ module Amber::Environment
         skip:     [] of String?,
         context:  ["request", "headers", "cookies", "session", "params"] of String?,
       }},
-      database_url: {type: String?, default: nil},
+      database_url: {type: String, default: ""},
       host: {type: String, default: "localhost"},
       name: {type: String, default: "Amber_App"},
       port: {type: Int32, default: 3000},


### PR DESCRIPTION
### Description of the Change

This solves #560 by ensuring we're using type `String` instead of `String | Nil` for the `database_url` setting.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Alternate Designs

Updating the template for `config/initializers/database.cr` to use `Amber.settings.database_url.not_nil!` instead of `Amber.settings.database_url`.

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Applications created using `amber new project -m crecto` compile instead of throwing an error about a type mismatch.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None that I can think of.

<!-- What are the possible side-effects or negative impacts of the code change? -->
