### PR TITLE
fix CORS issue when multiple origins

### DIFF
--- a/spec/amber/pipes/cors_spec.cr
+++ b/spec/amber/pipes/cors_spec.cr
@@ -109,6 +109,33 @@ module Amber::Pipe
           context.response.headers["Access-Control-Allow-Headers"].should eq "CoNtEnT-TyPe"
           context.response.headers["Access-Control-Allow-Origin"].should eq "example.com"
         end
+
+        context "after a previous valid preflight from another Origin" do
+          it "should set the correct headers" do
+            cors = CORS.new(origins: origins)
+
+            previous_context = cors_context(
+              "OPTIONS",
+              "Origin": "sample.com",
+              "Access-Control-Request-Method": "POST",
+              "Access-Control-Request-Headers": "CoNtEnT-TyPe"
+            )
+            cors.call(previous_context)
+
+            context = cors_context(
+              "OPTIONS",
+              "Origin": "example.com",
+              "Access-Control-Request-Method": "PUT",
+              "Access-Control-Request-Headers": "CoNtEnT-TyPe"
+            )
+            cors.call(context)
+
+            context.response.status_code = 200
+            context.response.headers["Access-Control-Allow-Methods"].should eq "PUT"
+            context.response.headers["Access-Control-Allow-Headers"].should eq "CoNtEnT-TyPe"
+            context.response.headers["Access-Control-Allow-Origin"].should eq "example.com"
+          end
+        end
       end
 
       context "invalid preflight" do

--- a/src/amber/pipes/cors.cr
+++ b/src/amber/pipes/cors.cr
@@ -135,7 +135,7 @@ module Amber
       end
 
       private def origin_header?(request)
-        @request_origin ||= request.headers[Headers::ORIGIN]? || request.headers[Headers::X_ORIGIN]?
+        @request_origin = request.headers[Headers::ORIGIN]? || request.headers[Headers::X_ORIGIN]?
       end
     end
   end


### PR DESCRIPTION
### Description of the Change

Memoized @request_origin variable was being used across multiple requests, this PR forces a refresh at each request.

### Benefits

This allows using Amber with Pipe::CORS for an API receiving requests from multiple origins.
For instance:

* if a first request comes with a 'sample.com' origin, it will receive an answer with 'Access-Control-Allow-Origin' set to sample.com
* if a second request comes with a 'example.com' origin, it will now receive an answer with 'Access-Control-Allow-Origin' set to example.com (and not sample.com like it was the case before this PR)

### Possible Drawbacks

Maybe a very very small loss in performance because `@request_origin = request.headers[Headers::ORIGIN]? || request.headers[Headers::X_ORIGIN]?` will be computed at each request instead for simply returning @request_origin when set.