### PR TITLE
Change confusing puts to info and add error logger

### DIFF
--- a/src/amber/cli/command.cr
+++ b/src/amber/cli/command.cr
@@ -1,5 +1,9 @@
 abstract class Command < Cli::Command
-  def puts(msg)
+  def info(msg)
     Amber::CLI.logger.info msg, Class.name, :light_cyan
+  end
+
+  def error(msg)
+    Amber::CLI.logger.error msg, Class.name, :red
   end
 end

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -120,7 +120,7 @@ module Amber::CLI
           Micrate::DB.connection_url = url.gsub(path, "/#{uri.scheme}")
           return path.gsub("/", "")
         else
-          CLI.logger.info "Could not determine database name", "Error", :red
+          info "Could not determine database name"
         end
       end
 

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -120,7 +120,7 @@ module Amber::CLI
           Micrate::DB.connection_url = url.gsub(path, "/#{uri.scheme}")
           return path.gsub("/", "")
         else
-          info "Could not determine database name"
+          error "Could not determine database name"
         end
       end
 

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -13,6 +13,7 @@ module Amber::CLI
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
         string ["-e", "--editor"], desc: "Preferred editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
         string ["-b", "--back"], desc: "Runs previous command files: 'amber exec -b [times_ago]'", default: "0"
+        bool "--no-color", desc: "Disable colored output", default: false
         help
       end
 
@@ -57,6 +58,7 @@ module Amber::CLI
       end
 
       def run
+        CLI.toggle_colors(options.no_color?)
         Dir.mkdir("tmp") unless Dir.exists?("tmp")
 
         if args.code.blank? || File.exists?(args.code)

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -35,7 +35,7 @@ module Amber::CLI
         File.open(@filelogs, "r") do |file|
           loop do
             output = file.gets_to_end
-            STDOUT.puts output unless output.empty?
+            puts output unless output.empty?
             sleep 1.millisecond
           end
         end

--- a/src/amber/cli/commands/generate.cr
+++ b/src/amber/cli/commands/generate.cr
@@ -19,6 +19,7 @@ module Amber::CLI
       end
 
       def run
+        CLI.toggle_colors(options.no_color?)
         if args.type == "error"
           template = Template.new("error", ".")
         else
@@ -39,7 +40,7 @@ module Amber::CLI
 
       private def ensure_name_argument!
         unless args.name?
-          CLI.logger.info "Parsing Error: The NAME argument is required.", "Error", :red
+          info "Parsing Error: The NAME argument is required."
           exit! help: true, error: true
         end
       end

--- a/src/amber/cli/commands/generate.cr
+++ b/src/amber/cli/commands/generate.cr
@@ -40,7 +40,7 @@ module Amber::CLI
 
       private def ensure_name_argument!
         unless args.name?
-          info "Parsing Error: The NAME argument is required."
+          error "Parsing Error: The NAME argument is required."
           exit! help: true, error: true
         end
       end

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -22,12 +22,12 @@ module Amber::CLI
       end
 
       def run
-        Amber::CLI.color = !options.no_color?
+        CLI.toggle_colors(options.no_color?)
         full_path_name = File.join(Dir.current, args.name)
         if full_path_name =~ /\s+/
-          CLI.logger.error "Path and project name can't contain a space."
-          CLI.logger.error "Replace spaces with underscores or dashes."
-          CLI.logger.error "#{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
+          error "Path and project name can't contain a space."
+          info "Replace spaces with underscores or dashes."
+          info "#{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
           exit 1
         end
         name = File.basename(args.name)

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -28,7 +28,7 @@ module Amber::CLI
           error "Path and project name can't contain a space."
           info "Replace spaces with underscores or dashes."
           info "#{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
-          exit 1
+          exit! error: true
         end
         name = File.basename(args.name)
 

--- a/src/amber/cli/commands/pipelines.cr
+++ b/src/amber/cli/commands/pipelines.cr
@@ -62,12 +62,12 @@ module Amber::CLI
       rescue ex : BadRoutesException
         error ex.message
         info "Good bye :("
-        exit 1
+        exit! error: true
       rescue ex
         error "Error: Not valid project root directory."
         info "Run `amber pipelines` in project root directory."
         info "Good bye :("
-        exit 1
+        exit! error: true
       end
 
       private def parse_routes

--- a/src/amber/cli/commands/pipelines.cr
+++ b/src/amber/cli/commands/pipelines.cr
@@ -56,16 +56,17 @@ module Amber::CLI
       command_name "pipelines"
 
       def run
