### PR TITLE
show amber database cli commands in help

### DIFF
--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -23,7 +23,20 @@ module Amber::CLI
       end
 
       class Help
-        caption "# Performs database maintenance tasks"
+        header <<-EOS
+          Performs database migrations and maintenance tasks. Powered by micrate (https://github.com/juanedi/micrate)
+
+        Commands:
+          drop      # Drops the database
+          create    # Creates the database
+          migrate   # Migrate the database to the most recent version available
+          rollback  # Roll back the database version by 1
+          redo      # Re-run the latest database migration
+          status    # dump the migration status for the current database
+          version   # Print the current version of the database
+          seed      # Initialize the database with seed data
+        EOS
+        caption "# Performs database migrations and maintenance tasks"
       end
 
       def run
@@ -53,7 +66,7 @@ module Amber::CLI
           when "version"
             Micrate::Cli.run_dbversion
           else
-            Micrate::Cli.print_help
+            exit! help: true, error: false
           end
         end
       rescue e : Micrate::UnorderedMigrationsException


### PR DESCRIPTION
### Description of the Change

Simple help ouput fix here.

I was just giving Amber a go for the first time this afternoon (really impressed so far!) and ran into an issue when migrating. The help output from the CLI was a little confusing, as the default micrate options don't line up 100% with Amber's CLI database command options (i.e. `dbversion` and `create`). The purpose of this PR is to provide the correct available commands when `amber db help` is invoked.

### Alternate Designs

N/A

### Benefits

This should help reduce any confusion new users might have over the amber vs micrate database options when using the CLI.

### Possible Drawbacks

None that I am aware of, aside from the fact that any lower-level Micrate command options that might be added in the future would be concealed from the user.