### PR TITLE
[Travis] Adds Dist Trusty and Sudo Required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ language: generic
 services:
   - docker
 
-before_install:
-  - docker build -t garnet-spec .
-
 env:
   - TEST_SUITE=./spec/build_spec.cr
   - TEST_SUITE=./spec/amber

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: required
 language: generic
 
 services:
@@ -6,13 +8,13 @@ services:
 before_install:
   - docker build -t garnet-spec .
 
-# env:
-#   - TEST_SUITE=./spec/build_spec.cr
-#   - TEST_SUITE=./spec/amber
+env:
+  - TEST_SUITE=./spec/build_spec.cr
+  - TEST_SUITE=./spec/amber
 
 script:
-  # - docker-compose run spec bash -c "bin/ameba"
-  - docker-compose run spec bash -c "crystal spec -D run_build_tests"
+  - docker-compose run spec bash -c "bin/ameba"
+  - docker-compose run spec bash -c "crystal spec $TEST_SUITE -D run_build_tests"
 
 notifications:
   webhooks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: postgres
+    image: postgres:10.2
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=test_app_development


### PR DESCRIPTION
### Description of the Change

As Per Travis CI docs 

> When specifying sudo: required, Travis CI runs each build in an isolated Google Compute Engine virtual machine that offer a vanilla build environment for every build.

This has the advantage that no state persists between builds, offering a clean slate and making sure that your tests run in an environment built from scratch.

Builds have access to a variety of services for data storage and messaging, and can install anything that’s required for them to run.
