### PR TITLE
Pull pipe specs one level up

### DIFF
--- a/spec/amber/pipes/cors_spec.cr
+++ b/spec/amber/pipes/cors_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber
   module Pipe

--- a/spec/amber/pipes/csrf_spec.cr
+++ b/spec/amber/pipes/csrf_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber
   module Pipe

--- a/spec/amber/pipes/error_spec.cr
+++ b/spec/amber/pipes/error_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber
   module Pipe

--- a/spec/amber/pipes/flash_spec.cr
+++ b/spec/amber/pipes/flash_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 require "json"
 
 module Amber

--- a/spec/amber/pipes/pipeline_spec.cr
+++ b/spec/amber/pipes/pipeline_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber
   module Pipe

--- a/spec/amber/pipes/powered_by_amber_spec.cr
+++ b/spec/amber/pipes/powered_by_amber_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber
   module Pipe

--- a/spec/amber/pipes/reload_spec.cr
+++ b/spec/amber/pipes/reload_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 class FakeEnvironment < Amber::Environment::Env
   def development?

--- a/spec/amber/pipes/session_spec.cr
+++ b/spec/amber/pipes/session_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber
   module Pipe

--- a/spec/amber/pipes/static_spec.cr
+++ b/spec/amber/pipes/static_spec.cr
@@ -1,5 +1,5 @@
 require "../../../spec_helper"
-require "../../../support/helpers/router_helper"
+require "../../support/helpers/router_helper"
 
 include RouterHelper
 


### PR DESCRIPTION
This change accompanies recent move of pipes from src/amber/router/pipe/ to
src/amber/pipes/. Now the specs are in spec/amber/pipes/ for uniformity.
