### PR TITLE
fixes not_nil runtime exception in json parser

### DIFF
--- a/spec/amber/router/parsers/json_spec.cr
+++ b/spec/amber/router/parsers/json_spec.cr
@@ -1,0 +1,21 @@
+require "../../../../spec_helper"
+
+module Amber::Router::Parsers
+  describe JSON do
+    describe "self.parse" do
+      it "should allow a nil body" do
+        request = HTTP::Request.new("PUT", "/")
+        request.body.should be_nil
+        params = JSON.parse(request)
+        params.keys.empty?.should be_true
+      end
+
+      it "should parse a json body" do
+        body = {test: "123"}.to_json
+        request = HTTP::Request.new("PUT", "/", nil, body)
+        params = JSON.parse(request)
+        params["test"].should eq "123"
+      end
+    end
+  end
+end

--- a/src/amber/router/parsers/json.cr
+++ b/src/amber/router/parsers/json.cr
@@ -2,19 +2,21 @@ module Amber::Router::Parsers
   module JSON
     def self.parse(request : HTTP::Request)
       json_params = Types::Params.new
-      if body = request.body.not_nil!.gets_to_end
-        if body.size > 2
-          case json = ::JSON.parse_raw(body)
-          when Hash
-            json.each do |key, value|
-              if value.is_a?(String)
-                json_params[key.as(String)] = value
-              else
-                json_params[key.as(String)] = value.to_json
+      if request_body = request.body
+        if body = request_body.gets_to_end
+          if body.size > 2
+            case json = ::JSON.parse_raw(body)
+            when Hash
+              json.each do |key, value|
+                if value.is_a?(String)
+                  json_params[key.as(String)] = value
+                else
+                  json_params[key.as(String)] = value.to_json
+                end
               end
+            when Array
+              json_params["_json"] = json.to_json
             end
-          when Array
-            json_params["_json"] = json.to_json
           end
         end
       end


### PR DESCRIPTION
### Description of the Change

Fixes #800 

It is possible for the request body to be nil with a JSON request (DELETE request for example), causing Amber to log a 200 response whereas the actual response in the browser is 500.

This change checks for existence rather than using `not_nil!`.
