### PR TITLE
Use context.locale instead of ::I18n.locale

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -23,7 +23,7 @@ dependencies:
 
   citrine-i18n:
     github: amberframework/citrine-i18n
-    version: 0.1.0
+    version: 0.2.0
 
 <% case @model when "crecto" -%>
   crecto:

--- a/src/amber/controller/helpers/i18n.cr
+++ b/src/amber/controller/helpers/i18n.cr
@@ -1,11 +1,11 @@
 module Amber::Controller::Helpers
   module I18n
     def t(*arg)
-      ::I18n.translate(*arg)
+      ::I18n.translate(*arg, force_locale: context.locale)
     end
 
     def l(*arg)
-      ::I18n.localize(*arg)
+      ::I18n.localize(*arg, force_locale: context.locale)
     end
   end
 end

--- a/src/amber/controller/helpers/i18n.cr
+++ b/src/amber/controller/helpers/i18n.cr
@@ -1,5 +1,3 @@
-require "citrine-i18n"
-
 module Amber::Controller::Helpers
   module I18n
     def t(*arg)

--- a/src/amber/controller/helpers/i18n.cr
+++ b/src/amber/controller/helpers/i18n.cr
@@ -1,3 +1,5 @@
+require "citrine-i18n"
+
 module Amber::Controller::Helpers
   module I18n
     def t(*arg)


### PR DESCRIPTION
This commit makes the locale choice thread-safe.

The corresponding changes to the citrine-i18n shard have already been made.

Fixes #776.