### PR TITLE
fixed the readme in the generated app on how to build a release build

### DIFF
--- a/src/amber/cli/templates/app/README.md.ecr
+++ b/src/amber/cli/templates/app/README.md.ecr
@@ -23,12 +23,12 @@ amber watch
 To build and run a **production** release:
 
 1. Add an environment variable `AMBER_ENV` with a value of `production`
-2. Run these commands:
+2. Run these commands (Note using `--release` is optional and may take a long time):
 
 ```
 npm run release
 amber db create migrate
-shards build --release
+shards build --production --release
 ./bin/<%= @name %>
 ```
 

--- a/src/amber/cli/templates/app/README.md.ecr
+++ b/src/amber/cli/templates/app/README.md.ecr
@@ -28,7 +28,7 @@ To build and run a **production** release:
 ```
 npm run release
 amber db create migrate
-shards build --production
+shards build --release
 ./bin/<%= @name %>
 ```
 


### PR DESCRIPTION
### Description of the Change

Fixed the readme that gets generated in an app. It previously suggested using `shards build --production` as part of building a release build, but that doesn't actually make a release build. The correct command is `shards build --release`.

### Alternate Designs

None

### Benefits

People won't get confused trying to build a release build

### Possible Drawbacks

None
