### PR TITLE
Enhancements for Travis and Specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,13 @@ cache:
     - lib
     - .shards
 
+env:
+  - TEST_SUITE=./spec/build_spec.cr
+  - TEST_SUITE=./spec/amber
+
 script:
-  - bin/ameba ./src
-  - crystal spec ./spec/amber
-  - crystal spec ./spec/build_spec.cr -D run_build_tests
+  - bin/ameba src/ $TEST_SUITE
+  - crystal spec $TEST_SUITE
 
 notifications:
   webhooks:
@@ -24,4 +27,3 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
-

--- a/spec/build_spec.cr
+++ b/spec/build_spec.cr
@@ -1,4 +1,3 @@
-{% if flag?(:run_build_tests) %}
 require "./spec_helper"
 require "./support/helpers/cli_helper"
 
@@ -70,4 +69,3 @@ module Amber::CLI
     cleanup
   end
 end
-{% end %}


### PR DESCRIPTION
### Description of the Change

We changed Travis jobs by a single Travis build because we thought this was causing Travis failures.

I discovered and fixed this failure on #783 

So, this change will speed up our CI

This PR also removes the macro flag to avoid misleading results on specs

### Alternate Designs

No

### Benefits

Speed up CI builds

### Possible Drawbacks

No
