### PR TITLE
[Travis] Removes Docker from Travis Ci Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
 dist: trusty
 sudo: required
-language: generic
+language: crystal
 
 services:
-  - docker
-
+  - postgres
+  - redis-server
+cache:
+  directories:
+    - bin/
+    - lib/
 env:
   - TEST_SUITE=./spec/build_spec.cr
   - TEST_SUITE=./spec/amber
 
 script:
-  - docker-compose run spec bash -c "bin/ameba"
-  - docker-compose run spec bash -c "crystal spec $TEST_SUITE -D run_build_tests"
+  - bin/ameba
+  - crystal spec $TEST_SUITE -D run_build_tests
 
 notifications:
   webhooks:


### PR DESCRIPTION
### Description of the Change

After many attempts to solver the issue where docker does not connect to
Redis. I like to propose that we remove the Docker from the Travis
build, since travis supports redis and postgres databases without the
need of using docker compose.

### Benefits
A couple of benefits to this:

- Faster Build Times each built takes only ~3 minutes vs 5 mminutes
- Simple configuration for running tests on Travis and removes a  layer of
complexitiy
- For those who like do not want to have a Redis and or Postgress
installation to run Amber Specs they can still use Docker and Docker Compose.

With this change we should experience more consistency running Specs on
Travis CI