### PR TITLE
Extract Logging and LoggingBuilder from Settings.cr file

### DIFF
--- a/src/amber/environment/logger_builder.cr
+++ b/src/amber/environment/logger_builder.cr
@@ -1,12 +1,14 @@
 module Amber::Environment
   class LoggerBuilder
+    getter logger : Logger
+
     def self.logger(io, logging)
       new(io, logging).logger
     end
 
     def initialize(io, logging)
       Colorize.enabled = logging.colorize
-      @logger = Environment::Logger.new(io)
+      @logger = Logger.new(io)
       @logger.level = logging.severity
       @logger.progname = "Server"
       @logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
@@ -17,10 +19,6 @@ module Amber::Environment
         io << " "
         io << message
       end
-    end
-
-    def logger
-      @logger
     end
   end
 end

--- a/src/amber/environment/logger_builder.cr
+++ b/src/amber/environment/logger_builder.cr
@@ -1,0 +1,26 @@
+module Amber::Environment
+  class LoggerBuilder
+    def self.logger(io, logging)
+      new(io, logging).logger
+    end
+
+    def initialize(io, logging)
+      Colorize.enabled = logging.colorize
+      @logger = Environment::Logger.new(io)
+      @logger.level = logging.severity
+      @logger.progname = "Server"
+      @logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
+        io << datetime.to_s("%I:%M:%S")
+        io << " "
+        io << progname
+        io << " (#{severity})" if severity > Logger::DEBUG
+        io << " "
+        io << message
+      end
+    end
+
+    def logger
+      @logger
+    end
+  end
+end

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -1,0 +1,34 @@
+module Amber::Environment
+  class Logging
+    SEVERITY_MAP = {
+      "debug":   Logger::DEBUG,
+      "info":    Logger::INFO,
+      "warn":    Logger::WARN,
+      "error":   Logger::ERROR,
+      "fatal":   Logger::FATAL,
+      "unknown": Logger::UNKNOWN,
+    }
+
+    setter severity : String
+    property colorize : Bool
+    property context : Array(String?)
+    property skip : Array(String?)
+    property filter : Array(String?)
+
+    def initialize(logging : Settings::LoggingType)
+      @colorize = logging[:colorize]
+      @severity = logging[:severity]
+      @filter = logging[:filter]
+      @skip = logging[:skip]
+      @context = logging[:context]
+    end
+
+    def severity
+      SEVERITY_MAP[@severity]
+    end
+
+    def logger
+      @logger
+    end
+  end
+end

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -1,5 +1,12 @@
 module Amber::Environment
   class Logging
+    alias OptionsType = NamedTuple(
+      severity: String,
+      colorize: Bool,
+      filter: Array(String?),
+      skip: Array(String?),
+      context: Array(String?))
+
     SEVERITY_MAP = {
       "debug":   Logger::DEBUG,
       "info":    Logger::INFO,
@@ -15,7 +22,7 @@ module Amber::Environment
     property skip : Array(String?)
     property filter : Array(String?)
 
-    def initialize(logging : Settings::LoggingType)
+    def initialize(logging : OptionsType)
       @colorize = logging[:colorize]
       @severity = logging[:severity]
       @filter = logging[:filter]

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -16,6 +16,14 @@ module Amber::Environment
       "unknown": Logger::UNKNOWN,
     }
 
+    DEFAULTS = {
+      severity: "debug",
+      colorize: true,
+      filter:   ["password", "confirm_password"] of String?,
+      skip:     [] of String?,
+      context:  ["request", "headers", "cookies", "session", "params"] of String?,
+    }
+
     setter severity : String
     property colorize : Bool
     property context : Array(String?)

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -25,10 +25,10 @@ module Amber::Environment
     }
 
     setter severity : String
-    property colorize : Bool
-    property context : Array(String?)
-    property skip : Array(String?)
-    property filter : Array(String?)
+    property colorize : Bool,
+      context : Array(String?),
+      skip : Array(String?),
+      filter : Array(String?)
 
     def initialize(logging : OptionsType)
       @colorize = logging[:colorize]

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -38,7 +38,7 @@ module Amber::Environment
       @context = logging[:context]
     end
 
-    def severity
+    def severity : Logger::Severity
       SEVERITY_MAP[@severity]
     end
 

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -41,9 +41,5 @@ module Amber::Environment
     def severity : Logger::Severity
       SEVERITY_MAP[@severity]
     end
-
-    def logger
-      @logger
-    end
   end
 end

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -134,37 +134,4 @@ module Amber::Environment
       @logger
     end
   end
