### PR TITLE
Use pluralize method

### DIFF
--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -40,4 +40,8 @@ module Amber::CLI::Helpers
       Process.new(command, shell: shell, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
     end
   end
+
+  def pluralize(word)
+    Inflector.pluralize(word)
+  end
 end

--- a/src/amber/cli/helpers/migration.cr
+++ b/src/amber/cli/helpers/migration.cr
@@ -1,5 +1,3 @@
-require "inflector"
-
 module Amber::CLI::Helpers::Migration
   def create_index_for_reference_fields_sql
     sql_statements = reference_fields.map do |field|
@@ -10,7 +8,7 @@ module Amber::CLI::Helpers::Migration
 
   def create_table_sql
     <<-SQL
-    CREATE TABLE #{Inflector.pluralize(@name)} (
+    CREATE TABLE #{pluralize(@name)} (
       #{@primary_key},
       #{create_table_fields_sql}
     );
@@ -18,7 +16,7 @@ module Amber::CLI::Helpers::Migration
   end
 
   def drop_table_sql
-    "DROP TABLE IF EXISTS #{Inflector.pluralize(@name)};"
+    "DROP TABLE IF EXISTS #{pluralize(@name)};"
   end
 
   def primary_key
@@ -37,7 +35,7 @@ module Amber::CLI::Helpers::Migration
   private def create_index_for_reference_field_sql(field : Field)
     index_name = "#{@name.underscore}_#{field.name}_id_idx"
     <<-SQL
-    CREATE INDEX #{index_name} ON #{Inflector.pluralize(@name)} (#{field.name}_id);
+    CREATE INDEX #{index_name} ON #{pluralize(@name)} (#{field.name}_id);
     SQL
   end
 

--- a/src/amber/cli/recipes/model.cr
+++ b/src/amber/cli/recipes/model.cr
@@ -1,5 +1,4 @@
 require "../templates/field.cr"
-require "inflector"
 
 module Amber::Recipes
   class Model < Teeplate::FileTree
@@ -42,7 +41,7 @@ module Amber::Recipes
     end
 
     def table_name
-      @table_name ||= "#{Inflector.pluralize(@name)}"
+      @table_name ||= "#{pluralize(@name)}"
     end
   end
 end

--- a/src/amber/cli/recipes/scaffold/controller.cr
+++ b/src/amber/cli/recipes/scaffold/controller.cr
@@ -1,5 +1,4 @@
 require "../../templates/field.cr"
-require "inflector"
 
 module Amber::Recipes::Scaffold
   class Controller < Teeplate::FileTree
@@ -34,7 +33,7 @@ module Amber::Recipes::Scaffold
       end
 
       add_routes :web, <<-ROUTE
-        resources "/#{Inflector.pluralize(@name)}", #{class_name}Controller
+        resources "/#{pluralize(@name)}", #{class_name}Controller
       ROUTE
     end
 

--- a/src/amber/cli/templates/api/controller.cr
+++ b/src/amber/cli/templates/api/controller.cr
@@ -1,5 +1,4 @@
 require "../field.cr"
-require "inflector"
 
 module Amber::CLI::Api
   class Controller < Teeplate::FileTree
@@ -23,7 +22,7 @@ module Amber::CLI::Api
       field_hash
 
       add_routes :api, <<-ROUTE
-        resources "/#{Inflector.pluralize(@name)}", #{class_name}Controller, except: [:new, :edit]
+        resources "/#{pluralize(@name)}", #{class_name}Controller, except: [:new, :edit]
       ROUTE
     end
 

--- a/src/amber/cli/templates/api/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/api/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -40,7 +40,7 @@ describe <%= class_name %>ControllerTest do
   it "renders <%= @name %> index json" do
     <%= class_name %>.clear
     model = create_<%= @name.downcase %>
-    response = subject.get "/<%= Inflector.pluralize(@name) %>"
+    response = subject.get "/<%= pluralize(@name) %>"
 
     response.status_code.should eq(200)
     response.body.should contain("Fake")
@@ -49,7 +49,7 @@ describe <%= class_name %>ControllerTest do
   it "renders <%= @name %> show json" do
     <%= class_name %>.clear
     model = create_<%= @name.downcase %>
-    location = "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    location = "/<%= pluralize(@name) %>/#{model.id}"
 
     response = subject.get location
 
@@ -59,7 +59,7 @@ describe <%= class_name %>ControllerTest do
 
   it "creates a <%= @name %>" do
     <%= class_name %>.clear
