### PR TITLE
Quartz secure smtp upgrades

### DIFF
--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -35,6 +35,10 @@ session:
   store: signed_cookie
   expires: 0
 
+smtp:
+  enabled: false
+
+
 secrets:
   description: Store your development secrets credentials and settings here.
 

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -34,6 +34,12 @@ session:
   key: amber.session
   store: signed_cookie
   expires: 0
+smtp:
+  host: smtp.sendgrid.com
+  port: 25
+  tls: true
+  username: api_key
+  enabled: false
 
 secrets:
   description: Store your production secrets credentials and settings here.

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -34,6 +34,8 @@ session:
   key: amber.session
   store: signed_cookie
   expires: 0
+smtp:
+  enabled: false
 
 secrets:
   description: Store your development secrets credentials and settings here.

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -33,7 +33,7 @@ dependencies:
 
   quartz_mailer:
     github: amberframework/quartz-mailer
-    version: ~> 0.5.0
+    version: ~> 0.5.1
 
   jasper_helpers:
     github: amberframework/jasper-helpers

--- a/src/amber/cli/templates/mailer/config/initializers/mailer.cr.ecr
+++ b/src/amber/cli/templates/mailer/config/initializers/mailer.cr.ecr
@@ -1,8 +1,19 @@
 Quartz.config do |c|
+  # Use to disable/enable attempting to send emails
+  c.smtp_enabled = false
+
+  c.logger = Amber.settings.logger.dup
+  c.logger.progname = "Email"
+
   # Example config for use with mailinator
   # c.smtp_address = "127.0.0.1"
   # c.smtp_port    = 1025
-  # c.logger = Amber.settings.logger.dup
 
-  # c.smtp_enabled = true
+  # Example config for use with Sendgrid
+  # c.smtp_address = "smtp.sendgrid.net"
+  # c.smtp_port    = 587
+  # c.username     = "apikey"
+  # c.password     = "SG.000000000000000000000000000000000000000000000000000000000000000000"
+  # c.use_tls  = true
+  # c.use_authentication = true
 end

--- a/src/amber/cli/templates/mailer/config/initializers/mailer.cr.ecr
+++ b/src/amber/cli/templates/mailer/config/initializers/mailer.cr.ecr
@@ -1,19 +1,14 @@
 Quartz.config do |c|
-  # Use to disable/enable attempting to send emails
-  c.smtp_enabled = false
+  c.smtp_enabled = Amber.settings.smtp.enabled
 
   c.logger = Amber.settings.logger.dup
   c.logger.progname = "Email"
 
-  # Example config for use with mailinator
-  # c.smtp_address = "127.0.0.1"
-  # c.smtp_port    = 1025
+  c.smtp_address = ENV["SMTP_ADDRESS"]?  || Amber.settings.smtp.host
+  c.smtp_port    = ENV["SMTP_PORT"]?     || Amber.settings.smtp.port
+  c.username     = ENV["SMTP_USERNAME"]? || Amber.settings.smtp.username
+  c.password     = ENV["SMTP_PASSWORD"]? || Amber.settings.smtp.password
 
-  # Example config for use with Sendgrid
-  # c.smtp_address = "smtp.sendgrid.net"
-  # c.smtp_port    = 587
-  # c.username     = "apikey"
-  # c.password     = "SG.000000000000000000000000000000000000000000000000000000000000000000"
-  # c.use_tls  = true
-  # c.use_authentication = true
+  c.use_tls = ! c.password.blank?
+  c.use_authentication = ! c.password.blank?
 end

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -10,7 +10,7 @@ module Amber::Environment
       skip: Array(String?),
       context: Array(String?))
 
-    alias Value = String | Int32 | Bool | Nil
+    alias SettingValue = String | Int32 | Bool | Nil
 
     struct SMTPSettings
       property host = "127.0.0.1"
@@ -20,7 +20,7 @@ module Amber::Environment
       property password = ""
       property tls = false
 
-      def self.from_hash(settings = {} of String => Value) : self
+      def self.from_hash(settings = {} of String => SettingValue) : self
         i = new
         i.host     = settings["host"]?     ? settings["host"].as String     : i.host
         i.port     = settings["port"]?     ? settings["port"].as Int32      : i.port
