### PR TITLE
[Params] To hash method not returning correct value

### DIFF
--- a/spec/amber/router/params_spec.cr
+++ b/spec/amber/router/params_spec.cr
@@ -103,6 +103,7 @@ module Amber::Router
 
       it "returns a hash with all params" do
         params.to_h.keys.should eq %w(test _method status _csrf title content)
+        params.to_h["test"].should eq "test"
       end
     end
   end

--- a/src/amber/router/params.cr
+++ b/src/amber/router/params.cr
@@ -65,11 +65,12 @@ module Amber::Router
     end
 
     def to_h
-      query.to_h
-           .merge(form.to_h)
-           .merge(route)
-           .merge(json)
-           .merge(multipart)
+      params_hash = Hash(String, String | Array(String) | Nil).new
+      query.each { |key, _| params_hash[key] = query[key] }
+      route.each { |key, _| params_hash[key] = route[key] }
+      multipart.each { |key, _| params_hash[key] = multipart[key] }
+      form.each { |key, _| params_hash[key] = form[key] }
+      params_hash
     end
 
     private def query


### PR DESCRIPTION
Issue: https://github.com/amberframework/amber/issues/730

### Description of the Change

When form submission with repeated form input names it returns the last
value of the list.

Example:

```html
<input name="cat" value="1" type="checkbox" checked>
<input name="cat" value="0" type="checkbox">
```

Actual

```crystal
params.raw_params['cat'] == 1
params.raw_params.to_h['cat'] == 0
params['cat'] == 1
```

Expected

```crystal
params.raw_params['cat'] == 1
params.raw_params.to_h['cat'] == 1
params['cat'] == 1
```

### Resolution

Removes the used of `.merge()` method in favor of manually merging the
hash.

### Possible Drawbacks

This slows down the hash generation of the params