### PR TITLE
Add handler of */* requested response

### DIFF
--- a/spec/amber/controller/respond_with_spec.cr
+++ b/spec/amber/controller/respond_with_spec.cr
@@ -14,6 +14,14 @@ module Amber::Controller
         context.response.status_code.should eq 200
       end
 
+      it "respond_with html as default option with */* header" do
+        expected_result = "<html><body><h1>Elorest <3 Amber</h1></body></html>"
+        context.request.headers["Accept"] = "*/*"
+        ResponsesController.new(context).index.should eq expected_result
+        context.response.headers["Content-Type"].should eq "text/html"
+        context.response.status_code.should eq 200
+      end
+
       it "respond_with html" do
         expected_result = "<html><body><h1>Elorest <3 Amber</h1></body></html>"
         context.request.headers["Accept"] = "text/html"
@@ -25,6 +33,14 @@ module Amber::Controller
       it "responds with json" do
         expected_result = %({"type":"json","name":"Amberator"})
         context.request.headers["Accept"] = "application/json"
+        ResponsesController.new(context).index.should eq expected_result
+        context.response.headers["Content-Type"].should eq "application/json"
+        context.response.status_code.should eq 200
+      end
+
+      it "responds with json having */* at end" do
+        expected_result = %({"type":"json","name":"Amberator"})
+        context.request.headers["Accept"] = "application/json;*/*"
         ResponsesController.new(context).index.should eq expected_result
         context.response.headers["Content-Type"].should eq "application/json"
         context.response.status_code.should eq 200

--- a/spec/amber/controller/respond_with_spec.cr
+++ b/spec/amber/controller/respond_with_spec.cr
@@ -40,7 +40,7 @@ module Amber::Controller
 
       it "responds with json having */* at end" do
         expected_result = %({"type":"json","name":"Amberator"})
-        context.request.headers["Accept"] = "application/json;*/*"
+        context.request.headers["Accept"] = "application/json,*/*"
         ResponsesController.new(context).index.should eq expected_result
         context.response.headers["Content-Type"].should eq "application/json"
         context.response.status_code.should eq 200
@@ -116,6 +116,14 @@ module Amber::Controller
         context.request.path = "/response/1.texas"
         ResponsesController.new(context).index.should eq expected_result
         context.response.headers["Content-Type"].should eq "application/json"
+        context.response.status_code.should eq 200
+      end
+
+      it "responds html as default with invalid extension but having */* at end" do
+        expected_result = "<html><body><h1>Elorest <3 Amber</h1></body></html>"
+        context.request.headers["Accept"] = "unsupported/extension,*/*"
+        ResponsesController.new(context).index.should eq expected_result
+        context.response.headers["Content-Type"].should eq "text/html"
         context.response.status_code.should eq 200
       end
     end

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -52,6 +52,7 @@ module Amber::Controller::Helpers
         raise "You must define at least one response_type." if @available_responses.empty?
         # NOTE: If only one response is requested don't return something else.
         @requested_responses << @available_responses.keys.first if @requested_responses.size != 1
+        @requested_responses = @available_responses.keys if @requested_responses.includes?("*/*")
         @requested_responses.find do |resp|
           @available_responses.keys.includes?(resp)
         end

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -50,9 +50,12 @@ module Amber::Controller::Helpers
 
       private def select_type
         raise "You must define at least one response_type." if @available_responses.empty?
-        # NOTE: If only one response is requested don't return something else.
-        @requested_responses << @available_responses.keys.first if @requested_responses.size != 1
-        @requested_responses = @available_responses.keys if @requested_responses.includes?("*/*")
+        # NOTE: If */* is requested - make all available, but if only one response is requested don't return something else
+        if @requested_responses.includes?("*/*")
+          @requested_responses = @available_responses.keys
+        elsif @requested_responses.size != 1
+          @requested_responses << @available_responses.keys.first
+        end
         @requested_responses.find do |resp|
           @available_responses.keys.includes?(resp)
         end

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -50,10 +50,8 @@ module Amber::Controller::Helpers
 
       private def select_type
         raise "You must define at least one response_type." if @available_responses.empty?
-        # NOTE: If */* is requested - make all available, but if only one response is requested don't return something else
-        if @requested_responses.includes?("*/*")
-          @requested_responses = @available_responses.keys
-        elsif @requested_responses.size != 1
+        # NOTE: If only one response is requested or */* is present don't return anything else.
+        if @requested_responses.size != 1 || @requested_responses.includes?("*/*")
           @requested_responses << @available_responses.keys.first
         end
         @requested_responses.find do |resp|


### PR DESCRIPTION
### Description of the Change

Adding just a single line to response helpers:

```crystal
@requested_responses = @available_responses.keys if @requested_responses.includes?("*/*")
```

Makes all types of responses available if "*/*" is present in requested responses, so fixing issue #584: interacting with APIs built in amber by other clients like `wget` or `curl` or etc is now available

### Benefits

Fixes #584, so our loved amber is a bit less buggy now and we can use it when creating, for example, JSON APIs
