### PR TITLE
[Router] Adds OPTIONS and HEAD routes by default

### DIFF
--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -14,7 +14,7 @@ module Amber
       route.class.should eq Route
     end
 
-    describe "#substitute_keys)in_path" do
+    describe "#substitute_keys_in_path" do
       it "parses route resource params" do
         params = {"id" => "123", "name" => "John"}
         empty_hash = {} of String => String

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -12,9 +12,18 @@ module Amber
           end
 
           router.match("GET", "/hello").path.should eq "get/hello"
+          router.match("HEAD", "/hello").path.should eq "head/hello"
+          router.match("OPTIONS", "/hello").path.should eq "options/hello"
           router.match("GET", "/hello/2").path.should eq "get/hello/:id"
+          router.match("HEAD", "/hello/2").path.should eq "head/hello/:id"
+          router.match("OPTIONS", "/hello/2").path.should eq "options/hello/:id"
           router.match("GET", "/hello/new").path.should eq "get/hello/new"
+          router.match("HEAD", "/hello/new").path.should eq "head/hello/new"
+          router.match("OPTIONS", "/hello/new").path.should eq "options/hello/new"
           router.match("GET", "/hello/2/edit").path.should eq "get/hello/:id/edit"
+          router.match("HEAD", "/hello/2/edit").path.should eq "head/hello/:id/edit"
+          router.match("OPTIONS", "/hello/2/edit").path.should eq "options/hello/:id/edit"
+          router.match("OPTIONS", "/hello/1").path.should eq "options/hello/:id"
           router.match("PUT", "/hello/1").path.should eq "put/hello/:id"
           router.match("PATCH", "/hello/1").path.should eq "patch/hello/:id"
           router.match("DELETE", "/hello/1").path.should eq "delete/hello/:id"

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -28,6 +28,13 @@ module Amber::DSL
     {% for verb in RESOURCES %}
       macro {{verb.id}}(*args)
         route {{verb}}, \{{*args}}
+        {% if verb == :get %}
+          route :head, \{{*args}}
+        {% end %}
+        route {{verb}}, \{{*args}}
+        {% if ![:trace, :connect, :options, :head].includes? verb %}
+        route :options, \{{*args}}
+        {% end %}
       end
     {% end %}
 

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -29,7 +29,7 @@ module Amber::DSL
       macro {{verb.id}}(*args)
         route {{verb}}, \{{*args}}
         {% if verb == :get %}
-          route :head, \{{*args}}
+        route :head, \{{*args}}
         {% end %}
         route {{verb}}, \{{*args}}
         {% if ![:trace, :connect, :options, :head].includes? verb %}

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -28,10 +28,6 @@ module Amber
       "#{verb.to_s.downcase}#{scope}#{resource}"
     end
 
-    def trail_head
-      "head#{scope}#{resource}"
-    end
-
     def call(context)
       handler.call(context)
     end

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -2,8 +2,7 @@ require "amber_router"
 
 module Amber
   module Router
-    # This is the main application handler all routers should finally hit this
-    # handler.
+    # This is the main application handler all routers should finally hit this handler.
     class Router
       property :routes, :routes_hash, :socket_routes
       PATH_EXT_REGEX = /\.[^$\/]+$/
@@ -32,7 +31,6 @@ module Amber
         trail = build_node(route.verb, route.resource)
         @routes.add(route.trail, route)
         @routes_hash["#{route.controller.downcase}##{route.action.to_s.downcase}"] = route
-        add_head(route) if route.verb == "GET"
       end
 
       def add_socket_route(route, handler : WebSockets::Server::Handler)
@@ -66,10 +64,6 @@ module Amber
 
       private def build_node(http_verb : Symbol | String, resource : String)
         "#{http_verb.to_s.downcase}#{resource}"
-      end
-
-      private def add_head(route)
-        @routes.add(route.trail_head, route)
       end
     end
   end


### PR DESCRIPTION
Issue https://github.com/amberframework/amber/issues/240

OPTIONS and HEAD routes should be automatically defined for routes
currently developers have to define the OPTIONS route via the option
route method.

- Removes the add_head method from router
- Adds OPTIONS and HEAD routes ass needed via DSL
- Removes the need to create OPTIONS and HEAD routes

With these changes developers should no longer need to specify the
OPTIONS and HEAD routes and will now be defined by default.

To learn more about HTTP Head and Options Specs Read https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html