### PR TITLE
[Specs] Attemps to fix Specs

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -67,8 +67,8 @@ dependencies:
     version: "~> 0.1.8"
 
   teeplate:
-    github: amberframework/teeplate
-    version: ~> 0.5.0
+    github: mosop/teeplate
+    version: ~> 0.6.1
 
 development_dependencies:
   ameba:

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -60,4 +60,4 @@ dependencies:
 development_dependencies:
   garnet_spec:
     github: amberframework/garnet-spec
-    version: ~> 0.1.1
+    version: ~> 0.1.2


### PR DESCRIPTION
This upgrades the garnet spec for generated apps in CLI and uses
mosop/teeplate shard instead of amberframework/teeplate :sweat_smile:

- Updates Garnet Spec version for CLI App Template
- Uses Mosop/Teeplate instead of amber teeplate