-    response = subject.post "/<%= Inflector.pluralize(@name) %>", body: <%= params_name %>
+    response = subject.post "/<%= pluralize(@name) %>", body: <%= params_name %>
 
     response.status_code.should eq(201)
     response.body.should contain "Fake"
@@ -68,7 +68,7 @@ describe <%= class_name %>ControllerTest do
   it "updates a <%= @name %>" do
     <%= class_name %>.clear
     model = <%= create_model_method %>
-    response = subject.patch "/<%= Inflector.pluralize(@name) %>/#{model.id}", body: <%= params_name %>
+    response = subject.patch "/<%= pluralize(@name) %>/#{model.id}", body: <%= params_name %>
 
     response.status_code.should eq(200)
     response.body.should contain "Fake"
@@ -77,7 +77,7 @@ describe <%= class_name %>ControllerTest do
   it "deletes a <%= @name %>" do
     <%= class_name %>.clear
     model = <%= create_model_method %>
-    response = subject.delete "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    response = subject.delete "/<%= pluralize(@name) %>/#{model.id}"
 
     response.status_code.should eq(204)
   end

--- a/src/amber/cli/templates/api/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/api/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -1,8 +1,8 @@
 class <%= class_name %>Controller < ApplicationController
   def index
-    <%= Inflector.pluralize(@name) %> = Repo.all(<%= class_name %>)
+    <%= pluralize(@name) %> = Repo.all(<%= class_name %>)
     respond_with 200 do
-      json <%= Inflector.pluralize(@name) %>.to_json
+      json <%= pluralize(@name) %>.to_json
     end
   end
 

--- a/src/amber/cli/templates/api/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/api/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -40,7 +40,7 @@ describe <%= class_name %>ControllerTest do
   it "renders <%= @name %> index json" do
     <%= class_name %>.clear
     model = create_<%= @name.downcase %>
-    response = subject.get "/<%= Inflector.pluralize(@name) %>"
+    response = subject.get "/<%= pluralize(@name) %>"
 
     response.status_code.should eq(200)
     response.body.should contain("Fake")
@@ -49,7 +49,7 @@ describe <%= class_name %>ControllerTest do
   it "renders <%= @name %> show json" do
     <%= class_name %>.clear
     model = create_<%= @name.downcase %>
-    location = "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    location = "/<%= pluralize(@name) %>/#{model.id}"
 
     response = subject.get location
 
@@ -59,7 +59,7 @@ describe <%= class_name %>ControllerTest do
 
   it "creates a <%= @name %>" do
     <%= class_name %>.clear
-    response = subject.post "/<%= Inflector.pluralize(@name) %>", body: <%= params_name %>
+    response = subject.post "/<%= pluralize(@name) %>", body: <%= params_name %>
 
     response.status_code.should eq(201)
     response.body.should contain "Fake"
@@ -68,7 +68,7 @@ describe <%= class_name %>ControllerTest do
   it "updates a <%= @name %>" do
     <%= class_name %>.clear
     model = <%= create_model_method %>
-    response = subject.patch "/<%= Inflector.pluralize(@name) %>/#{model.id}", body: <%= params_name %>
+    response = subject.patch "/<%= pluralize(@name) %>/#{model.id}", body: <%= params_name %>
 
     response.status_code.should eq(200)
     response.body.should contain "Fake"
@@ -77,7 +77,7 @@ describe <%= class_name %>ControllerTest do
   it "deletes a <%= @name %>" do
     <%= class_name %>.clear
     model = <%= create_model_method %>
-    response = subject.delete "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    response = subject.delete "/<%= pluralize(@name) %>/#{model.id}"
 
     response.status_code.should eq(204)
   end

--- a/src/amber/cli/templates/api/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/api/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -1,8 +1,8 @@
 class <%= class_name %>Controller < ApplicationController
   def index
-    <%= Inflector.pluralize(@name) %> = <%= class_name %>.all
+    <%= pluralize(@name) %> = <%= class_name %>.all
     respond_with 200 do
-      json <%= Inflector.pluralize(@name) %>.to_json
+      json <%= pluralize(@name) %>.to_json
     end
   end
 

--- a/src/amber/cli/templates/auth/crecto/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/models/{{name}}.cr.ecr
@@ -3,7 +3,7 @@ require "crypto/bcrypt/password"
 class <%= class_name %> < Crecto::Model
   include Crypto
 
