### PR TITLE
Update crystal-redis to 2.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -48,7 +48,7 @@ dependencies:
 
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 1.11.0
+    version: ~> 2.0.0
 
   shell-table:
     github: jwaldrip/shell-table.cr


### PR DESCRIPTION
### Description of the Change

Redis 2.0.0 [has been released](https://github.com/stefanwille/crystal-redis/releases/tag/v2.0.0) today. This pull request updates the dependency.

### Alternate Designs

No

### Benefits

New release supports automatic reconnecting when connection to redis server was lost, which is pretty important. 

### Possible Drawbacks

Amber will stop working with other shards using Redis that were not updated (such as Sidekiq), but probably they will catch up soon.
