### PR TITLE
Update Crecto to v0.9.0 (v0.25.0 compat)

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -24,7 +24,7 @@ dependencies:
 <% case @model when "crecto" -%>
   crecto:
     github: Crecto/crecto
-    version: ~> 0.8.6
+    version: ~> 0.9.0
 <% else -%>
   granite:
     github: amberframework/granite


### PR DESCRIPTION
### Description of the Change

Crecto has been updated

### Alternate Designs

No

### Benefits

Fixes v0.25.0 compat with Crecto

### Possible Drawbacks

No
