### PR TITLE
Fix indentation when adding auth routes

### DIFF
--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -3,7 +3,7 @@ module Amber::CLI::Helpers
     routes = File.read("./config/routes.cr")
     replacement = <<-ROUTES
     routes :#{pipeline.to_s} do
-        #{route}
+      #{route}
     ROUTES
     File.write("./config/routes.cr", routes.gsub("routes :#{pipeline.to_s} do", replacement))
   end

--- a/src/amber/cli/templates/auth.cr
+++ b/src/amber/cli/templates/auth.cr
@@ -33,13 +33,13 @@ module Amber::CLI
     private def setup_routes
       add_routes :web, <<-ROUTES
         get "/profile", #{class_name}Controller, :show
-        get "/profile/edit", #{class_name}Controller, :edit
-        patch "/profile", #{class_name}Controller, :update
-        get "/signin", SessionController, :new
-        post "/session", SessionController, :create
-        get "/signout", SessionController, :delete
-        get "/signup", RegistrationController, :new
-        post "/registration", RegistrationController, :create
+          get "/profile/edit", #{class_name}Controller, :edit
+          patch "/profile", #{class_name}Controller, :update
+          get "/signin", SessionController, :new
+          post "/session", SessionController, :create
+          get "/signout", SessionController, :delete
+          get "/signup", RegistrationController, :new
+          post "/registration", RegistrationController, :create
       ROUTES
     end
 


### PR DESCRIPTION
### Description of the Change

When generating Auth from template, a couple of routes are added with wrong indentation. This PR fix that.

Before:

```crystal
  routes :web do
      get "/profile", PlayerController, :show
  get "/profile/edit", PlayerController, :edit
  patch "/profile", PlayerController, :update
  get "/signin", SessionController, :new
  post "/session", SessionController, :create
  get "/signout", SessionController, :delete
  get "/signup", RegistrationController, :new
  post "/registration", RegistrationController, :create
    get "/", HomeController, :index
  end
```
After:

```crystal
  routes :web do
    get "/profile", PlayerController, :show
    get "/profile/edit", PlayerController, :edit
    patch "/profile", PlayerController, :update
    get "/signin", SessionController, :new
    post "/session", SessionController, :create
    get "/signout", SessionController, :delete
    get "/signup", RegistrationController, :new
    post "/registration", RegistrationController, :create
    get "/", HomeController, :index
  end
```
