### PR TITLE
Remove 'require' for ORM shard

### DIFF
--- a/spec/support/fixtures/cli_fixtures.cr
+++ b/spec/support/fixtures/cli_fixtures.cr
@@ -55,8 +55,6 @@ module CLIFixtures
 
   def expected_post_model
     <<-MODEL
-    require "granite_orm/adapter/pg"
-
     class Post < Granite::ORM::Base
       adapter pg
       table_name posts

--- a/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
@@ -1,5 +1,3 @@
-require "granite_orm/adapter/<%= @database %>"
-
 class <%= class_name %> < Granite::ORM::Base
   adapter <%= @database %>
   <%= "table_name #{table_name}" %>


### PR DESCRIPTION
The 'require' is no longer needed in model template because it is
already added to config/initializers/database.cr at the time of
app creation.