### PR TITLE
[CI] Attempts to fix Build Spec For Consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ cache:
     - .shards
 
 script:
-  - bin/ameba ./src && crystal spec ./spec/amber && crystal spec ./spec/build_spec.cr -D run_build_tests
+  - bin/ameba ./src
+  - crystal spec ./spec/amber
+  - crystal spec ./spec/build_spec.cr -D run_build_tests
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,17 @@ sudo: required
 language: crystal
 
 services:
-  - postgres
+  - postgresql
   - redis-server
+
 cache:
   directories:
-    - bin/
-    - lib/
-env:
-  - TEST_SUITE=./spec/build_spec.cr
-  - TEST_SUITE=./spec/amber
+    - bin
+    - lib
+    - .shards
 
 script:
-  - bin/ameba
-  - crystal spec $TEST_SUITE -D run_build_tests
+  - bin/ameba ./src && crystal spec ./spec/amber && crystal spec ./spec/build_spec.cr -D run_build_tests
 
 notifications:
   webhooks:

--- a/spec/build_spec.cr
+++ b/spec/build_spec.cr
@@ -26,7 +26,6 @@ module Amber::CLI
       MainCommand.run ["generate", "channel", "Falcon"]
 
       prepare_yaml(Dir.current)
-      prepare_db_yml(CLIHelper::BASE_ENV_PATH) if ENV["CI"]? == "true"
       Amber::CLI.env = "test"
       Amber::CLI.settings.logger = Amber::Environment::Logger.new(nil)
 


### PR DESCRIPTION
- Removes the Prepare DB YAML, this was use for when CI used to run on a
docker image which is no longer the case

- Renames the Postgres Travis CI service to Postgresql

### Alternative Setup

The following  setup can be use to only run `build_spec` for master branches and not PRs

```yaml
dist: trusty
sudo: required
language: crystal

services:
  - postgresql
  - redis-server

cache:
  directories:
    - bin
    - lib
    - .shards

jobs:
  include:
    - stage: test
      script: bin/ameba
      script: crystal spec ./spec/amber
    - stage: regression
      script: bin/ameba
      script: crystal spec ./spec/build_spec.cr -D run_build_tests
      if: branch = master

notifications:
  webhooks:
    urls:
      - https://webhooks.gitter.im/e/aaf02221d4649d70b384
    on_success: change  # options: [always|never|change] default: always
    on_failure: always  # options: [always|never|change] default: always
    on_start: never     # options: [always|never|change] default: always


```