### PR TITLE
Simplifies render by removing edge case.

### DIFF
--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -84,11 +84,11 @@ end
 
 class RenderController < Amber::Controller::Base
   def render_template_page
-    render("spec/support/sample/views/test/test.slang", layout: false)
+    render(path: "spec/support/sample/views", template: "test/test.slang", layout: false)
   end
 
   def render_partial
-    render(partial: "spec/support/sample/views/test/_test.slang")
+    render(path: "spec/support/sample/views", partial: "test/_test.slang")
   end
 
   def render_with_layout
@@ -100,12 +100,12 @@ class RenderController < Amber::Controller::Base
   end
 
   def render_with_csrf
-    render(partial: "spec/support/sample/views/test/_form.slang")
+    render(path: "spec/support/sample/views", partial: "test/_form.slang")
   end
 
   def render_with_flash
     flash["error"] = "Displays error Message!"
-    render("spec/support/sample/views/test/flash.slang", layout: false)
+    render(path: "spec/support/sample/views", template: "test/flash.slang", layout: false)
   end
 end
 

--- a/spec/support/sample/views/layouts/layout_with_partials.slang
+++ b/spec/support/sample/views/layouts/layout_with_partials.slang
@@ -1,7 +1,7 @@
 html
   body
     h1
-      == render(partial: "spec/support/sample/views/test/_test.slang")
+      == render(path: "spec/support/sample/views", partial: "test/_test.slang")
     h2
-      == render(partial: "spec/support/sample/views/test/_test2.slang")
+      == render(path: "spec/support/sample/views", partial: "test/_test2.slang")
     == content

--- a/src/amber/controller/helpers/render.cr
+++ b/src/amber/controller/helpers/render.cr
@@ -15,27 +15,23 @@ module Amber::Controller::Helpers
       {% else %}
         {{ short_path = folder.gsub(/^.+?(?:controllers|views)\//, "") }}
         {% if folder.id.ends_with?(".ecr") %}
-          %content = render_template("#{{{path}}}/#{{{short_path.gsub(/\/[^\.\/]+\.ecr/, "")}}}/#{{{filename}}}")
+          %content = render_template("#{{{short_path.gsub(/\/[^\.\/]+\.ecr/, "")}}}/#{{{filename}}}", {{path}})
         {% else %}
-          %content = render_template("#{{{path}}}/#{{{short_path.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}")
+          %content = render_template("#{{{short_path.gsub(/\_controller\.cr|\.cr/, "")}}}/#{{{filename}}}", {{path}})
         {% end %}
       {% end %}
 
       # Render Layout
       {% if layout && !partial %}
         content = %content
-        render_template("#{{{path}}}/layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}")
+        render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
       {% else %}
         %content
       {% end %}
     end
 
     private macro render_template(filename, path = "src/views")
-      {% if filename.id.split("/").size > 2 %}
-        Kilt.render("{{filename.id}}")
-      {% else %}
-        Kilt.render("#{{{path}}}/{{filename.id}}")
-      {% end %}
+      Kilt.render("#{{{path}}}/{{filename.id}}")
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

Resolves issue: https://github.com/amberframework/amber/issues/790

Simplifies render by removing edge case, which is mostly only useful in specs. 

Still easily testable by passing in path param.

### Alternate Designs

Leave it how it is.

### Benefits

More straight forward with fewer magics to remember.

### Possible Drawbacks

Less magic, but more readable.
