### PR TITLE
Fix slang indentation issues

### DIFF
--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -15,9 +15,9 @@ html
           == render(partial: "layouts/_nav.slang")
     div.container
       div.row
-      - flash.each do |key, value|
-        div class="alert alert-#{ key }"
-          p = flash[key]
+        - flash.each do |key, value|
+          div class="alert alert-#{key}"
+            p = flash[key]
       div.row
         div.col-sm-12.main
           == content

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -17,8 +17,8 @@
 
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
   <div class="form-group">
-<% case field.type -%>
-<% when "text" -%>
+<% case field.type
+   when "text" -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
     <div class="checkbox">

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -17,8 +17,8 @@
 
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
   <div class="form-group">
-<% case field.type
-   when "text" -%>
+<% case field.type -%>
+<% when "text" -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
     <div class="checkbox">

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -1,7 +1,7 @@
 - if <%= @model == "crecto" ? "changeset" : @name %>.errors
   ul.errors
-  - <%= @model == "crecto" ? "changeset" : @name %>.errors.each do |error|
-    li = error.to_s
+    - <%= @model == "crecto" ? "changeset" : @name %>.errors.each do |error|
+      li = error.to_s
 
 == form(action: "/<%= @name -%>s/#{<%= @name -%>.id.to_s}", method: <%= @name %>.id ? :patch : :post) do
   == csrf_tag

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -7,19 +7,19 @@
   == csrf_tag
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
   div.form-group
-<% case field.type
-   when "text" -%>
-  == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")
-<% when "boolean" -%>
-  div.checkbox
-    == label(<%=":#{field.name}"%>) do
-      == check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>)
-<% when "reference" -%>
+  <% case field.type -%>
+  <% when "text" -%>
+    == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")
+  <% when "boolean" -%>
+    div.checkbox
+      == label(<%=":#{field.name}"%>) do
+        == check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>)
+  <% when "reference" -%>
     == label(<%=":#{field.name}"%>)
     == select_field(name: "<%= field.name %>_id", collection: <%= field.name.capitalize %>.all.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control")
-<% else -%>
-  == text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control")
-<% end -%>
+  <% else -%>
+    == text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control")
+  <% end -%>
 <% end -%>
   == submit("Submit", class: "btn btn-primary btn-xs")
   == link_to("back", "/<%= @name %>s", class: "btn btn-default btn-xs")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -7,8 +7,8 @@
   == csrf_tag
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
   div.form-group
-  <% case field.type -%>
-  <% when "text" -%>
+  <% case field.type
+     when "text" -%>
     == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")
   <% when "boolean" -%>
     div.checkbox

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -7,18 +7,18 @@ div.table-responsive
   table.table.table-striped
     thead
       tr
-<% @fields.reject{|f| f.hidden }.each do |field| -%>
+        <% @fields.reject{|f| f.hidden }.each do |field| -%>
         th <%= field.name.capitalize %>
-<% end -%>
+        <% end -%>
         th Actions
     tbody
-    - <%= @name %>s.each do |<%= @name %>|
-      tr
-<% @fields.reject{|f| f.hidden }.each do |field| -%>
-        td = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
-<% end -%>
-        td
-          span
-            == link_to("read", "/<%= @name %>s/#{<%= @name %>.id}", class: "btn btn-success btn-xs")
-            == link_to("edit", "/<%= @name %>s/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
-            == link_to("delete", "/<%= @name %>s/#{ <%= @name %>.id }?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');")
+      - <%= @name %>s.each do |<%= @name %>|
+        tr
+          <% @fields.reject{|f| f.hidden }.each do |field| -%>
+          td = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
+          <% end -%>
+          td
+            span
+              == link_to("read", "/<%= @name %>s/#{<%= @name %>.id}", class: "btn btn-success btn-xs")
+              == link_to("edit", "/<%= @name %>s/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
+              == link_to("delete", "/<%= @name %>s/#{ <%= @name %>.id }?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');")


### PR DESCRIPTION
### Description of the Change

I found some issues in slang templates:

![screenshot_20180131_145546](https://user-images.githubusercontent.com/3067335/35644398-d29ce48e-0696-11e8-866f-9704e62f81ea.png)

![screenshot_20180131_145728](https://user-images.githubusercontent.com/3067335/35644493-102e6ea8-0697-11e8-940f-61ab1bb01db2.png)

![screenshot_20180131_145814](https://user-images.githubusercontent.com/3067335/35644539-2ad7614c-0697-11e8-8ad3-4c2784033974.png)

![screenshot_20180131_150616](https://user-images.githubusercontent.com/3067335/35644913-4a46823c-0698-11e8-8430-747f18e0aabd.png)

This ^ happens because slang renders same level ignoring internal code block spaces, so we must indent code blocks too.  

### Alternate Designs

No

### Benefits

Outputs good HTML

### Possible Drawbacks

No
