### PR TITLE
Fix warning on make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ run:
 	$(AMBER)
 
 install: build | $(INSTALL_DIR)
-	@-rm $(AMBER_SYSTEM)
+	@rm -f $(AMBER_SYSTEM)
 	@cp $(AMBER) $(AMBER_SYSTEM)
 
 link: build | $(INSTALL_DIR)


### PR DESCRIPTION
Fixes a warning on 'make install' which is printed if the previous binary
does not exist.

Functionally the previous and current behavior are almost identical, with
the benefit that the irrelevant error message is now silently ignored
rather than too verbosely printed and potentially confusing to the user.