-  schema "<%= Inflector.pluralize(@name) %>" do
+  schema "<%= pluralize(@name) %>" do
   <% @fields.reject{|f| f.hidden }.each do |field| -%>
   field :<%= field.name %>, <%= field.cr_type %>
   <% end -%>

--- a/src/amber/cli/templates/model.cr
+++ b/src/amber/cli/templates/model.cr
@@ -1,5 +1,4 @@
 require "./field.cr"
-require "inflector"
 
 module Amber::CLI
   class Model < Teeplate::FileTree
@@ -22,7 +21,7 @@ module Amber::CLI
     end
 
     def table_name
-      @table_name ||= "#{Inflector.pluralize(@name)}"
+      @table_name ||= "#{pluralize(@name)}"
     end
   end
 end

--- a/src/amber/cli/templates/scaffold/controller.cr
+++ b/src/amber/cli/templates/scaffold/controller.cr
@@ -1,5 +1,4 @@
 require "../field.cr"
-require "inflector"
 
 module Amber::CLI::Scaffold
   class Controller < Teeplate::FileTree
@@ -23,7 +22,7 @@ module Amber::CLI::Scaffold
       field_hash
 
       add_routes :web, <<-ROUTE
-        resources "/#{Inflector.pluralize(@name)}", #{class_name}Controller
+        resources "/#{pluralize(@name)}", #{class_name}Controller
       ROUTE
     end
 

--- a/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -41,7 +41,7 @@ describe <%= class_name %>ControllerTest do
 
   it "renders <%= @name %> index template" do
     Repo.delete_all(<%= class_name %>)
-    response = subject.get "/<%= Inflector.pluralize(@name) %>"
+    response = subject.get "/<%= pluralize(@name) %>"
 
     response.status_code.should eq(200)
     response.body.should contain("<%= display_name %>s")
@@ -50,7 +50,7 @@ describe <%= class_name %>ControllerTest do
   it "renders <%= @name %> show template" do
     Repo.delete_all(<%= class_name %>)
     model = create_<%= @name.downcase %>
-    location = "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    location = "/<%= pluralize(@name) %>/#{model.id}"
 
     response = subject.get location
 
@@ -60,7 +60,7 @@ describe <%= class_name %>ControllerTest do
 
   it "renders <%= @name %> new template" do
     Repo.delete_all(<%= class_name %>)
-    location = "/<%= Inflector.pluralize(@name) %>/new"
+    location = "/<%= pluralize(@name) %>/new"
 
     response = subject.get location
 
@@ -71,7 +71,7 @@ describe <%= class_name %>ControllerTest do
   it "renders <%= @name %> edit template" do
     Repo.delete_all(<%= class_name %>)
     model = <%= create_model_method %>
-    location = "/<%= Inflector.pluralize(@name) %>/#{model.id}/edit"
+    location = "/<%= pluralize(@name) %>/#{model.id}/edit"
 
     response = subject.get location
 
@@ -81,9 +81,9 @@ describe <%= class_name %>ControllerTest do
 
   it "creates a <%= @name %>" do
     Repo.delete_all(<%= class_name %>)
-    response = subject.post "/<%= Inflector.pluralize(@name) %>", body: <%= params_name %>
+    response = subject.post "/<%= pluralize(@name) %>", body: <%= params_name %>
 
-    response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
+    response.headers["Location"].should eq "/<%= pluralize(@name) %>"
     response.status_code.should eq(302)
     response.body.should eq "302"
   end
@@ -91,9 +91,9 @@ describe <%= class_name %>ControllerTest do
   it "updates a <%= @name %>" do
     Repo.delete_all(<%= class_name %>)
     model = <%= create_model_method %>
-    response = subject.patch "/<%= Inflector.pluralize(@name) %>/#{model.id}", body: <%= params_name %>
+    response = subject.patch "/<%= pluralize(@name) %>/#{model.id}", body: <%= params_name %>
 
-    response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
+    response.headers["Location"].should eq "/<%= pluralize(@name) %>"
     response.status_code.should eq(302)
     response.body.should eq "302"
   end
@@ -101,9 +101,9 @@ describe <%= class_name %>ControllerTest do
   it "deletes a <%= @name %>" do
     Repo.delete_all(<%= class_name %>)
     model = <%= create_model_method %>
-    response = subject.delete "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    response = subject.delete "/<%= pluralize(@name) %>/#{model.id}"
 
-    response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
+    response.headers["Location"].should eq "/<%= pluralize(@name) %>"
     response.status_code.should eq(302)
     response.body.should eq "302"
   end

