### PR TITLE
Add 'logger' to Amber::Controller::Base

### DIFF
--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -42,6 +42,10 @@ module Amber::Controller
       it "has a session id" do
         controller.session.id.not_nil!.size.should eq 36
       end
+
+      it "has logger" do
+        controller.logger.class.should eq Amber::Environment::Logger
+      end
     end
   end
 end

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -15,6 +15,8 @@ module Amber::Controller
     protected getter context : HTTP::Server::Context
     protected getter params : Amber::Validators::Params
 
+    delegate :logger, to: Amber.settings
+
     delegate :client_ip,
       :cookies,
       :delete?,


### PR DESCRIPTION
It seems like it would be useful to have `logger` (rather than `Amber.logger`) directly available in controller and views.

This patch does it and adds a test for it.