+        CLI.toggle_colors(options.no_color?)
         parse_routes
         print_pipelines
       rescue ex : BadRoutesException
-        CLI.logger.error(ex.message.colorize(:red))
-        CLI.logger.error "Good bye :("
+        error ex.message
+        info "Good bye :("
         exit 1
       rescue ex
-        CLI.logger.error "Error: Not valid project root directory.".colorize(:red)
-        CLI.logger.error "Run `amber pipelines` in project root directory.".colorize(:light_blue)
-        CLI.logger.error "Good bye :("
+        error "Error: Not valid project root directory."
+        info "Run `amber pipelines` in project root directory."
+        info "Good bye :("
         exit 1
       end
 

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -33,6 +33,7 @@ module Amber::CLI
       end
 
       def run
+        CLI.toggle_colors(options.no_color?)
         parse_routes
         print_routes_table
       rescue

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -39,7 +39,7 @@ module Amber::CLI
         error "Not valid project root directory."
         info "Run `amber routes` in project root directory."
         info "Good bye :("
-        exit 1
+        exit! error: true
       end
 
       private def parse_routes

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -36,9 +36,9 @@ module Amber::CLI
         parse_routes
         print_routes_table
       rescue
-        puts "Error: Not valid project root directory.".colorize(:red)
-        puts "Run `amber routes` in project root directory.".colorize(:light_blue)
-        puts "Good bye :("
+        error "Not valid project root directory."
+        info "Run `amber routes` in project root directory."
+        info "Good bye :("
         exit 1
       end
 

--- a/src/amber/cli/recipes/recipe.cr
+++ b/src/amber/cli/recipes/recipe.cr
@@ -37,6 +37,7 @@ module Amber::Recipes
         @name = name.underscore
       else
         error "Name is not valid."
+        exit 1
       end
 
       @directory = File.join(directory)
@@ -78,6 +79,7 @@ module Amber::Recipes
         Scaffold::View.new(name, @recipe, @fields).render(directory, list: true, color: true)
       else
         error "Template not found"
+        exit 1
       end
     end
 

--- a/src/amber/cli/recipes/recipe.cr
+++ b/src/amber/cli/recipes/recipe.cr
@@ -53,21 +53,21 @@ module Amber::Recipes
       case template
       when "app"
         if options
-          log_message "Rendering App #{name} in #{directory} from #{options.r}"
+          info "Rendering App #{name} in #{directory} from #{options.r}"
           App.new(name, options.d, options.t, options.m, options.r).render(directory, list: true, color: true)
           if options.deps?
-            log_message "Installing Dependencies"
+            info "Installing Dependencies"
             Amber::CLI::Helpers.run("cd #{name} && shards update")
           end
         end
       when "controller"
-        log_message "Rendering Controller #{name} from #{@recipe}"
+        info "Rendering Controller #{name} from #{@recipe}"
         Controller.new(name, @recipe, @fields).render(directory, list: true, color: true)
       when "model"
-        log_message "Rendering Model #{name} from #{@recipe}"
+        info "Rendering Model #{name} from #{@recipe}"
         Model.new(name, @recipe, @fields).render(directory, list: true, color: true)
       when "scaffold"
-        log_message "Rendering Scaffold #{name} from #{@recipe}"
+        info "Rendering Scaffold #{name} from #{@recipe}"
         if model == "crecto"
           Amber::CLI::CrectoMigration.new(name, @fields).render(directory, list: true, color: true)
         else
@@ -85,7 +85,7 @@ module Amber::Recipes
       CLI.config.model
     end
 
-    def log_message(msg)
+    def info(msg)
       CLI.logger.info msg, "Generate", :light_cyan
     end
   end

--- a/src/amber/cli/recipes/recipe.cr
+++ b/src/amber/cli/recipes/recipe.cr
@@ -36,7 +36,7 @@ module Amber::Recipes
       if name.match(/\A[a-zA-Z]/)
         @name = name.underscore
       else
-        raise "Name is not valid."
+        error "Name is not valid."
       end
 
       @directory = File.join(directory)
@@ -77,7 +77,7 @@ module Amber::Recipes
         Scaffold::Controller.new(name, @recipe, @fields).render(directory, list: true, color: true)
         Scaffold::View.new(name, @recipe, @fields).render(directory, list: true, color: true)
       else
-        CLI.logger.error "Template not found", "Generate", :light_red
+        error "Template not found"
       end
     end
 
