### PR TITLE
ensure minimum version of 0.2.5 for liquid shard

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -32,7 +32,7 @@ dependencies:
 
   liquid:
     github: TechMagister/liquid.cr
-    version: ~> 0.2.4
+    version: ~> 0.2.5
 
   micrate:
     github: amberframework/micrate


### PR DESCRIPTION
### Description of the Change
This ensures that the minimum version of liquid shard installed is 0.2.5, which is the version that has whitespace control to remove extra whitespace from artifacts generated from a liquid template.

### Alternate Designs
N/A
### Benefits
The ability to remove whitespace in artifacts generated from liquid templates

### Possible Drawbacks
None perceived
