### PR TITLE
[Shard] [Breaking Change] Update Teeplate Shard to 0.6.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -68,7 +68,7 @@ dependencies:
 
   teeplate:
     github: amberframework/teeplate
-    version: ~> 0.5.0
+    version: ~> 0.6.1
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
Issue: https://github.com/amberframework/amber/issues/853

Changes to crystal requires teeplate to be upgraded

### Description of the Change

Currently specs are failing because teeplate shard is Out of Date and is causing the following error
`lib/teeplate/src/lib/file_tree/macros/directory.cr:33: undefined method 'stat' for File:Class`

### Benefits

- Updates to latest Teeplate shard version to correct the issue. 

### Possible Drawbacks

- Apps running on older crystal version 0.25.0 might run into an issue. 
