### PR TITLE
Make valid? return false on missing field

### DIFF
--- a/spec/amber/validations/base_rule_spec.cr
+++ b/spec/amber/validations/base_rule_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Validators
   describe BaseRule do

--- a/spec/amber/validations/optional_rule_spec.cr
+++ b/spec/amber/validations/optional_rule_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Validators
   describe OptionalRule do

--- a/spec/amber/validations/params_spec.cr
+++ b/spec/amber/validations/params_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Validators
   describe Params do
@@ -88,9 +88,7 @@ module Amber::Validators
           required("nonexisting") { |v| !v.nil? }
         end
 
-        expect_raises Exceptions::Validator::InvalidParam do
-          validator.valid?
-        end
+        validator.valid?.should be_false
       end
 
       it "returns true with valid fields" do


### PR DESCRIPTION
When one calls params.valid?, before this patch the following happens:

1) If required param was provided, but does not pass validation, return value is false (this is correct)
2) If required param was not provided at all, valid? raises an exception (this is incorrect, should return false without raising)

With this patch, calling params.valid? returns false as expected.

Tests are also fixed to behave accordingly. (It is interesting that the description of an existing test was correct, but the expectation in it needed to be fixed.)

Also some excess "../" were fixed.