### PR TITLE
[Granite] Bump Granite Version to 0.8.4

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -28,7 +28,7 @@ dependencies:
 <% else -%>
   granite_orm:
     github: amberframework/granite-orm
-    version: ~> 0.8.2
+    version: ~> 0.8.4
 <% end -%>
 
   quartz_mailer:


### PR DESCRIPTION
This bumps the granite version to 0.8.4 for the CLI template in shard.yml