### PR TITLE
Add missing make

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ brew install amber
 git clone https://github.com/amberframework/amber.git
 cd amber
 git checkout stable
+make
 sudo make install
 ```
 


### PR DESCRIPTION
### Description of the Change

Add make to avoid building amber using elevated permissions

### Alternate Designs

No

### Benefits

Avoid to create dirs and files with elevated permissions on build folder,

This will ask for permission just when amber is going to be installed

### Possible Drawbacks

No
