### PR TITLE
Fix Auth generator for classes different than User

### DIFF
--- a/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
@@ -16,8 +16,8 @@ class <%= class_name %> < Granite::ORM::Base
     (email = <%= @name %>.email) ? !email.empty? : false
   end
 
-  validate :email, "already in use", -> (user : User) do
-    existing = User.find_by :email, user.email
+  validate :email, "already in use", -> (<%= @name %> : <%= class_name %>) do
+    existing = <%= class_name %>.find_by :email, <%= @name %>.email
     !existing
   end
 


### PR DESCRIPTION
### Description of the Change

Model class generated by 
```bash
amber g auth Player
```

Generated a class `Player` with code that referenced to `User`, when the model name that we specified was  `Player`

### Alternate Designs

not applicable

### Benefits

not applicable

### Possible Drawbacks

not applicable
