### PR TITLE
Updated to use Jasper with with checkbox params reversed.

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -41,7 +41,7 @@ dependencies:
 
   jasper_helpers:
     github: amberframework/jasper-helpers
-    version: ~> 0.1.6
+    version: ~> 0.2.0
 
 <% case @database when "pg" -%>
   pg:


### PR DESCRIPTION
### Description of the Change

In rails and every other framework I know the convention for checkboxes is to created a hidden field with the same name first with the unchecked value. This is because an unchecked checkbox doesn't actually submit a form value making it impossible to uncheck a box once checked.

Since the params rewrite we apparently choose the first instead of last param (seems to be a crystal thing only incidentally related to @eliasjpr's rewrite).

To fix that without changing the way params work again, I changed jasper to put the checkbox before the hidden field.