### PR TITLE
Test Errno by code rather than description

### DIFF
--- a/src/amber/server/server.cr
+++ b/src/amber/server/server.cr
@@ -74,7 +74,7 @@ module Amber
           server.listen(settings.port_reuse)
           exit
         rescue e : Errno
-          if e.message == "accept: Too many open files"
+          if e.errno == Errno::EMFILE
             logger.error e.message
             logger.info "Restarting server..."
             sleep 1


### PR DESCRIPTION
Errno::EMFILE corresponds to errno 24, which corresponds to the current 'accept: Too many open files'.