### PR TITLE
Update granite and rename Granite::ORM to Granite

### DIFF
--- a/spec/support/fixtures/cli_fixtures.cr
+++ b/spec/support/fixtures/cli_fixtures.cr
@@ -55,7 +55,7 @@ module CLIFixtures
 
   def expected_post_model
     <<-MODEL
-    class Post < Granite::ORM::Base
+    class Post < Granite::Base
       adapter pg
       table_name posts
 

--- a/src/amber/cli/templates/app/config/initializers/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/initializers/database.cr.ecr
@@ -1,9 +1,9 @@
 <% if @model == "granite" -%>
-require "granite_orm/adapter/<%= @database %>"
+require "granite/adapter/<%= @database %>"
 
-Granite::ORM.settings.database_url = Amber.settings.database_url
-Granite::ORM.settings.logger = Amber.settings.logger.dup
-Granite::ORM.settings.logger.progname = "Granite"
+Granite.settings.database_url = Amber.settings.database_url
+Granite.settings.logger = Amber.settings.logger.dup
+Granite.settings.logger.progname = "Granite"
 
 <% else -%>
 require "<%= @database %>"

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -30,9 +30,9 @@ dependencies:
     github: Crecto/crecto
     version: ~> 0.8.1
 <% else -%>
-  granite_orm:
-    github: amberframework/granite-orm
-    version: ~> 0.9.1
+  granite:
+    github: amberframework/granite
+    version: ~> 0.11.0
 <% end -%>
 
   quartz_mailer:

--- a/src/amber/cli/templates/app/spec/spec_helper.cr
+++ b/src/amber/cli/templates/app/spec/spec_helper.cr
@@ -12,7 +12,7 @@ Micrate::DB.connection_url = Amber.settings.database_url
 Micrate::Cli.run_up
 
 # Disable query logger for tests
-Granite::ORM.settings.logger = Logger.new nil
+Granite.settings.logger = Logger.new nil
 
 module Spec
   DRIVER = :chrome

--- a/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
@@ -1,7 +1,7 @@
-require "granite_orm/adapter/<%= @database %>"
+require "granite/adapter/<%= @database %>"
 require "crypto/bcrypt/password"
 
-class <%= class_name %> < Granite::ORM::Base
+class <%= class_name %> < Granite::Base
   include Crypto
   adapter <%= @database %>
   primary id : Int64

--- a/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
@@ -1,4 +1,4 @@
-class <%= class_name %> < Granite::ORM::Base
+class <%= class_name %> < Granite::Base
   adapter <%= @database %>
   <%= "table_name #{table_name}" %>
 


### PR DESCRIPTION
### Description of the Change

This updated Granite to latest version, including new granite namespace: `Granite` (without `::ORM`)

### Alternate Designs

No

### Benefits

Fixes #793 

Use latest granite version `v0.11.0`

### Possible Drawbacks

No
