### PR TITLE
[CLI] DB Seed Command

### DIFF
--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -54,7 +54,7 @@ module Amber::CLI
           when "create"
             Micrate.logger.info create_database
           when "seed"
-            `crystal db/seeds.cr`
+            Helpers.run("crystal db/seeds.cr", wait: true, shell: true)
             Micrate.logger.info "Seeded database"
           when "migrate"
             begin


### PR DESCRIPTION
Resolves https://github.com/amberframework/amber/issues/753

### Description of the Change

Allows to shows Granite logger output when running `db seed` command
this gives feedback to the user of which actions has been performed against
the database without using puts.

This does not fix the case when using `puts` inside the `db/seeds.cr` file, instead 
`Amber.logger.info` can be used in its place

**Example** 

`db/seeds.cr` file 

```crystal 
require "../config/application.cr"

user = User.new

user.email = "admin@example.com"
user.password = "password"
user.save

Amber.logger.info user.to_h 

```

**Gives the following output** 

```bash 
 ± bin/amber db seed
07:15:27 Granite    | (INFO) SELECT users.id, users.firstname, users.lastname, users.email, users.hashed_password, users.created_at, users.updated_at FROM users WHERE email=$1 LIMIT 1: admin@example.com
07:15:27 Granite    | (INFO) INSERT INTO users (firstname, lastname, email, hashed_password, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6): [nil, nil, "admin@example.com", "$2a$10$qnUcrAHYW2dJ6HgRsGU9x.PtNAv6KLJGq9.HZQ69WkBwsGlRQ6R4e", "2018-04-14 23:15:27", "2018-04-14 23:15:27"]
07:15:27 Server     | (INFO) {"id" => 1_i64, "firstname" => nil, "lastname" => nil, "email" => "admin@example.com", "hashed_password" => "$2a$10$qnUcrAHYW2dJ6HgRsGU9x.PtNAv6KLJGq9.HZQ69WkBwsGlRQ6R4e", "created_at" => "2018-04-14 23:15:27", "updated_at" => "2018-04-14 23:15:27"}
07:15:27 Database   | (INFO) Seeded database
```



<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits

Allows users to log actions committed against the database using `Amber.logger`

### Alternative 

Use `amber exec db/seeds.cr` and it will output to console

### Possible Drawbacks

`puts` inside `db/seeds.cr` file does not work
