### PR TITLE
Updates dependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _Amber makes building web applications fast, simple, and enjoyable - with fewer 
 
 [![Build Status](https://travis-ci.org/amberframework/amber.svg?branch=master)](https://travis-ci.org/amberframework/amber)
 [![Version](https://img.shields.io/github/tag/amberframework/amber.svg?maxAge=360)](https://github.com/amberframework/amber/releases/latest)
-[![Dependencies](https://shards.rocks/badge/github/amberframework/amber/status.svg)](https://shards.rocks/github/amberframework/amber)
+[![Dependencies](https://img.shields.io/badge/dependencies-shards-brightgreen.svg)](https://github.com/amberframework/amber/blob/master/shard.yml#L16)
 [![License](https://img.shields.io/github/license/amberframework/amber.svg)](https://github.com/amberframework/amber/blob/master/LICENSE)
 [![Gitter](https://img.shields.io/gitter/room/amberframework/amber.svg)](https://gitter.im/amberframework/amber)
 


### PR DESCRIPTION
### Description of the Change

shards.rocks is no longer available, see: https://github.com/shardsrocks/sharock/issues/7 so I replaced it by an alternative badge:

![screenshot_20180612_144329](https://user-images.githubusercontent.com/3067335/41313208-f9b2d270-6e4e-11e8-882a-7d335e6d4900.png)

Fixed:

![screenshot_20180612_144409](https://user-images.githubusercontent.com/3067335/41313249-11e1ee62-6e4f-11e8-859e-5bb9992ee9d5.png)

### Alternate Designs

Remove this badge

### Benefits

No dead links

### Possible Drawbacks

This is kinda a workaround :sweat_smile: 