--- a/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -1,6 +1,6 @@
 class <%= class_name %>Controller < ApplicationController
   def index
-    <%= Inflector.pluralize(@name) %> = Repo.all(<%= class_name %>)
+    <%= pluralize(@name) %> = Repo.all(<%= class_name %>)
     render("index.<%= @language %>")
   end
 
@@ -9,7 +9,7 @@ class <%= class_name %>Controller < ApplicationController
       render("show.<%= @language %>")
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     end
   end
 
@@ -29,7 +29,7 @@ class <%= class_name %>Controller < ApplicationController
       render("new.<%= @language %>")
     else
       flash["success"] = "Created <%= class_name %> successfully."
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     end
   end
 
@@ -39,7 +39,7 @@ class <%= class_name %>Controller < ApplicationController
       render("edit.<%= @language %>")
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     end
   end
 
@@ -53,11 +53,11 @@ class <%= class_name %>Controller < ApplicationController
         render("edit.<%= @language %>")
       else
         flash["success"] = "Updated <%= class_name %> successfully."
-        redirect_to "/<%= Inflector.pluralize(@name) %>"
+        redirect_to "/<%= pluralize(@name) %>"
       end
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     end
   end
 
@@ -67,7 +67,7 @@ class <%= class_name %>Controller < ApplicationController
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
     end
-    redirect_to "/<%= Inflector.pluralize(@name) %>"
+    redirect_to "/<%= pluralize(@name) %>"
   end
 
   def <%= @name %>_params

--- a/src/amber/cli/templates/scaffold/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -40,16 +40,16 @@ describe <%= class_name %>ControllerTest do
 
   it "renders <%= @name %> index template" do
     <%= class_name %>.clear
-    response = subject.get "/<%= Inflector.pluralize(@name) %>"
+    response = subject.get "/<%= pluralize(@name) %>"
 
     response.status_code.should eq(200)
-    response.body.should contain("<%= Inflector.pluralize(display_name) %>")
+    response.body.should contain("<%= pluralize(display_name) %>")
   end
 
   it "renders <%= @name %> show template" do
     <%= class_name %>.clear
     model = create_<%= @name.downcase %>
-    location = "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    location = "/<%= pluralize(@name) %>/#{model.id}"
 
     response = subject.get location
 
@@ -59,7 +59,7 @@ describe <%= class_name %>ControllerTest do
 
   it "renders <%= @name %> new template" do
     <%= class_name %>.clear
-    location = "/<%= Inflector.pluralize(@name) %>/new"
+    location = "/<%= pluralize(@name) %>/new"
 
     response = subject.get location
 
@@ -70,7 +70,7 @@ describe <%= class_name %>ControllerTest do
   it "renders <%= @name %> edit template" do
     <%= class_name %>.clear
     model = <%= create_model_method %>
-    location = "/<%= Inflector.pluralize(@name) %>/#{model.id}/edit"
+    location = "/<%= pluralize(@name) %>/#{model.id}/edit"
 
     response = subject.get location
 
@@ -80,9 +80,9 @@ describe <%= class_name %>ControllerTest do
 
   it "creates a <%= @name %>" do
     <%= class_name %>.clear
-    response = subject.post "/<%= Inflector.pluralize(@name) %>", body: <%= params_name %>
+    response = subject.post "/<%= pluralize(@name) %>", body: <%= params_name %>
 
-    response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
+    response.headers["Location"].should eq "/<%= pluralize(@name) %>"
     response.status_code.should eq(302)
     response.body.should eq "302"
   end
@@ -90,9 +90,9 @@ describe <%= class_name %>ControllerTest do
   it "updates a <%= @name %>" do
     <%= class_name %>.clear
     model = <%= create_model_method %>
-    response = subject.patch "/<%= Inflector.pluralize(@name) %>/#{model.id}", body: <%= params_name %>
+    response = subject.patch "/<%= pluralize(@name) %>/#{model.id}", body: <%= params_name %>
 
-    response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
+    response.headers["Location"].should eq "/<%= pluralize(@name) %>"
     response.status_code.should eq(302)
     response.body.should eq "302"
   end
@@ -100,9 +100,9 @@ describe <%= class_name %>ControllerTest do
   it "deletes a <%= @name %>" do
     <%= class_name %>.clear
     model = <%= create_model_method %>
-    response = subject.delete "/<%= Inflector.pluralize(@name) %>/#{model.id}"
+    response = subject.delete "/<%= pluralize(@name) %>/#{model.id}"
 
