### PR TITLE
add amber target to shard.yml

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -12,6 +12,9 @@ targets:
   <%= @name %>:
     main: src/<%= @name %>.cr
 
+  amber:
+    main: lib/amber/src/amber/cli.cr
+
 dependencies:
   amber:
     github: amberframework/amber


### PR DESCRIPTION
### Description of the Change

This fixes issue #582 

To create a local binary, run `shards build amber`

### Benefits

This provides a local binary version of amber.  This allows for older versions of amber to still be used.

### Possible Drawbacks

By having the amber target, this requires all the shards that amber depends on to exist in the project.
