### PR TITLE
Using non-parenthesis method calls in scaffolded controllers

### DIFF
--- a/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -6,62 +6,62 @@ class <%= class_name %>Controller < ApplicationController
   end
 
   def index
-    <%= name_plural %> = Repo.all(<%= class_name %>)
-    render("index.<%= @language %>")
+    <%= name_plural %> = Repo.all <%= class_name %>
+    render "index.<%= @language %>"
   end
 
   def show
-    render("show.<%= @language %>")
+    render "show.<%= @language %>"
   end
 
   def new
-    changeset = <%= class_name %>.changeset(<%= @name %>)
-    render("new.<%= @language %>")
+    changeset = <%= class_name %>.changeset <%= @name %>
+    render "new.<%= @language %>"
   end
 
   def edit
-    changeset = Repo.update(<%= @name %>)
-    render("edit.<%= @language %>")
+    changeset = Repo.update <%= @name %>
+    render "edit.<%= @language %>"
   end
 
   def create
-    <%= @name %>.update_from_hash(params.to_h.select(<%= @name %>_params.validate!.keys).compact)
-    changeset = Repo.insert(<%= @name %>)
+    <%= @name %>.update_from_hash params.to_h.select(<%= @name %>_params.validate!.keys).compact
+    changeset = Repo.insert <%= @name %>
 
     if changeset.errors.any?
       flash["danger"] = "Could not create <%= class_name %>!"
-      render("new.<%= @language %>")
+      render "new.<%= @language %>"
     else
       redirect_to action: :index, flash: {"success" => "Created <%= @name %> successfully."}
     end
   end
 
   def update
-    <%= @name %>.update_from_hash(params.to_h.select(<%= @name %>_params.validate!.keys).compact)
-    changeset = Repo.update(<%= @name %>)
+    <%= @name %>.update_from_hash params.to_h.select(<%= @name %>_params.validate!.keys).compact
+    changeset = Repo.update <%= @name %>
 
     if changeset.errors.any?
       flash["danger"] = "Could not update <%= class_name %>!"
-      render("edit.<%= @language %>")
+      render "edit.<%= @language %>"
     else
       redirect_to action: :index, flash: {"success" => "Updated <%= @name %> successfully."}
     end
   end
 
   def destroy
-    Repo.delete(<%= @name %>)
+    Repo.delete <%= @name %>
     redirect_to action: :index, flash: {"success" => "Deleted <%= @name %> successfully."}
   end
 
   private def <%= @name %>_params
     params.validation do
       <%- @fields_hash.keys.each do |k| -%>
-      required(:<%= k %>) { |f| !f.nil? }
+      required :<%= k %> { |f| !f.nil? }
       <%- end -%>
     end
   end
 
   private def set_<%= @name %>
-    @<%= @name %> = Repo.get!(<%= class_name %>, params[:id])
+    @<%= @name %> = Repo.get! <%= class_name %>, params[:id]
   end
 end

--- a/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -7,38 +7,38 @@ class <%= class_name %>Controller < ApplicationController
 
   def index
     <%= name_plural %> = <%= class_name %>.all
-    render("index.<%= @language %>")
+    render "index.<%= @language %>"
   end
 
   def show
-    render("show.<%= @language %>")
+    render "show.<%= @language %>"
   end
 
   def new
-    render("new.<%= @language %>")
+    render "new.<%= @language %>"
   end
 
   def edit
-    render("edit.<%= @language %>")
+    render "edit.<%= @language %>"
   end
 
   def update
-    <%= @name %>.set_attributes(<%= @name %>_params.validate!)
+    <%= @name %>.set_attributes <%= @name %>_params.validate!
     if <%= @name %>.save
       redirect_to action: :index, flash: {"success" => "Updated <%= @name %> successfully."}
     else
       flash["danger"] = "Could not update <%= class_name %>!"
-      render("edit.<%= @language %>")
+      render "edit.<%= @language %>"
     end
   end
 
   def create
-    <%= @name %> = <%= class_name %>.new(<%= @name %>_params.validate!)
+    <%= @name %> = <%= class_name %>.new <%= @name %>_params.validate!
     if <%= @name %>.save
       redirect_to action: :index, flash: {"success" => "Created <%= @name %> successfully."}
     else
       flash["danger"] = "Could not create <%= class_name %>!"
-      render("new.<%= @language %>")
+      render "new.<%= @language %>"
     end
   end
 
@@ -50,7 +50,7 @@ class <%= class_name %>Controller < ApplicationController
   private def <%= @name %>_params
     params.validation do
       <%- @fields_hash.keys.each do |k| -%>
-      required(:<%= k %>) { |f| !f.nil? }
+      required :<%= k %> { |f| !f.nil? }
       <%- end -%>
     end
   end


### PR DESCRIPTION
### Description of the Change

Fixes #892. Using non-parenthesis method calls in scaffolded controllers.

### Alternate Designs

Another option was to use a parenthesis call. Check gitter and #892 for discussion.

### Benefits

Consistent code style.

### Possible Drawbacks

Some people might prefer parenthesis.
