### PR TITLE
Disable granite query logger in generate app test

### DIFF
--- a/src/amber/cli/templates/app/spec/spec_helper.cr
+++ b/src/amber/cli/templates/app/spec/spec_helper.cr
@@ -4,6 +4,9 @@ require "spec"
 require "garnet_spec"
 require "../config/*"
 
+# Disable query logger for tests
+Granite::ORM.settings.logger = Logger.new nil
+
 module Spec
   DRIVER = :chrome
   PATH   = "/usr/local/bin/chromedriver"


### PR DESCRIPTION
### Description of the Change

The Granite query logger is great, but it's also verbose. Currently the buildspec ends up looking like this:

![image](https://user-images.githubusercontent.com/208647/36687064-ae34e64c-1ae5-11e8-9d31-fb014d068939.png)

### Alternate Designs

- This could go in the `initializers/database` file, but I didn't want to add another logic dimension to that file. This is test-run specific code, so I think it should live in the configuration for the test run.
- Critical database failures are also hidden. Should this change the log level to `ERROR` instead?

### Benefits

Cleaner test run output!

### Possible Drawbacks

- If someone needs to see the query log, they'll have to comment out this line. 
