### PR TITLE
Fix HTML issues in application.ecr template

### DIFF
--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -1,13 +1,13 @@
 <!doctype html>
 <html>
   <head>
-  <title><%= display_name %> using Amber</title>
+    <title><%= display_name %> using Amber</title>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
     <link rel="stylesheet" href="/dist/main.bundle.css">
-  <head>
+  </head>
   <body>
     <div class="masthead">
       <div class="container">


### PR DESCRIPTION
Fixes two small issues in the template for `application.ecr`.

1. Indentation of the `title` tag.
2. Broken closing `head` tag.