### PR TITLE
Amber-CLI no longer encrypts with New Line character

### DIFF
--- a/spec/amber/support/file_encryptor.cr
+++ b/spec/amber/support/file_encryptor.cr
@@ -1,51 +1,61 @@
 require "../../../spec_helper"
 
 describe Amber::Support::FileEncryptor do
+  secret_key = "mnDiAY4OyVjqg5u0wvpr0MoBkOGXBeYo7_ysjwsNzmw"
+  secret_file = "./tmp/amber_excrypt.enc"
   Dir.mkdir_p("./tmp")
   context "#encryption_key" do
     it "load encryption_key from ENV variable" do
-      ENV[Amber::SECRET_KEY] = "fake encryption key"
+      ENV["AMBER_ENCRYPTION_KEY"] = "fake encryption key"
       Amber::Support::FileEncryptor.encryption_key.should eq "fake encryption key"
     end
 
     it "load encryption_key from .encryption_key file" do
-      ENV[Amber::SECRET_KEY] = nil
-      File.write(Amber::SECRET_FILE, "fake secret key")
-      Amber::Support::FileEncryptor.encryption_key.should eq "fake secret key"
+      ENV["AMBER_ENCRYPTION_KEY"] = nil
+      File.write(secret_file, "fake secret key")
+      Amber::Support::FileEncryptor.encryption_key(secret_file).should eq "fake secret key"
 
       # TODO: This is dangerous as this file could be left over.
-      File.delete(Amber::SECRET_FILE)
+      File.delete(secret_file)
+    end
+
+    it "reads encryption key from file without newline char" do
+      ENV["AMBER_ENCRYPTION_KEY"] = nil
+      File.write(secret_file, "#{secret_key}\n")
+      result = Amber::Support::FileEncryptor.encryption_key(secret_file)
+      result.should eq secret_key
+      File.delete(secret_file)
     end
   end
 
   context "read and write global_key" do
-    ENV[Amber::SECRET_KEY] = "mnDiAY4OyVjqg5u0wvpr0MoBkOGXBeYo7_ysjwsNzmw"
+    ENV["AMBER_ENCRYPTION_KEY"] = secret_key
 
     it "writes and encrypted file" do
-      Amber::Support::FileEncryptor.write("./tmp/testenc.enc", "name: elorest")
-      File.exists?("./tmp/testenc.enc").should be_truthy
+      Amber::Support::FileEncryptor.write(secret_file, "name: elorest")
+      File.exists?(secret_file).should be_truthy
     end
 
     it "reads encrypted file" do
-      result = String.new(Amber::Support::FileEncryptor.read("./tmp/testenc.enc"))
+      result = String.new(Amber::Support::FileEncryptor.read(secret_file))
       result.should eq "name: elorest"
     end
 
     it "reads encrypted file to string" do
-      result = Amber::Support::FileEncryptor.read_as_string("./tmp/testenc.enc")
+      result = Amber::Support::FileEncryptor.read_as_string(secret_file)
       result.should eq "name: elorest"
     end
   end
 
   context "read and write with specified key" do
-    ENV[Amber::SECRET_KEY] = nil
+    ENV["AMBER_ENCRYPTION_KEY"] = nil
     it "writes and encrypted file" do
-      Amber::Support::FileEncryptor.write("./tmp/testenc.enc", "name: elorest", "mnDiAY4OyVjqg5u0wvpr0MoBkOGXBeYo7_ysjwsNzmw")
-      File.exists?("./tmp/testenc.enc").should be_truthy
+      Amber::Support::FileEncryptor.write(secret_file, "name: elorest", secret_key)
+      File.exists?(secret_file).should be_truthy
     end
 
     it "reads encrypted file" do
-      result = String.new(Amber::Support::FileEncryptor.read("./tmp/testenc.enc", "mnDiAY4OyVjqg5u0wvpr0MoBkOGXBeYo7_ysjwsNzmw"))
+      result = String.new(Amber::Support::FileEncryptor.read(secret_file, secret_key))
       result.should eq "name: elorest"
     end
   end

--- a/src/amber/support/file_encryptor.cr
+++ b/src/amber/support/file_encryptor.cr
@@ -19,10 +19,10 @@ module Amber::Support
       String.new(read(filename, encryption_key))
     end
 
-    def self.encryption_key
-      ENV[ENCRYPT_ENV]? || File.open(FILE_PATH).gets_to_end.to_s
+    def self.encryption_key(file = FILE_PATH)
+      ENV[ENCRYPT_ENV]? || File.open(file).read_line
     rescue
-      raise Amber::Exceptions::EncryptionKeyMissing.new(FILE_PATH, ENCRYPT_ENV)
+      raise Amber::Exceptions::EncryptionKeyMissing.new(file, ENCRYPT_ENV)
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

Use `read_line` on `File.open` in order to make sure that there is no `\n` at the end of the encryption key when reading from file.

### Alternate Designs

Looked at the possibility of `strip` on the original code. Didn't take this route as it would require reading the whole file, thus likely slower.

### Benefits

Reading encryption key from file and from `ENV` will now be the same.

### Possible Drawbacks

Multi line encryption files will not work with this change
