### PR TITLE
Fixes view filename for controller in recipes

### DIFF
--- a/src/amber/cli/recipes/controller.cr
+++ b/src/amber/cli/recipes/controller.cr
@@ -51,7 +51,7 @@ module Amber::Recipes
     end
 
     def add_views
-      @actions.each do |action|
+      @actions.each do |action, verb|
         FileUtils.mkdir_p("src/views/#{@name}")
         File.touch("src/views/#{@name}/#{action}.#{language}")
       end

--- a/src/amber/cli/recipes/controller.cr
+++ b/src/amber/cli/recipes/controller.cr
@@ -51,7 +51,7 @@ module Amber::Recipes
     end
 
     def add_views
-      @actions.each do |action, verb|
+      @actions.each do |action, _|
         FileUtils.mkdir_p("src/views/#{@name}")
         File.touch("src/views/#{@name}/#{action}.#{language}")
       end

--- a/src/amber/cli/recipes/controller.cr
+++ b/src/amber/cli/recipes/controller.cr
@@ -51,9 +51,9 @@ module Amber::Recipes
     end
 
     def add_views
-      @actions.each do |action, _|
+      @actions.each do |action_name, _|
         FileUtils.mkdir_p("src/views/#{@name}")
-        File.touch("src/views/#{@name}/#{action}.#{language}")
+        File.touch("src/views/#{@name}/#{action_name}.#{language}")
       end
     end
   end


### PR DESCRIPTION
### Description of the Change

Fixes https://github.com/amberframework/recipes/issues/19

 I tried to generate a controller using recipes with:

```
amber generate controller Information all
```

all generated files are fine except views:

![screenshot_20180527_192413](https://user-images.githubusercontent.com/3067335/40592337-8b074be8-61e3-11e8-9efb-a6ef3cefcab6.png)

I discovered this on #15 , see failing build: https://travis-ci.org/amberframework/recipes/builds/384468314

### Alternate Designs

No

### Benefits

Fixes https://github.com/amberframework/recipes/issues/19

### Possible Drawbacks

No

/cc @damianham 