### PR TITLE
Update ::puts to puts

### DIFF
--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -78,7 +78,7 @@ module Amber::CLI
         end
 
         unless exit_code.zero?
-          ::puts File.read(@filename)
+          puts File.read(@filename)
           exit! error: true, code: exit_code
         end
       end


### PR DESCRIPTION
### Description of the Change

#796 has been merged, this PR changes `::puts` by `puts`

### Alternate Designs

No

### Benefits

Use standard `puts` without misleading behaviors, fixed on #796 

### Possible Drawbacks

No
