### PR TITLE
[Shards] Removes Spinner Shard

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -28,7 +28,7 @@ dependencies:
 
   slang:
     github: jeromegn/slang
-    version: ~> 1.7.1 
+    version: ~> 1.7.1
 
   redis:
     github: stefanwille/crystal-redis
@@ -49,10 +49,6 @@ dependencies:
   shell-table:
     github: jwaldrip/shell-table.cr
     version: ~> 0.9.1
-
-  spinner:
-    github: askn/spinner
-    version: ~> 0.1.1
 
   pg:
     github: will/crystal-pg

--- a/src/amber/cli/commands/deploy.cr
+++ b/src/amber/cli/commands/deploy.cr
@@ -1,7 +1,6 @@
 require "cli"
 require "yaml"
 require "colorize"
-require "spinner"
 
 module Amber::CLI
   class MainCommand < ::Cli::Supercommand
@@ -32,7 +31,6 @@ module Amber::CLI
 
       def run
         CLI.toggle_colors(options.no_color?)
-        (spinner = Spin.new(0.1, Spinner::Charset[:arrow2].map { |c| c.colorize(:light_green).to_s })).start
         shard = YAML.parse(File.read("./shard.yml"))
         @project_name = shard["name"].to_s
         @server_name = "#{project_name}-#{args.server_suffix}".gsub(/[^\w\d]/, "-")
@@ -41,7 +39,6 @@ module Amber::CLI
         else
           deploy
         end
-        spinner.stop
       rescue e
         exit! e.message, error: true
       end


### PR DESCRIPTION
This is only being used once and in one place. While the spinner looks
fancy is does not seem necessary

This PR removes the spinner shard making the shards.yaml cleaner and
removing an extra dependency
