### PR TITLE
Rename extensions

### DIFF
--- a/spec/amber/extensions/http_spec.cr
+++ b/spec/amber/extensions/http_spec.cr
@@ -1,0 +1,13 @@
+require "../../../spec_helper"
+
+module Amber::Extensions
+  describe HTTPServerContext do
+    it "client_ip should exist and be nil" do
+      request = HTTP::Request.new("GET", "/")
+      io = IO::Memory.new
+      response = HTTP::Server::Response.new(io)
+      context = HTTP::Server::Context.new(request, response)
+      context.client_ip.should be_nil
+    end
+  end
+end

--- a/spec/amber/extensions/http_spec.cr
+++ b/spec/amber/extensions/http_spec.cr
@@ -2,7 +2,7 @@ require "../../../spec_helper"
 
 module Amber::Extensions
   describe HTTPServerContext do
-    it "client_ip should exist and be nil" do
+    it "defaults client_ip to nil" do
       request = HTTP::Request.new("GET", "/")
       io = IO::Memory.new
       response = HTTP::Server::Response.new(io)

--- a/spec/amber/extensions/number_spec.cr
+++ b/spec/amber/extensions/number_spec.cr
@@ -1,7 +1,7 @@
 require "../../../spec_helper"
 
 module Amber::Extensions
-  describe NumberExtension do
+  describe Number do
     it "negative number test" do
       (-5.542_3).negative?.should eq(true)
     end

--- a/spec/amber/extensions/string_spec.cr
+++ b/spec/amber/extensions/string_spec.cr
@@ -1,7 +1,7 @@
 require "../../../spec_helper"
 
 module Amber::Extensions
-  describe StringExtension do
+  describe String do
     it "returns true on valid email address" do
       "info@burakdemirtas.org".email?.should eq(true)
       "info@crystal-lang.com".email?.should eq(true)

--- a/src/amber/extensions/core.cr
+++ b/src/amber/extensions/core.cr
@@ -4,13 +4,13 @@ require "../support/locale_formats"
 # We are patching the String class and Number struct to extend the predicates
 # available. This will allow to add friendlier methods for validation cases.
 class String
-  include Amber::Extensions::StringExtension
+  include Amber::Extensions::String
 end
 
 abstract struct Number
-  include Amber::Extensions::NumberExtension
+  include Amber::Extensions::Number
 end
 
 class HTTP::Server::Context
-  include Amber::Extensions::HTTPServerContextExtension
+  include Amber::Extensions::HTTPServerContext
 end

--- a/src/amber/extensions/http.cr
+++ b/src/amber/extensions/http.cr
@@ -1,6 +1,6 @@
 module Amber
   module Extensions
-    module HTTPServerContextExtension
+    module HTTPServerContext
       property client_ip : Socket::IPAddress?
     end
   end

--- a/src/amber/extensions/number.cr
+++ b/src/amber/extensions/number.cr
@@ -1,6 +1,6 @@
 module Amber
   module Extensions
-    module NumberExtension
+    module Number
       # the positive number validation
       def positive?
         self.sign === 1

--- a/src/amber/extensions/string.cr
+++ b/src/amber/extensions/string.cr
@@ -1,6 +1,6 @@
 module Amber
   module Extensions
-    module StringExtension
+    module String
       def str?
         self.is_a? String
       end


### PR DESCRIPTION
- Rename Amber::Extensions::[Type]Extension into Amber::Extensions::[Type]
  (This makes it uniform with other things in Amber, e.g. pipes are named
   Amber::Pipe::[Name], not Amber::Pipe::[Name]Pipe.)
- Rename files accordingly as well
- Add test for HTTP extensions
