### PR TITLE
Database migration enhancements

### DIFF
--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -102,9 +102,7 @@ module Amber::CLI
       private def create_database
         url = Micrate::DB.connection_url.to_s
         if url.starts_with? "sqlite3:"
-          puts <<-MSG
-          No migration files were found. For sqlite3, the database will be created during the first migration.
-          MSG
+          "For sqlite3, the database will be created during the first migration."
         else
           name = set_database_to_schema url
           Micrate::DB.connect do |db|

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -15,6 +15,7 @@ module Amber::CLI
     class Database < Command
       command_name "database"
       MIGRATIONS_DIR = "./db/migrations"
+      CREATE_SQLITE_MESSAGE = "For sqlite3, the database will be created during the first migration."
 
       class Options
         arg_array "commands", desc: "drop create migrate rollback redo status version seed"
@@ -102,7 +103,7 @@ module Amber::CLI
       private def create_database
         url = Micrate::DB.connection_url.to_s
         if url.starts_with? "sqlite3:"
-          "For sqlite3, the database will be created during the first migration."
+          CREATE_SQLITE_MESSAGE
         else
           name = set_database_to_schema url
           Micrate::DB.connect do |db|

--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -3,7 +3,7 @@ module Amber::CLI::Helpers
     routes = File.read("./config/routes.cr")
     replacement = <<-ROUTES
     routes :#{pipeline.to_s} do
-        #{route}
+      #{route}
     ROUTES
     File.write("./config/routes.cr", routes.gsub("routes :#{pipeline.to_s} do", replacement))
   end

--- a/src/amber/cli/templates/auth.cr
+++ b/src/amber/cli/templates/auth.cr
@@ -33,13 +33,13 @@ module Amber::CLI
     private def setup_routes
       add_routes :web, <<-ROUTES
         get "/profile", #{class_name}Controller, :show
-        get "/profile/edit", #{class_name}Controller, :edit
-        patch "/profile", #{class_name}Controller, :update
-        get "/signin", SessionController, :new
-        post "/session", SessionController, :create
-        get "/signout", SessionController, :delete
-        get "/signup", RegistrationController, :new
-        post "/registration", RegistrationController, :create
+          get "/profile/edit", #{class_name}Controller, :edit
+          patch "/profile", #{class_name}Controller, :update
+          get "/signin", SessionController, :new
+          post "/session", SessionController, :create
+          get "/signout", SessionController, :delete
+          get "/signup", RegistrationController, :new
+          post "/registration", RegistrationController, :create
       ROUTES
     end
 

--- a/src/amber/cli/templates/migration.cr
+++ b/src/amber/cli/templates/migration.cr
@@ -20,7 +20,6 @@ module Amber::CLI
       @fields += %w(created_at:time updated_at:time).map do |f|
         Field.new(f, hidden: true, database: @database)
       end
-      @timestamp = Time.now.to_s("%Y%m%d%H%M%S%L")
       @primary_key = primary_key
     end
   end

--- a/src/amber/cli/templates/migration.cr
+++ b/src/amber/cli/templates/migration.cr
@@ -14,7 +14,6 @@ module Amber::CLI
     @primary_key : String
 
     def initialize(@name, fields)
-      @fields = fields.map { |field| Field.new(field) }
       @timestamp = Time.now.to_s("%Y%m%d%H%M%S%L")
       @fields = fields.map { |field| Field.new(field, database: @database) }
       @fields += %w(created_at:time updated_at:time).map do |f|


### PR DESCRIPTION
### Description of the Change

This PR does:

- Fix wrong database message for sqlite on `amber db drop create`

```
➜  blog ../amber/bin/amber db drop create
09:46:32 Database   | (INFO) Deleted file ./db/blog_development.db
09:46:32 Class      | (INFO) No migration files were found. For sqlite3, the database will be created during the first migration.
09:46:32 Database   | (INFO) #<IO::FileDescriptor:0x55fa5dd72e10>
```

- Removes duplicate `@timestamp` on `src/amber/cli/templates/migration.cr`
- Renames `.keep` to `.gitkeep` to be recognized by editors.


![screenshot_20180513_101955](https://user-images.githubusercontent.com/3067335/39968713-3137ae20-5697-11e8-8d8a-13f94a34a1f2.png)

![screenshot_20180513_101921](https://user-images.githubusercontent.com/3067335/39968715-3c432218-5697-11e8-9fa0-4cfde030ea3e.png)

### Alternate Designs

No

### Benefits

Fix sqlite message, file editor icon, remove duplicate code

### Possible Drawbacks

No