-    response.headers["Location"].should eq "/<%= Inflector.pluralize(@name) %>"
+    response.headers["Location"].should eq "/<%= pluralize(@name) %>"
     response.status_code.should eq(302)
     response.body.should eq "302"
   end

--- a/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -1,6 +1,6 @@
 class <%= class_name %>Controller < ApplicationController
   def index
-    <%= Inflector.pluralize(@name) %> = <%= class_name %>.all
+    <%= pluralize(@name) %> = <%= class_name %>.all
     render("index.<%= @language %>")
   end
 
@@ -9,7 +9,7 @@ class <%= class_name %>Controller < ApplicationController
       render("show.<%= @language %>")
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     end
   end
 
@@ -23,7 +23,7 @@ class <%= class_name %>Controller < ApplicationController
 
     if <%= @name %>.valid? && <%= @name %>.save
       flash["success"] = "Created <%= class_name %> successfully."
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     else
       flash["danger"] = "Could not create <%= class_name %>!"
       render("new.<%= @language %>")
@@ -35,7 +35,7 @@ class <%= class_name %>Controller < ApplicationController
       render("edit.<%= @language %>")
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     end
   end
 
@@ -44,14 +44,14 @@ class <%= class_name %>Controller < ApplicationController
       <%= @name %>.set_attributes(<%= @name %>_params.validate!)
       if <%= @name %>.valid? && <%= @name %>.save
         flash["success"] = "Updated <%= class_name %> successfully."
-        redirect_to "/<%= Inflector.pluralize(@name) %>"
+        redirect_to "/<%= pluralize(@name) %>"
       else
         flash["danger"] = "Could not update <%= class_name %>!"
         render("edit.<%= @language %>")
       end
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
-      redirect_to "/<%= Inflector.pluralize(@name) %>"
+      redirect_to "/<%= pluralize(@name) %>"
     end
   end
 
@@ -61,7 +61,7 @@ class <%= class_name %>Controller < ApplicationController
     else
       flash["warning"] = "<%= class_name %> with ID #{params["id"]} Not Found"
     end
-    redirect_to "/<%= Inflector.pluralize(@name) %>"
+    redirect_to "/<%= pluralize(@name) %>"
   end
 
   def <%= @name %>_params

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.ecr.ecr
@@ -1,2 +1,2 @@
-<%="<"%>%- active = context.request.path == "/<%= Inflector.pluralize(@name) %>" ? "active" : "" %>
-<a class="nav-item <%="<"%>%= active %>" href="/<%= Inflector.pluralize(@name) %>"><%= display_name %>s</a>
+<%="<"%>%- active = context.request.path == "/<%= pluralize(@name) %>" ? "active" : "" %>
+<a class="nav-item <%="<"%>%= active %>" href="/<%= pluralize(@name) %>"><%= display_name %>s</a>

--- a/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/layouts/+_nav.slang.ecr
@@ -1,2 +1,2 @@
-- active = context.request.path == "/<%= Inflector.pluralize(@name) %>" ? "active" : ""
-a class="nav-item #{active}" href="/<%= Inflector.pluralize(@name) %>" <%= Inflector.pluralize(display_name) %>
+- active = context.request.path == "/<%= pluralize(@name) %>" ? "active" : ""
+a class="nav-item #{active}" href="/<%= pluralize(@name) %>" <%= pluralize(display_name) %>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -8,7 +8,7 @@
 
 
 
-<%="<"%>%- action = (<%= @name %>.id ? "/<%= Inflector.pluralize(@name) %>/" + <%= @name %>.id.to_s : "/<%= Inflector.pluralize(@name) %>") %>
+<%="<"%>%- action = (<%= @name %>.id ? "/<%= pluralize(@name) %>/" + <%= @name %>.id.to_s : "/<%= pluralize(@name) %>") %>
 <form action="<%="<"%>%= action %>" method="post">
   <%="<"%>%= csrf_tag %>
   <%="<"%>%- if <%= @name %>.id %>
@@ -34,5 +34,5 @@
   </div>
 <% end -%>
   <%="<"%>%= submit("Submit", class: "btn btn-primary btn-sm") -%>
-  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-light btn-sm") -%>
+  <%="<"%>%= link_to("back", "/<%= pluralize(@name) %>", class: "btn btn-light btn-sm") -%>
 </form>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -3,7 +3,7 @@
     - <%= @model == "crecto" ? "changeset" : @name %>.errors.each do |error|
       li = error.to_s
 
