### PR TITLE
[Bug Fix] Fixed Delete link to work similar to Rails UJS

### DIFF
--- a/assets/js/amber.js
+++ b/assets/js/amber.js
@@ -226,3 +226,19 @@ export class Socket {
 module.exports = {
   Socket: Socket
 }
+
+
+/**
+ * Allows delete links to post for security and ease of use similar to Rails jquery_ujs
+ */
+$(document).ready(() => {
+  $( "a[data-method='delete']" ).click(function(){
+    var confirm_message = $(this).data("confirm") || "Are you sure?"
+    if(confirm(confirm_message)){
+      const form = $(`<form action='${this.href}' method='POST'><input type='hidden' name='_method' value='DELETE' /></form>`);
+      $(document.body).append(form);
+      form.submit();
+    }
+    return false;
+  }); 
+}); 

--- a/assets/js/amber.js
+++ b/assets/js/amber.js
@@ -231,14 +231,23 @@ module.exports = {
 /**
  * Allows delete links to post for security and ease of use similar to Rails jquery_ujs
  */
-$(document).ready(() => {
-  $( "a[data-method='delete']" ).click(function(){
-    var confirm_message = $(this).data("confirm") || "Are you sure?"
-    if(confirm(confirm_message)){
-      const form = $(`<form action='${this.href}' method='POST'><input type='hidden' name='_method' value='DELETE' /></form>`);
-      $(document.body).append(form);
-      form.submit();
-    }
-    return false;
-  }); 
-}); 
+document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll("a[data-method='delete']").forEach(function (element) {
+        element.addEventListener("click", function (e) {
+            e.preventDefault();
+            var message = element.getAttribute("data-confirm") || "Are you sure?";
+            if (confirm(message)) {
+                var form = document.createElement("form");
+                var input = document.createElement("input");
+                form.setAttribute("action", element.getAttribute("href"));
+                form.setAttribute("method", "POST");
+                input.setAttribute("type", "hidden");
+                input.setAttribute("value", "DELETE");
+                form.appendChild(input);
+                document.body.appendChild(form);
+                form.submit();
+            }
+            return false;
+        })
+    })
+});

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -26,7 +26,7 @@
           <span>
             <%="<"%>%= link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-success btn-xs") -%>
             <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs") -%>
-            <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');") -%>
+            <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs") -%>
           </span>
         </td>
       </tr>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -21,4 +21,4 @@ div.table-responsive
             span
               == link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-success btn-xs")
               == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
-              == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{ <%= @name %>.id }?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');")
+              == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
@@ -6,5 +6,5 @@
 <p>
   <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>s", class: "btn btn-success btn-xs") -%>
   <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs") -%>
-  <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');") -%>
+  <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs") -%>
 </p>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
@@ -5,4 +5,4 @@ p = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
 p
   == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-success btn-xs")
   == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-xs")
-  == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_method=delete&_csrf=#{csrf_token}", class: "btn btn-danger btn-xs", onclick: "return confirm('Are you sure?');")
+  == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-xs")


### PR DESCRIPTION
### Description of the Change

Added a few lines of javascript which submit the delete link as a form while still allowing it to be styled like the other links.

### Alternate Designs

Just add a form straight to the page with a submit button. After looking over all the modern frameworks I decided not to do it this way.

### Benefits

Delete button uses POST instead of GET and overrides with DELETE method.

