### PR TITLE
[TravisCI] Use crystal specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: trusty
 sudo: required
 language: crystal
+crystal:
+  - 0.24.1
 
 services:
   - postgresql


### PR DESCRIPTION
Issue: https://github.com/amberframework/amber/issues/855

Until we can add support for the latest crystal version Travis should
run in the previous supported Crystal version. Currently some specs are failing.

We should expect specs to pass in the supported version
