### PR TITLE
[BUGFIX] Refixed error controller where ex#inspect_with_backtrace raises new exception.

### DIFF
--- a/spec/amber/router/pipe/client_ip_spec.cr
+++ b/spec/amber/router/pipe/client_ip_spec.cr
@@ -4,7 +4,6 @@ module Amber
   module Pipe
     describe ClientIp do
       context "IP from headers" do
-
         Amber::Server.router.draw :web do
           get "/client_ip_address", HelloController, :client_ip_address
         end

--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -3,7 +3,7 @@ Amber::Server.configure do |app|
     # Plug is the method to use connect a pipe (middleware)
     # A plug accepts an instance of HTTP::Handler
     plug Amber::Pipe::PoweredByAmber.new
-    #plug Amber::Pipe::ClientIp.new(["X-Forwarded-For"])
+    # plug Amber::Pipe::ClientIp.new(["X-Forwarded-For"])
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Logger.new
     plug Amber::Pipe::Session.new
@@ -16,7 +16,7 @@ Amber::Server.configure do |app|
   # All static content will run these transformations
   pipeline :static do
     plug Amber::Pipe::PoweredByAmber.new
-    #plug Amber::Pipe::ClientIp.new(["X-Forwarded-For"])
+    # plug Amber::Pipe::ClientIp.new(["X-Forwarded-For"])
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Static.new("./public")
   end

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -37,7 +37,7 @@ module Amber::Controller
       :session,
       :valve,
       :websocket?,
-    to: context
+      to: context
 
     def initialize(@context : HTTP::Server::Context)
       @params = Amber::Validators::Params.new(context.params)

--- a/src/amber/controller/error.cr
+++ b/src/amber/controller/error.cr
@@ -13,9 +13,9 @@ module Amber::Controller
 
     def internal_server_error
       response_format("ERROR: #{@ex.inspect_with_backtrace}")
-      # NOTE: As I commented in December 540cde6
-      # #inspect_with_backtrace will fail in some situtions which breaks the tests.
-      # it was added back with 3fcf593e
+      # IMPORTANT: #inspect_with_backtrace will fail in some situtions which breaks the tests.
+      # Even if you call @ex.callstack you'll notice that backtrace is nil. 
+      # #backtrace? is supposed to be safe but it exceptions anyway.
       # Please don't remove this without verifying that crystal core has been fixed first. 
     rescue ex : IndexError
       response_format("ERROR: #{@ex.message}")

--- a/src/amber/controller/error.cr
+++ b/src/amber/controller/error.cr
@@ -14,9 +14,9 @@ module Amber::Controller
     def internal_server_error
       response_format("ERROR: #{@ex.inspect_with_backtrace}")
       # IMPORTANT: #inspect_with_backtrace will fail in some situtions which breaks the tests.
-      # Even if you call @ex.callstack you'll notice that backtrace is nil. 
+      # Even if you call @ex.callstack you'll notice that backtrace is nil.
       # #backtrace? is supposed to be safe but it exceptions anyway.
-      # Please don't remove this without verifying that crystal core has been fixed first. 
+      # Please don't remove this without verifying that crystal core has been fixed first.
     rescue ex : IndexError
       response_format("ERROR: #{@ex.message}")
     end

--- a/src/amber/controller/error.cr
+++ b/src/amber/controller/error.cr
@@ -13,6 +13,12 @@ module Amber::Controller
 
     def internal_server_error
       response_format("ERROR: #{@ex.inspect_with_backtrace}")
+      # NOTE: As I commented in December 540cde6
+      # #inspect_with_backtrace will fail in some situtions which breaks the tests.
+      # it was added back with 3fcf593e
+      # Please don't remove this without verifying that crystal core has been fixed first. 
+    rescue ex : IndexError
+      response_format("ERROR: #{@ex.message}")
     end
 
     def forbidden

--- a/src/amber/pipes/client_ip.cr
+++ b/src/amber/pipes/client_ip.cr
@@ -10,11 +10,11 @@ module Amber
     # public-facing reverse proxies should delete the header if request is
     # coming from an untrusted client before appending their own, valid value.
     class ClientIp < Base
-
       def initialize(header : String = "X-Forwarded-For")
         @headers = [header]
       end
-      def initialize( @headers : Array(String))
+
+      def initialize(@headers : Array(String))
       end
 
       def call(context : HTTP::Server::Context)

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -14,7 +14,7 @@ end
 # passed to each handler that will read from the request object and build a
 # response object.  Params and Session hash can be accessed from the Context.
 class HTTP::Server::Context
-  METHODS            = %i(get post put patch delete head)
+  METHODS = %i(get post put patch delete head)
 
   include Amber::Router::Files
   include Amber::Router::Session


### PR DESCRIPTION
### Description of the Change

Fix for https://github.com/amberframework/amber/issues/624

`amber spec` is broken because `inspect_with_backtrace` currently fails if backtrace is empty.
It's been this way ever since 0.24.1. This was one of the things @drujensen and I figured out over new years when we were trying to get the release with new crystal support finished before midnight. 540cde6

Looks like it was changed back on the 25th with a PR that cleaned up the output: 3fcf593e

I've fixed it so that if there's an exception on printing the backtrace it will just print the message.