-== form(action: "/<%= Inflector.pluralize(@name) -%>/#{<%= @name -%>.id.to_s}", method: <%= @name %>.id ? :patch : :post) do
+== form(action: "/<%= pluralize(@name) -%>/#{<%= @name -%>.id.to_s}", method: <%= @name %>.id ? :patch : :post) do
   == csrf_tag
 <%- @fields.reject{|f| f.hidden }.each do |field| -%>
   .form-group
@@ -21,4 +21,4 @@
   <%- end -%>
 <%- end -%>
   == submit("Submit", class: "btn btn-primary btn-sm")
-  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-light btn-sm")
+  == link_to("back", "/<%= pluralize(@name) %>", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -1,9 +1,9 @@
 <div class="row">
   <div class="col-sm-11">
-    <h2><%= Inflector.pluralize(display_name) %></h2>
+    <h2><%= pluralize(display_name) %></h2>
   </div>
   <div class="col-sm-1">
-    <a class="btn btn-success btn-sm" href="/<%= Inflector.pluralize(@name) %>/new">New</a>
+    <a class="btn btn-success btn-sm" href="/<%= pluralize(@name) %>/new">New</a>
   </div>
 </div>
 
@@ -17,16 +17,16 @@
         <th>Actions</th>
       </tr>
     <tbody>
-    <%="<"%>%- <%= Inflector.pluralize(@name) %>.each do |<%= @name %>| %>
+    <%="<"%>%- <%= pluralize(@name) %>.each do |<%= @name %>| %>
       <tr>
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
         <td><%="<"%>%= <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %> %></td>
 <% end -%>
         <td>
           <span>
-            <%="<"%>%= link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm") -%>
-            <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
-            <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
+            <%="<"%>%= link_to("read", "/<%= pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm") -%>
+            <%="<"%>%= link_to("edit", "/<%= pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
+            <%="<"%>%= link_to("delete", "/<%= pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
           </span>
         </td>
       </tr>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -1,8 +1,8 @@
 .row
   .col-sm-11
-    h2 <%= Inflector.pluralize(display_name) %>
+    h2 <%= pluralize(display_name) %>
   .col-sm-1
-    a.btn.btn-success.btn-sm href="/<%= Inflector.pluralize(@name) %>/new" New
+    a.btn.btn-success.btn-sm href="/<%= pluralize(@name) %>/new" New
 .table-responsive
   table.table.table-striped
     thead
@@ -12,13 +12,13 @@
         <%- end -%>
         th Actions
     tbody
-      - <%= Inflector.pluralize(@name) %>.each do |<%= @name %>|
+      - <%= pluralize(@name) %>.each do |<%= @name %>|
         tr
           <%- @fields.reject{|f| f.hidden }.each do |field| -%>
           td = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
           <%- end -%>
           td
             span
-              == link_to("read", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm")
-              == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
-              == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")
+              == link_to("read", "/<%= pluralize(@name) %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm")
+              == link_to("edit", "/<%= pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
+              == link_to("delete", "/<%= pluralize(@name) %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
@@ -4,7 +4,7 @@
 <p><%="<"%>%= <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %> %></p>
 <% end -%>
 <p>
-  <%="<"%>%= link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-light btn-sm") -%>
-  <%="<"%>%= link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
-  <%="<"%>%= link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
+  <%="<"%>%= link_to("back", "/<%= pluralize(@name) %>", class: "btn btn-light btn-sm") -%>
+  <%="<"%>%= link_to("edit", "/<%= pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
+  <%="<"%>%= link_to("delete", "/<%= pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
 </p>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
@@ -3,6 +3,6 @@ h1 Show <%= display_name %>
 p = <%= @name %>.<%= field.name %><%= field.reference? ? ".id" : "" %>
 <% end -%>
 p
-  == link_to("back", "/<%= Inflector.pluralize(@name) %>", class: "btn btn-light btn-sm")
-  == link_to("edit", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
-  == link_to("delete", "/<%= Inflector.pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")
+  == link_to("back", "/<%= pluralize(@name) %>", class: "btn btn-light btn-sm")
+  == link_to("edit", "/<%= pluralize(@name) %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
+  == link_to("delete", "/<%= pluralize(@name) %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")


### PR DESCRIPTION
### Description of the Change

This PR simplifies pluralization by using `pluralize` method instead of `Inflector.pluralize`

### Alternate Designs

Keep `Inflector.pluralize`

### Benefits

Less verbose and fixes #713 

### Possible Drawbacks

No
