### PR TITLE
[Generator] Remove raise from Template

### DIFF
--- a/src/amber/cli/templates/template.cr
+++ b/src/amber/cli/templates/template.cr
@@ -106,7 +106,7 @@ module Amber::CLI
         puts "Rendering View #{name}"
         View.new(name, fields).render(directory, list: true, color: true)
       else
-        raise "Template not found"
+        CLI.logger.error "Template not found", "Generate", :light_red
       end
     end
 


### PR DESCRIPTION
We do not raise errors in the CLI, instead we log a message to the
console.