### PR TITLE
Run migrations at the start of a test run

### DIFF
--- a/src/amber/cli/templates/app/spec/spec_helper.cr
+++ b/src/amber/cli/templates/app/spec/spec_helper.cr
@@ -4,6 +4,11 @@ require "spec"
 require "garnet_spec"
 require "../config/*"
 
+require "micrate"
+Micrate::DB.connection_url = Amber.settings.database_url
+
+# Automatically run migrations on the test database
+Micrate::Cli.run_up
 module Spec
   DRIVER = :chrome
   PATH   = "/usr/local/bin/chromedriver"


### PR DESCRIPTION
### Description of the Change

Fixes #646, default generated apps to run migrations at the start of a test run.

### Benefits

When building a database with migrations, it's currently necessary to run migrations against the test environment before running tests.

Something like this: `AMBER_ENV=test amber db migrate`

### Possible Drawbacks

There is some risk to automatically running migrations. If someone manually overrides the ENV for some reason when running tests:

```
$ export AMBER_ENV=production
$ crystal spec # would run migrations
```