-
-  class Logging
-    SEVERITY_MAP = {
-      "debug":   Logger::DEBUG,
-      "info":    Logger::INFO,
-      "warn":    Logger::WARN,
-      "error":   Logger::ERROR,
-      "fatal":   Logger::FATAL,
-      "unknown": Logger::UNKNOWN,
-    }
-
-    setter severity : String
-    property colorize : Bool
-    property context : Array(String?)
-    property skip : Array(String?)
-    property filter : Array(String?)
-
-    def initialize(logging : Settings::LoggingType)
-      @colorize = logging[:colorize]
-      @severity = logging[:severity]
-      @filter = logging[:filter]
-      @skip = logging[:skip]
-      @context = logging[:context]
-    end
-
-    def severity
-      SEVERITY_MAP[@severity]
-    end
-
-    def logger
-      @logger
-    end
-  end
 end

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -51,13 +51,10 @@ module Amber::Environment
     end
 
     YAML.mapping(
-      logging: {type: Logging::OptionsType, default: {
-        severity: "debug",
-        colorize: true,
-        filter:   ["password", "confirm_password"] of String?,
-        skip:     [] of String?,
-        context:  ["request", "headers", "cookies", "session", "params"] of String?,
-      }},
+      logging: {
+        type: Logging::OptionsType,
+        default: Logging::DEFAULTS
+      },
       database_url: {type: String, default: ""},
       host: {type: String, default: "localhost"},
       name: {type: String, default: "Amber_App"},

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -109,29 +109,4 @@ module Amber::Environment
       @_logging ||= Logging.new(@logging)
     end
   end
-
-  class LoggerBuilder
-    def self.logger(io, logging)
-      new(io, logging).logger
-    end
-
-    def initialize(io, logging)
-      Colorize.enabled = logging.colorize
-      @logger = Environment::Logger.new(io)
-      @logger.level = logging.severity
-      @logger.progname = "Server"
-      @logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
-        io << datetime.to_s("%I:%M:%S")
-        io << " "
-        io << progname
-        io << " (#{severity})" if severity > Logger::DEBUG
-        io << " "
-        io << message
-      end
-    end
-
-    def logger
-      @logger
-    end
-  end
 end

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -26,19 +26,19 @@ module Amber::Environment
     end
 
     setter session : Hash(String, Int32 | String)
-    property database_url : String
-    property host : String
-    property name : String
-    property port : Int32
-    property port_reuse : Bool
-    property process_count : Int32
-    property redis_url
-    property secret_key_base : String
-    property secrets : Hash(String, String)
-    property ssl_key_file : String
-    property ssl_cert_file : String
-    property logging : Logging::OptionsType
-    property logger : Logger?
+    property database_url : String,
+      host : String,
+      name : String,
+      port : Int32,
+      port_reuse : Bool,
+      process_count : Int32,
+      redis_url : String?,
+      secret_key_base : String,
+      secrets : Hash(String, String),
+      ssl_key_file : String,
+      ssl_cert_file : String,
+      logging : Logging::OptionsType,
+      logger : Logger?
 
     @smtp_settings : SMTPSettings?
 

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -1,5 +1,5 @@
-require "./logger"
 require "yaml"
+require "./logger"
 
 module Amber::Environment
   class Settings

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -26,7 +26,6 @@ module Amber::Environment
     end
 
     setter session : Hash(String, Int32 | String)
-    property logging : Logging::OptionsType
     property database_url : String
     property host : String
     property name : String
@@ -38,11 +37,8 @@ module Amber::Environment
     property secrets : Hash(String, String)
     property ssl_key_file : String
     property ssl_cert_file : String
+    property logging : Logging::OptionsType
     property logger : Logger?
-
-    def logger
-      @logger ||= LoggerBuilder.new(STDOUT, logging).logger
-    end
 
     @smtp_settings : SMTPSettings?
 
@@ -97,6 +93,10 @@ module Amber::Environment
 
     def logging
       @_logging ||= Logging.new(@logging)
+    end
+
+    def logger
+      @logger ||= LoggerBuilder.new(STDOUT, logging).logger
     end
   end
 end

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -3,13 +3,6 @@ require "./logger"
 
 module Amber::Environment
   class Settings
-    alias LoggingType = NamedTuple(
-      severity: String,
-      colorize: Bool,
-      filter: Array(String?),
-      skip: Array(String?),
-      context: Array(String?))
-
     alias SettingValue = String | Int32 | Bool | Nil
 
     struct SMTPSettings
@@ -33,7 +26,7 @@ module Amber::Environment
     end
 
     setter session : Hash(String, Int32 | String)
-    property logging : LoggingType
+    property logging : Logging::OptionsType
     property database_url : String
     property host : String
     property name : String
@@ -58,7 +51,7 @@ module Amber::Environment
     end
 
     YAML.mapping(
-      logging: {type: LoggingType, default: {
+      logging: {type: Logging::OptionsType, default: {
         severity: "debug",
         colorize: true,
         filter:   ["password", "confirm_password"] of String?,


### PR DESCRIPTION
### Description of the Change

Hi! Lately I have been trying to create a new Logger for my Amber application, for that purpose I've studied all code related to managing Logger settings, specifically classes `Settings`, `Logging` and `LoggerBuilder`

I found that `Settings` class is a bit messy/bloated,  it contains too many things that makes kind of difficult to separate concepts in your head so I decided to try to clean things up a bit.

What I have done:

- Extract `Logging` from `Settings` file to its own file
- Extract `LoggerBuidler` from `Settings` file to its own file
- Use `getter` macro to generate `LoggerBuilder#logger` method instead of manually creating it
- Remove `Logging#logger` method because it wasn't used
- Create `Logging::DEFAULTS` constant to improve readability of YAML default settings
- Move `LoggingType` to `Logging` class as `OptionsType`
- Add types that were not specified
- Use `property` macro 1 time per file instead of 13 times in `Settings` and 4 times in `Logging`

### Benefits

As you can see changes are only focused into improving readability in order to make easier to implement new features, bugfixes (or complete rewrites) in the future (like https://github.com/amberframework/amber/issues/645).

### How has been tested

* Running specs plus ameba.
* Compiling the project with the changes
* Creating a new app with the compiled executable
* Changing amber specification in `shard.yml` to point to my local branch of amber with the changes
* `amber watch` and check that logs were printing correctly

### Possible Drawbacks

No feature has been added nor removed.
