### PR TITLE
Fix crecto controller spec

### DIFF
--- a/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -36,10 +36,14 @@ class <%= class_name %>ControllerTest < GarnetSpec::Controller::Test
 end
 
 describe <%= class_name %>ControllerTest do
+
+  Spec.before_each do
+    Repo.delete_all(<%= class_name %>)
+  end
+
   subject = <%= class_name %>ControllerTest.new
 
   it "renders <%= @name %> index template" do
-    <%= class_name %>.clear
     response = subject.get "/<%= Inflector.pluralize(@name) %>"
 
     response.status_code.should eq(200)
@@ -47,7 +51,6 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "renders <%= @name %> show template" do
-    <%= class_name %>.clear
     model = create_<%= @name.downcase %>
     location = "/<%= Inflector.pluralize(@name) %>/#{model.id}"
 
@@ -58,7 +61,6 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "renders <%= @name %> new template" do
-    <%= class_name %>.clear
     location = "/<%= Inflector.pluralize(@name) %>/new"
 
     response = subject.get location
@@ -68,7 +70,6 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "renders <%= @name %> edit template" do
-    <%= class_name %>.clear
     model = <%= create_model_method %>
     location = "/<%= Inflector.pluralize(@name) %>/#{model.id}/edit"
 
@@ -79,7 +80,6 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "creates a <%= @name %>" do
-    <%= class_name %>.clear
     response = subject.post "/<%= Inflector.pluralize(@name) %>", body: <%= params_name %>
 
     response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
@@ -88,7 +88,6 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "updates a <%= @name %>" do
-    <%= class_name %>.clear
     model = <%= create_model_method %>
     response = subject.patch "/<%= Inflector.pluralize(@name) %>/#{model.id}", body: <%= params_name %>
 
@@ -98,7 +97,6 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "deletes a <%= @name %>" do
-    <%= class_name %>.clear
     model = <%= create_model_method %>
     response = subject.delete "/<%= Inflector.pluralize(@name) %>/#{model.id}"
 

--- a/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -37,13 +37,10 @@ end
 
 describe <%= class_name %>ControllerTest do
 
-  Spec.before_each do
-    Repo.delete_all(<%= class_name %>)
-  end
-
   subject = <%= class_name %>ControllerTest.new
 
   it "renders <%= @name %> index template" do
+    Repo.delete_all(<%= class_name %>)
     response = subject.get "/<%= Inflector.pluralize(@name) %>"
 
     response.status_code.should eq(200)
@@ -51,6 +48,7 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "renders <%= @name %> show template" do
+    Repo.delete_all(<%= class_name %>)
     model = create_<%= @name.downcase %>
     location = "/<%= Inflector.pluralize(@name) %>/#{model.id}"
 
@@ -61,6 +59,7 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "renders <%= @name %> new template" do
+    Repo.delete_all(<%= class_name %>)
     location = "/<%= Inflector.pluralize(@name) %>/new"
 
     response = subject.get location
@@ -70,6 +69,7 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "renders <%= @name %> edit template" do
+    Repo.delete_all(<%= class_name %>)
     model = <%= create_model_method %>
     location = "/<%= Inflector.pluralize(@name) %>/#{model.id}/edit"
 
@@ -80,6 +80,7 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "creates a <%= @name %>" do
+    Repo.delete_all(<%= class_name %>)
     response = subject.post "/<%= Inflector.pluralize(@name) %>", body: <%= params_name %>
 
     response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
@@ -88,6 +89,7 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "updates a <%= @name %>" do
+    Repo.delete_all(<%= class_name %>)
     model = <%= create_model_method %>
     response = subject.patch "/<%= Inflector.pluralize(@name) %>/#{model.id}", body: <%= params_name %>
 
@@ -97,6 +99,7 @@ describe <%= class_name %>ControllerTest do
   end
 
   it "deletes a <%= @name %>" do
+    Repo.delete_all(<%= class_name %>)
     model = <%= create_model_method %>
     response = subject.delete "/<%= Inflector.pluralize(@name) %>/#{model.id}"
 

--- a/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -16,9 +16,9 @@ def <%= params_name %>
 end
 
 def <%= create_model_method %>
-  model = <%= class_name %>.new(<%= hash_name %>)
-  model.save
-  model
+  model = <%= class_name %>.new
+  model.update_from_hash(<%= hash_name %>)
+  Repo.insert(model).instance
 end
 
 class <%= class_name %>ControllerTest < GarnetSpec::Controller::Test


### PR DESCRIPTION
### Description of the Change

This PR fixes wrong generated spec by `amber g scaffold` when Crecto is used.

### Alternate Designs

No

### Benefits

Fixes Crecto controller spec.

### Possible Drawbacks

No