@@ -87,6 +87,10 @@ module Amber::Recipes
 
     def info(msg)
       CLI.logger.info msg, "Generate", :light_cyan
+    end
+
+    def error(msg)
+      CLI.logger.error msg, "Generate", :light_red
     end
   end
 end

--- a/src/amber/cli/templates/template.cr
+++ b/src/amber/cli/templates/template.cr
@@ -28,7 +28,8 @@ module Amber::CLI
       if name.match(/\A[a-zA-Z]/)
         @name = name.underscore
       else
-        raise "Name is not valid."
+        error "Name is not valid."
+        exit 1
       end
 
       @directory = File.join(directory)
@@ -43,18 +44,18 @@ module Amber::CLI
       case template
       when "app"
         if options
-          puts "Rendering App #{name} in #{directory}"
+          info "Rendering App #{name} in #{directory}"
           App.new(name, options.d, options.t, options.m).render(directory, list: true, color: true)
           if options.deps?
-            puts "Installing Dependencies"
+            info "Installing Dependencies"
             Helpers.run("cd #{name} && shards update")
           end
         end
       when "migration"
-        puts "Rendering Migration #{name}"
+        info "Rendering Migration #{name}"
         Migration.new(name, fields).render(directory, list: true, color: true)
       when "model"
-        puts "Rendering Model #{name}"
+        info "Rendering Model #{name}"
         if model == "crecto"
           CrectoMigration.new(name, fields).render(directory, list: true, color: true)
           CrectoModel.new(name, fields).render(directory, list: true, color: true)
@@ -63,10 +64,10 @@ module Amber::CLI
           GraniteModel.new(name, fields).render(directory, list: true, color: true)
         end
       when "controller"
-        puts "Rendering Controller #{name}"
+        info "Rendering Controller #{name}"
         Controller.new(name, fields).render(directory, list: true, color: true)
       when "scaffold"
-        puts "Rendering Scaffold #{name}"
+        info "Rendering Scaffold #{name}"
         if model == "crecto"
           CrectoMigration.new(name, fields).render(directory, list: true, color: true)
           CrectoModel.new(name, fields).render(directory, list: true, color: true)
@@ -78,10 +79,10 @@ module Amber::CLI
         end
         Scaffold::View.new(name, fields).render(directory, list: true, color: true)
       when "mailer"
-        puts "Rendering Mailer #{name}"
+        info "Rendering Mailer #{name}"
         Mailer.new(name, fields).render(directory, list: true, color: true)
       when "socket"
-        puts "Rendering Socket #{name}"
+        info "Rendering Socket #{name}"
         if fields != [] of String
           fields.each do |field|
             WebSocketChannel.new(field).render(directory, list: true, color: true)
@@ -89,16 +90,17 @@ module Amber::CLI
         end
         WebSocket.new(name, fields).render(directory, list: true, color: true)
       when "channel"
-        puts "Rendering Channel #{name}"
+        info "Rendering Channel #{name}"
         WebSocketChannel.new(name).render(directory, list: true, color: true)
       when "auth"
-        puts "Rendering Auth #{name}"
+        info "Rendering Auth #{name}"
         if model == "crecto"
-          raise "Auth not supported for crecto yet"
+          error "Auth not supported for crecto yet"
+          exit 1
         end
         Auth.new(name, fields).render(directory, list: true, color: true)
       when "error"
-        puts "Rendering Error Template"
+        info "Rendering Error Template"
         actions = ["forbidden", "not_found", "internal_server_error"]
         ErrorTemplate.new("error", actions).render(directory, list: true, color: true)
       else
@@ -110,8 +112,12 @@ module Amber::CLI
       CLI.config.model
     end
 
-    def puts(msg)
+    def info(msg)
       CLI.logger.info msg, "Generate", :light_cyan
+    end
+
+    def error(msg)
+      CLI.logger.error msg, "Generate", :red
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

This PR does:

- Removes `puts` to call Amber logger because is a bit confusing.
- Encourages to use `info` and `error` as shortcut for `CLI.logger`
- Adds missing `toggle_colors` for some sub commands with already existent `--no-color` flag
- Encourages to use `exit!` method from cli shard on cli commands, See: [Explicit Exit](https://github.com/mosop/cli/wiki/The-Exit-Ways#explicit-exit)

### Alternate Designs

No

### Benefits

Logger usage more explicit 

Can use stdlib `puts` without `::puts` or `STDOUT.puts`

### Possible Drawbacks

No
