### PR TITLE
Add more build specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ cache:
     - .shards
 
 env:
-  - TEST_SUITE=./spec/build_spec.cr
+  - TEST_SUITE=./spec/build_spec_granite.cr
+  - TEST_SUITE=./spec/build_spec_crecto.cr
   - TEST_SUITE=./spec/amber
 
 script:

--- a/spec/build_spec_crecto.cr
+++ b/spec/build_spec_crecto.cr
@@ -1,0 +1,21 @@
+require "./build_spec_helper"
+
+module Amber::CLI
+  describe "building a generated app using crecto model and slang template" do
+    generate_app("new", "-m", "crecto", "-t", "slang")
+    check_formatting
+    check_binary
+    check_app_specs
+  ensure
+    cleanup
+  end
+
+  describe "building a generated app using crecto model and ecr template" do
+    generate_app("new", "-m", "crecto", "-t", "ecr")
+    check_formatting
+    check_binary
+    check_app_specs
+  ensure
+    cleanup
+  end
+end

--- a/spec/build_spec_granite.cr
+++ b/spec/build_spec_granite.cr
@@ -1,0 +1,21 @@
+require "./build_spec_helper"
+
+module Amber::CLI
+  describe "building a generated app using granite model and slang template" do
+    generate_app("new", "-m", "granite", "-t", "slang")
+    check_formatting
+    check_binary
+    check_app_specs
+  ensure
+    cleanup
+  end
+
+  describe "building a generated app using granite model and ecr template" do
+    generate_app("new", "-m", "granite", "-t", "ecr")
+    check_formatting
+    check_binary
+    check_app_specs
+  ensure
+    cleanup
+  end
+end

--- a/spec/build_spec_helper.cr
+++ b/spec/build_spec_helper.cr
@@ -1,0 +1,71 @@
+require "./spec_helper"
+require "./support/helpers/cli_helper"
+
+include CLIHelper
+
+macro generate_app(*options)
+  ENV["AMBER_ENV"] = "test"
+
+  cleanup
+  scaffold_app(TESTING_APP, *{{options}})
+
+  options = ["user:reference", "name:string", "body:text", "age:integer", "published:bool"]
+  temp_options = options - ["user:reference", "age:integer"]
+  MainCommand.run ["generate", "auth", "User"] | (options - ["user:reference"])
+  MainCommand.run ["generate", "error"]
+  MainCommand.run ["generate", "scaffold", "Animal"] | temp_options
+  MainCommand.run ["generate", "scaffold", "Post"] | options
+  MainCommand.run ["generate", "scaffold", "PostComment"] | (options + ["post:reference"])
+  MainCommand.run ["generate", "model", "Bat"] | options
+  MainCommand.run ["generate", "migration", "Crocodile"] | options
+  MainCommand.run ["generate", "mailer", "Dinosaur"] | options
+  MainCommand.run ["generate", "socket", "Eagle"] | ["soar", "nest"]
+  MainCommand.run ["generate", "channel", "Falcon"]
+
+  prepare_yaml(Dir.current)
+  Amber::CLI.env = "test"
+  Amber::CLI.settings.logger = Amber::Environment::Logger.new(nil)
+
+  puts "RUNNING: amber db drop create migrate - started..."
+  MainCommand.run ["db", "drop", "create", "migrate"]
+
+  puts "RUNNING: shards update - started..."
+  system("shards update")
+
+  puts "RUNNING: shards build #{TEST_APP_NAME} - started..."
+  system("shards build #{TEST_APP_NAME}")
+end
+
+macro check_formatting
+  it "check formatting on generated files" do
+    system("crystal tool format --check src").should be_true
+  end
+end
+
+macro check_binary
+  it "generates a binary" do
+    File.exists?("bin/#{TEST_APP_NAME}").should be_true
+  end
+end
+
+macro check_app_specs
+  context "crystal spec" do
+    puts "RUNNING: crystal spec #{TESTING_APP} - started..."
+
+    spec_result = `crystal spec`
+
+    puts spec_result
+
+    it "can be executed" do
+      spec_result.should contain "Finished in"
+    end
+
+    it "has no errors" do
+      spec_result.should_not contain "Error in line"
+    end
+
+    it "has no failures" do
+      spec_result.should_not contain "Failures"
+    end
+  end
+end

--- a/src/amber/cli/templates/app/config/initializers/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/initializers/database.cr.ecr
@@ -7,7 +7,9 @@ Granite.settings.logger.progname = "Granite"
 <% else -%>
 require "<%= @database == "sqlite" ? "sqlite3" : @database %>"
 require "crecto"
+
 Query = Crecto::Repo::Query
+Multi = Crecto::Repo::Multi
 
 module Repo
   extend Crecto::Repo

--- a/src/amber/cli/templates/model/crecto/spec/models/spec_helper.cr
+++ b/src/amber/cli/templates/model/crecto/spec/models/spec_helper.cr
@@ -1,0 +1,1 @@
+require "../spec_helper"

--- a/src/amber/cli/templates/model/crecto/spec/models/{{name}}_spec.cr.ecr
+++ b/src/amber/cli/templates/model/crecto/spec/models/{{name}}_spec.cr.ecr
@@ -1,0 +1,8 @@
+require "./spec_helper"
+require "../../src/models/<%= @name %>.cr"
+
+describe <%= class_name %> do
+  Spec.before_each do
+    Repo.delete_all(<%= class_name %>)
+  end
+end

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -21,7 +21,7 @@
    when "text" -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
-  <%="<"%>%= label(<%=":#{field.name}"%>, class: "form-check-label") do
+  <%="<"%>%= label(<%=":#{field.name}"%>) do
     check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>,
               class: "form-check-input")
   end -%>


### PR DESCRIPTION
### Description of the Change

This PR add more build specs like [recipes repo already does](https://github.com/amberframework/recipes/tree/master/spec):

| model/template | ecr | slang |
| --- | --- | --- |
| granite | :+1:  | :+1:  |
| crecto | :+1:  | :+1:  |

### Alternate Designs

Add more built specs (mysql, sqlite)?

### Benefits

This will help us to prevent issues with projects ecr and crecto because this combination is currently untested. We had [several issues in the past](https://github.com/orgs/amberframework/projects/1?fullscreen=true&card_filter_query=crecto+is%3Aclosed) with crecto/ecr mainly because no build specs on them

### Possible Drawbacks

This will check all amber features are working fine (well, except other db :sweat_smile: )
