### PR TITLE
Fix Crecto auth spec

### DIFF
--- a/src/amber/cli/templates/auth/crecto/spec/models/{{name}}_spec.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/spec/models/{{name}}_spec.cr.ecr
@@ -3,6 +3,6 @@ require "../../src/models/<%= @name %>.cr"
 
 describe <%= class_name %> do
   Spec.before_each do
-    <%= class_name %>.clear
+    Repo.delete_all(<%= class_name %>)
   end
 end


### PR DESCRIPTION
### Description of the Change

This PR fixes wrong generated spec by `amber g auth User` when Crecto is used.

This was implemented on #815 by @wontruefree :+1: 

### Alternate Designs

No

### Benefits

Fixes Crecto spec

### Possible Drawbacks

No
