### PR TITLE
Set default error content_type to text/html

### DIFF
--- a/src/amber/cli/templates/error/src/handlers/error.cr.ecr
+++ b/src/amber/cli/templates/error/src/handlers/error.cr.ecr
@@ -2,7 +2,7 @@ module Amber
   module Pipe
     # The Error Handler catches RouteNotFound and returns a 404.  It will
     # response based on the `Accepts` header as JSON or HTML.  It also catches
-    # any runtime Exceptions and returns a backtrace in text/plain format.
+    # any runtime Exceptions and returns a backtrace in text/html format.
     class Error < Base
       def call(context : HTTP::Server::Context)
         begin

--- a/src/amber/controller/error.cr
+++ b/src/amber/controller/error.cr
@@ -12,9 +12,7 @@ module Amber::Controller
     end
 
     def internal_server_error
-      # TODO: #inspect_with_backtrace doesn't seem to work in 0.24.1
-      # "ERROR: #{@ex.inspect_with_backtrace}"
-      response_format("ERROR: #{@ex.message}")
+      response_format("ERROR: #{@ex.inspect_with_backtrace}")
     end
 
     def forbidden
@@ -34,7 +32,7 @@ module Amber::Controller
       when "application/json"
         {"error": message}.to_json
       when "text/html"
-        "<html><body>#{message}</body></html>"
+        "<html><body><pre>#{message}</pre></body></html>"
       else
         message
       end

--- a/src/amber/controller/error.cr
+++ b/src/amber/controller/error.cr
@@ -12,10 +12,9 @@ module Amber::Controller
     end
 
     def internal_server_error
-      context.response.content_type = "text/plain"
       # TODO: #inspect_with_backtrace doesn't seem to work in 0.24.1
       # "ERROR: #{@ex.inspect_with_backtrace}"
-      "ERROR: #{@ex.message}"
+      response_format("ERROR: #{@ex.message}")
     end
 
     def forbidden
@@ -26,7 +25,7 @@ module Amber::Controller
       if context.request.headers["Accept"]?
         request.headers["Accept"].split(",").first
       else
-        "text/plain"
+        "text/html"
       end
     end
 


### PR DESCRIPTION
### Description of the Change

Currently, default error controller is [showing this](https://gitter.im/amberframework/amber?at=5a6623bf0ad3e04b1b549cef):

```
<!-- Code injected by Amber Framework -->
<script type="text/javascript">
  // <![CDATA[  <-- For SVG support
  if ('WebSocket' in window) {
    (function() {
      function refreshCSS() {
        console.log('Reloading CSS...');
        var sheets = [].slice.call(document.getElementsByTagName('link'));
        var head = document.getElementsByTagName('head')[0];
        for (var i = 0; i < sheets.length; ++i) {
          var elem = sheets[i];
          var rel = elem.rel;
          if (elem.href && typeof rel != 'string' || rel.length == 0 || rel.toLowerCase() == 'stylesheet') {
            head.removeChild(elem);
            var url = elem.href.replace(/(&|\?)_cacheOverride=\d+/, '');
            elem.href = url + (url.indexOf('?') >= 0 ? '&' : '?') + '_cacheOverride=' + (new Date().valueOf());
            head.appendChild(elem);
          }
        }
      }
      var protocol = window.location.protocol === 'http:' ? 'ws://' : 'wss://';
      var address = protocol + window.location.host + '/3ud0vr';
      var socket = new WebSocket(address);
      socket.onmessage = function(msg) {
        if (msg.data == 'reload') {
          window.location.reload();
        } else if (msg.data == 'refreshcss') {
          refreshCSS();
        }
      };
      socket.onclose = function() {
        console.log('Conection closed!');
        setTimeout(function() {
            window.location.reload();
        }, 1000);
      }
      console.log('Live reload enabled.');
    })();
  }
  // ]]>
</script>
ERROR: Invalid Int32:
```

With this change will show this:

![screenshot_20180123_132440](https://user-images.githubusercontent.com/3067335/35293127-c604dc2e-0040-11e8-8dc6-e689be0c39e3.png)


### Alternate Designs

This is happening because `context.format == "html"` is checked before `content_type = "text/plain"`, so maybe we can fix this, adding INJECTED_CODE after all pipes are processed, even `Amber::Pipe::Error`.

Also we can generate an error handler with `amber generate error` but it needs some extra user action.

However injecting code reload script has some benefits, see below:

### Benefits

Sometimes, an error is shown when a database query fail or a parameter is invalid, then if the output is `text/plain` you will need to reload your browser manually.

This PR, fix this small detail, when your webapp show an error you just need to fix your code and the browser reload this automatically.

### Possible Drawbacks

Console tools like `curl` will get the `INJECTED_CODE` plus other body content.
