### PR TITLE
Use Helpers.run to have a live output

### DIFF
--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -35,11 +35,11 @@ module Amber::CLI::Helpers
     File.write("./config/application.cr", application.gsub("require \"amber\"", replacement))
   end
 
-  def self.run(command, wait = true)
+  def self.run(command, wait = true, shell = true)
     if wait
-      Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      Process.run(command, shell: shell, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
     else
-      Process.new(command, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      Process.new(command, shell: shell, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
     end
   end
 end

--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -34,4 +34,8 @@ module Amber::CLI::Helpers
     REQUIRES
     File.write("./config/application.cr", application.gsub("require \"amber\"", replacement))
   end
+
+  def self.run(command)
+    Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+  end
 end

--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -35,7 +35,11 @@ module Amber::CLI::Helpers
     File.write("./config/application.cr", application.gsub("require \"amber\"", replacement))
   end
 
-  def self.run(command)
-    Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+  def self.run(command, wait = true)
+    if wait
+      Process.run(command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+    else
+      Process.new(command, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+    end
   end
 end

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -1,3 +1,5 @@
+require "./helpers"
+
 module Sentry
   class ProcessRunner
     property processes = [] of Process
@@ -76,17 +78,17 @@ module Sentry
 
     private def build_app_process
       log "Building project #{project_name}..."
-      Process.run(@build_command, shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      Amber::CLI::Helpers.run(@build_command)
     end
 
     private def create_watch_process
       log "Starting #{project_name}..."
-      Process.new(@run_command, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      Amber::CLI::Helpers.run(@run_command, wait: false, shell: false)
     end
 
     private def create_npm_process
       node_log "Installing dependencies..."
-      Process.new("npm install --loglevel=error && npm run watch", shell: true, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      Amber::CLI::Helpers.run("npm install --loglevel=error && npm run watch", wait: false)
       node_log "Watching public directory"
     end
 

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -32,13 +32,15 @@ module Sentry
     # Compiles and starts the application
     def start_app
       build_result = build_app_process
-      if build_result && build_result.success?
-        stop_all_processes
-        create_all_processes
-        @app_running = true
-      elsif !@app_running
-        log "Compile time errors detected. Shutting down..."
-        exit 1
+      if build_result.is_a? Process:Status
+        if build_result.success?
+          stop_all_processes
+          create_all_processes
+          @app_running = true
+        elsif !@app_running
+          log "Compile time errors detected. Shutting down..."
+          exit 1
+        end
       end
     end
 

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -71,7 +71,8 @@ module Sentry
     end
 
     private def create_all_processes
-      @processes << create_watch_process
+      process = create_watch_process
+      @processes << process if process.is_a? Process::Status
       unless @npm_process
         create_npm_process
         @npm_process = true

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -72,7 +72,7 @@ module Sentry
 
     private def create_all_processes
       process = create_watch_process
-      @processes << process if process.is_a? Process::Status
+      @processes << process if process.is_a? Process
       unless @npm_process
         create_npm_process
         @npm_process = true

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -32,7 +32,7 @@ module Sentry
     # Compiles and starts the application
     def start_app
       build_result = build_app_process
-      if build_result.is_a? Process:Status
+      if build_result.is_a? Process::Status
         if build_result.success?
           stop_all_processes
           create_all_processes

--- a/src/amber/cli/templates/template.cr
+++ b/src/amber/cli/templates/template.cr
@@ -1,6 +1,6 @@
 require "teeplate"
 require "random/secure"
-require "../helpers/helpers.cr"
+require "../helpers/helpers"
 require "./app"
 require "./migration"
 require "./crecto_migration"
@@ -47,7 +47,7 @@ module Amber::CLI
           App.new(name, options.d, options.t, options.m).render(directory, list: true, color: true)
           if options.deps?
             puts "Installing Dependencies"
-            puts `cd #{name} && crystal deps update`
+            Helpers.run("cd #{name} && shards update")
           end
         end
       when "migration"


### PR DESCRIPTION
### Description of the Change

Currently, when `--deps` flag is used we need to wait for process to be finished to be able to see `shards update` output.

With this change the `shards update` output is printed immediately 

### Alternate Designs

Not using `Helpers.run` but local method.

I think `Helpers.run` is better because can be shared in other features like process runner, avoiding duplicate code.

### Benefits

`shards update` output is printed immediately and reduce duplicate code

### Possible Drawbacks

No
