### PR TITLE
Changed visibility scope of some Amber::Server methods

### DIFF
--- a/src/amber/server/server.cr
+++ b/src/amber/server/server.cr
@@ -53,7 +53,7 @@ module Amber
 
     def start
       time = Time.now
-      logger.info "#{version} serving application \"#{settings.name.capitalize}\" at #{host_url}".to_s
+      logger.info "#{version.colorize(:light_cyan)} serving application \"#{settings.name.capitalize}\" at #{host_url.colorize(:light_cyan).mode(:underline)}"
       handler.prepare_pipelines
       server = HTTP::Server.new(settings.host, settings.port, handler)
       server.tls = Amber::SSL.new(settings.ssl_key_file.not_nil!, settings.ssl_cert_file.not_nil!).generate_tls if ssl_enabled?
@@ -83,23 +83,23 @@ module Amber
       end
     end
 
-    private def version
-      "Amber #{Amber::VERSION}".colorize(:light_cyan)
+    def version
+      "Amber #{Amber::VERSION}"
     end
 
-    private def host_url
-      "#{scheme}://#{settings.host}:#{settings.port}".colorize(:light_cyan).mode(:underline)
+    def host_url
+      "#{scheme}://#{settings.host}:#{settings.port}"
     end
 
-    private def ssl_enabled?
+    def ssl_enabled?
       settings.ssl_key_file && settings.ssl_cert_file
     end
 
-    private def scheme
+    def scheme
       ssl_enabled? ? "https" : "http"
     end
 
-    private def logger
+    def logger
       Amber.logger
     end
 


### PR DESCRIPTION
### Description of the Change

This PR:

* Makes public some of the `Amber::Server` methods to make possible accessing them from outer scope when needed, like for instance in [raven.cr](https://github.com/Sija/raven.cr) shard when building full request url - see [Kemal integration](https://github.com/Sija/raven.cr/blob/33cf933064ff8d287439b8d36361b1ea00a2ead7/src/raven/integrations/kemal.cr#L19-L22) as an example.
* Moves `.colorize` calls from the method's return value directly to `Amber::Server.start`, where it should've been in the first place.

### Alternate Designs

Monkey-patching.

### Benefits

```cr
# being able to call

Amber::Server.instance.version      # => "Amber 0.7.2"
Amber::Server.instance.scheme       # => "http"
Amber::Server.instance.ssl_enabled? # => false
```

### Possible Drawbacks

None (I would know of).