### PR TITLE
Integrate amberframework/citrine-i18n

### DIFF
--- a/src/amber/cli/templates/app/config/initializers/i18n.cr
+++ b/src/amber/cli/templates/app/config/initializers/i18n.cr
@@ -1,0 +1,24 @@
+require "citrine-i18n"
+
+Citrine::I18n.configure do |settings|
+  # Backend storage (as supported by i18n.cr)
+  # settings.backend = I18n::Backend::Yaml.new
+
+  # Default locale (defaults to "en" and "./src/locales/en.yml").
+  # For a new default locale to be accepted, it must be found by the
+  # backend storage and reported in "settings.available_locales".
+  # settings.default_locale = "en"
+
+  # Separator between sublevels of data (defaults to '.')
+  # e.g. I18n.translate("some/thing") instead of "some.thing"
+  # settings.default_separator = '.'
+
+  # Returns the current exception handler. Defaults to an instance of
+  # I18n::ExceptionHandler.
+  # settings.exception_handler = ExceptionHandler.new
+
+  # The path from where the translations should be loaded
+  settings.load_path += ["./src/locales"]
+end
+
+I18n.init

--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -4,6 +4,7 @@ Amber::Server.configure do |app|
     # A plug accepts an instance of HTTP::Handler
     plug Amber::Pipe::PoweredByAmber.new
     # plug Amber::Pipe::ClientIp.new(["X-Forwarded-For"])
+    plug Citrine::Pipe::I18n.new
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Logger.new
     plug Amber::Pipe::Session.new

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -21,6 +21,10 @@ dependencies:
     branch: master
     #version: <%= Amber::VERSION %>
 
+  citrine-i18n:
+    github: amberframework/citrine-i18n
+    branch: master
+
 <% case @model when "crecto" -%>
   crecto:
     github: Crecto/crecto

--- a/src/amber/cli/templates/app/src/locales/en.yml
+++ b/src/amber/cli/templates/app/src/locales/en.yml
@@ -1,0 +1,2 @@
+---
+welcome_to_amber: "Welcome to Amber Framework!"

--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -1,6 +1,6 @@
 <div id="logo" class="col-sm-6"></div>
 <div class="col-sm-6">
-  <h2>Welcome to Amber Framework!</h2>
+  <h2><%= "<" %>%= t "welcome_to_amber" %></h2>
   <p>Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.</p>
   <div class="list-group">
     <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -1,6 +1,6 @@
 div#logo.col-sm-6
 div.col-sm-6
-  h2 Welcome to Amber Framework!
+  h2 = t "welcome_to_amber"
   p Thank you for trying out the Amber Framework.  We are working hard to provide a super fast and reliable framework that provides all the productivity tools you are used to without sacrificing the speed.
   div.list-group
     a.list-group-item.list-group-item-action target="_blank" href="https://docs.amberframework.org" Getting Started with Amber Framework

--- a/src/amber/controller/base.cr
+++ b/src/amber/controller/base.cr
@@ -10,6 +10,7 @@ module Amber::Controller
     include Helpers::Render
     include Helpers::Responders
     include Helpers::Route
+    include Helpers::I18n
     include Callbacks
 
     protected getter context : HTTP::Server::Context

--- a/src/amber/controller/helpers/i18n.cr
+++ b/src/amber/controller/helpers/i18n.cr
@@ -1,0 +1,11 @@
+module Amber::Controller::Helpers
+  module I18n
+    def t(*arg)
+      ::I18n.translate(*arg)
+    end
+
+    def l(*arg)
+      ::I18n.localize(*arg)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds:

1) citrine-i18n initializer config file
2) Citrine::Pipe::I18n pipe for locale detection
3) Minimal locale example in src/locales/en.yml
4) "t" and "l" shorthands for ::I18n.translate and ::I18n.localize
5) "Welcome to Amber Framework!" which now comes from a translation 

What's missing from here is:

1) Maybe we should generate basic locale files (or just empty directories) in src/locales/{models,views,...}/ when these types are generated

This could be done in a separate commit/PR.