### PR TITLE
Dj/fixes to docker

### DIFF
--- a/src/amber/cli/templates/app/Dockerfile.ecr
+++ b/src/amber/cli/templates/app/Dockerfile.ecr
@@ -1,4 +1,4 @@
-FROM amberframework/amber:<%= Amber::VERSION %>
+FROM amberframework/amber:v<%= Amber::VERSION %>
 
 WORKDIR /app
 

--- a/src/amber/cli/templates/app/Dockerfile.ecr
+++ b/src/amber/cli/templates/app/Dockerfile.ecr
@@ -7,4 +7,6 @@ RUN crystal deps
 
 ADD . /app
 
+RUN rm -rf /app/node_modules
+
 CMD amber watch

--- a/src/amber/cli/templates/app/Dockerfile.ecr
+++ b/src/amber/cli/templates/app/Dockerfile.ecr
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY shard.* /app/
 RUN crystal deps
 
-ADD . /app
+COPY . /app
 
 RUN rm -rf /app/node_modules
 


### PR DESCRIPTION
### Description of the Change

A couple bugs in the `Dockerfile`:

1. The tag has a `v` so the image version requires this.

2. If you run `amber w` before running `docker-compose up`, the `node_modules` from the current OS gets copied to the image.  We need to remove these so that the linux OS based node_modules is properly installed.
