### PR TITLE
[Shard] Change citrine-i18n version to 0.1.0

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -23,7 +23,7 @@ dependencies:
 
   citrine-i18n:
     github: amberframework/citrine-i18n
-    branch: master
+    version: 0.1.0
 
 <% case @model when "crecto" -%>
   crecto:


### PR DESCRIPTION
### Description of the Change

Change citrine-i18n to version 0.1.0

### Alternate Designs

No

### Benefits

Use citrine-i18n version instead of master branch and avoid dependency issues

### Possible Drawbacks

No