### PR TITLE
Use shards command with production flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: build
 build: lib $(AMBER)
 
 lib:
-	@crystal deps
+	@shards install --production
 
 $(AMBER): $(AMBER_SOURCES) | $(OUT_DIR)
 	@echo "Building amber in $@"


### PR DESCRIPTION
### Description of the Change

Add `--production` flag and avoid using `@crystal deps` , use `@shards install` instead

### Alternate Designs

No

### Benefits

Avoid running ameba when running `make` to build amber executable

### Possible Drawbacks

No
