### PR TITLE
Fix format issues when scaffolding auth

### DIFF
--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -16,9 +16,7 @@ module Amber::CLI::Helpers
     return unless pipes
 
     replacement = <<-PLUGS
-    pipeline :#{pipeline.to_s} do
-      #{pipes[1]}
-      #{plug}
+    pipeline :#{pipeline.to_s} do#{pipes[1]}#{plug}
       end
     PLUGS
     File.write("./config/routes.cr", routes.gsub(pipes[0], replacement))

--- a/src/amber/cli/templates/auth.cr
+++ b/src/amber/cli/templates/auth.cr
@@ -83,7 +83,7 @@ module Amber::CLI
 
         def current_#{@name}
           context.current_#{@name}
-        end
+        end\n
       AUTH
     end
 
@@ -104,7 +104,7 @@ module Amber::CLI
             flash[:info] = "Must be logged in"
             redirect_to "/signin"
           end
-        end\n
+        end
       AUTH
     end
 

--- a/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/session_controller.cr.ecr
@@ -7,14 +7,14 @@ class SessionController < ApplicationController
   def create
     <%= @name %> = <%= class_name %>.find_by(:email, params["email"].to_s)
     if <%= @name %> && <%= @name %>.authenticate(params["password"].to_s)
-        session[:<%= @name %>_id] = <%= @name %>.id
-        flash[:info] = "Successfully logged in"
-        redirect_to "/"
-      else
-        flash[:danger] = "Invalid email or password"
-        <%= @name %> = <%= class_name %>.new
-        render("new.<%= @language %>")
-      end
+      session[:<%= @name %>_id] = <%= @name %>.id
+      flash[:info] = "Successfully logged in"
+      redirect_to "/"
+    else
+      flash[:danger] = "Invalid email or password"
+      <%= @name %> = <%= class_name %>.new
+      render("new.<%= @language %>")
+    end
   end
 
   def delete

--- a/src/amber/cli/templates/auth/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/{{name}}_controller.cr.ecr
@@ -33,8 +33,8 @@ class <%= class_name %>Controller < ApplicationController
 
   private def <%= @name %>_params
     params.validation do
-      required(:email) {|f| !f.nil? && !f.empty? }
-      optional(:password) {|f| !f.nil? && !f.empty? }
+      required(:email) { |f| !f.nil? && !f.empty? }
+      optional(:password) { |f| !f.nil? && !f.empty? }
     end
   end
 end

--- a/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
@@ -12,16 +12,16 @@ class <%= class_name %> < Granite::ORM::Base
   timestamps
 <% end -%>
 
-  validate :email, "is required", -> (<%= @name %> : <%= class_name %>) do
+  validate :email, "is required", ->(<%= @name %> : <%= class_name %>) do
     (email = <%= @name %>.email) ? !email.empty? : false
   end
 
-  validate :email, "already in use", -> (<%= @name %> : <%= class_name %>) do
+  validate :email, "already in use", ->(<%= @name %> : <%= class_name %>) do
     existing = <%= class_name %>.find_by :email, <%= @name %>.email
     !existing
   end
 
-  validate :password, "is too short", -> (<%= @name %> : <%= class_name %>) do
+  validate :password, "is too short", ->(<%= @name %> : <%= class_name %>) do
     <%= @name %>.password_changed? ? <%= @name %>.valid_password_size? : true
   end
 

--- a/src/amber/cli/templates/auth/src/pipes/authenticate.cr.ecr
+++ b/src/amber/cli/templates/auth/src/pipes/authenticate.cr.ecr
@@ -28,5 +28,4 @@ class Authenticate < Amber::Pipe::Base
     # Example, if only a few private paths exist
     # return false if ["/secret", "/super/secret", "/private"].includes?(path)
   end
-
 end


### PR DESCRIPTION
Now when a user scaffold authentication using cli, the code generated doesn't produce `crystal tool format` issues.

Fixes #748 