@@ -80,9 +80,9 @@ module Amber::Environment
       ssl_key_file: {type: String?, default: nil},
       ssl_cert_file: {type: String?, default: nil},
       smtp: {
-        type:    Hash(String, Value),
+        type:    Hash(String, SettingValue),
         getter:  false,
-        default: Hash(String, Value){
+        default: Hash(String, SettingValue){
           "enabled" => false,
         },
       }

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -10,8 +10,9 @@ module Amber::Environment
       skip: Array(String?),
       context: Array(String?))
 
+    alias Value = String | Int32 | Bool | Nil
 
-    struct SmtpSettings
+    struct SMTPSettings
       property host = "127.0.0.1"
       property port = 1025
       property enabled = false
@@ -19,7 +20,7 @@ module Amber::Environment
       property password = ""
       property tls = false
 
-      def self.from_hash(settings = {} of String => String | Int32 | Bool | Nil) : self
+      def self.from_hash(settings = {} of String => Value) : self
         i = new
         i.host     = settings["host"]?     ? settings["host"].as String     : i.host
         i.port     = settings["port"]?     ? settings["port"].as Int32      : i.port
@@ -50,10 +51,10 @@ module Amber::Environment
       @logger ||= LoggerBuilder.new(STDOUT, logging).logger
     end
 
-    @smtp_settings : SmtpSettings?
+    @smtp_settings : SMTPSettings?
 
-    def smtp : SmtpSettings
-      @smtp_settings ||= SmtpSettings.from_hash @smtp
+    def smtp : SMTPSettings
+      @smtp_settings ||= SMTPSettings.from_hash @smtp
     end
 
     YAML.mapping(
@@ -79,11 +80,11 @@ module Amber::Environment
       ssl_key_file: {type: String?, default: nil},
       ssl_cert_file: {type: String?, default: nil},
       smtp: {
-        type: Hash(String, String | Int32 | Bool | Nil),
-        getter: false,
-        default: Hash(String, String | Int32 | Bool | Nil) {
-          "enabled" => false
-        }
+        type:    Hash(String, Value),
+        getter:  false,
+        default: Hash(String, Value){
+          "enabled" => false,
+        },
       }
     )
 

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -10,6 +10,27 @@ module Amber::Environment
       skip: Array(String?),
       context: Array(String?))
 
+
+    struct SmtpSettings
+      property host = "127.0.0.1"
+      property port = 1025
+      property enabled = false
+      property username = ""
+      property password = ""
+      property tls = false
+
+      def self.from_hash(settings = {} of String => String | Int32 | Bool | Nil) : self
+        i = new
+        i.host     = settings["host"]?     ? settings["host"].as String     : i.host
+        i.port     = settings["port"]?     ? settings["port"].as Int32      : i.port
+        i.enabled  = settings["enabled"]?  ? settings["enabled"].as Bool    : i.enabled
+        i.username = settings["username"]? ? settings["username"].as String : i.username
+        i.password = settings["password"]? ? settings["password"].as String : i.password
+        i.tls      = settings["tls"]?      ? settings["tls"].as Bool        : i.tls
+        i
+      end
+    end
+
     setter session : Hash(String, Int32 | String)
     property logging : LoggingType
     property database_url : String
@@ -27,6 +48,12 @@ module Amber::Environment
 
     def logger
       @logger ||= LoggerBuilder.new(STDOUT, logging).logger
+    end
+
+    @smtp_settings : SmtpSettings?
+
+    def smtp : SmtpSettings
+      @smtp_settings ||= SmtpSettings.from_hash @smtp
     end
 
     YAML.mapping(
@@ -51,6 +78,13 @@ module Amber::Environment
       }},
       ssl_key_file: {type: String?, default: nil},
       ssl_cert_file: {type: String?, default: nil},
+      smtp: {
+        type: Hash(String, String | Int32 | Bool | Nil),
+        getter: false,
+        default: Hash(String, String | Int32 | Bool | Nil) {
+          "enabled" => false
+        }
+      }
     )
 
     def session


### PR DESCRIPTION
### Description of the Change

Small updates to the quartz initializer. See [#15 on quartz](https://github.com/amberframework/quartz-mailer/pull/15) for more information.

blocked by https://github.com/amberframework/quartz-mailer/pull/15

I also added an example config for connecting to sendgrid, changed the logger progname for the mailer logger.

**I updated the version number in the generated shard.yml, but that's a wild guess as to what the version number will be.**

### Benefits

- better example code
- allows authenticated smtp connections
- correct verbiage ~ssl~->**tls**

### Possible Drawbacks

- This is technically a breaking change.
