### PR TITLE
Add API-only CLI option

### DIFF
--- a/src/amber/cli/config.cr
+++ b/src/amber/cli/config.cr
@@ -11,6 +11,7 @@ module Amber::CLI
     property database : String = "pg"
     property language : String = "slang"
     property model : String = "granite"
+    property api_only : Bool = false
     property recipe : (String | Nil) = nil
     property recipe_source : (String | Nil) = nil
 
@@ -21,6 +22,7 @@ module Amber::CLI
       database: {type: String, default: "pg"},
       language: {type: String, default: "slang"},
       model: {type: String, default: "granite"},
+      api_only: {type: Bool, default: false},
       recipe: String | Nil,
       recipe_source: String | Nil
     )

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -73,10 +73,10 @@ module Sentry
     private def create_all_processes
       process = create_watch_process
       @processes << process if process.is_a? Process
-      unless @npm_process
-        create_npm_process
-        @npm_process = true
-      end
+
+      return if Amber::CLI.config.api_only || @npm_process
+      create_npm_process
+      @npm_process = true
     end
 
     private def build_app_process


### PR DESCRIPTION
### Description of the Change

Now it is possible to tell `amber watch` to not to run npm process using `api_only` option.
`api_only` is a term borrowed from Rails' [configuration](http://guides.rubyonrails.org/api_app.html#changing-an-existing-application). It might be reused in future for other API-specific functionality.

Related Amber recipe: https://github.com/amberframework/recipes/pull/33

### Alternate Designs

Something like `no_npm` option in `.amber.yml` might be used as well, although I find `api_only` more common and extendible in the future.
Also `--no-npm` argument for `amber watch` could be used but I find it unintuitive to use and this way we have some cli options in `.amber.yml` and some as arguments and this is inconsistent.

### Benefits

User is able to run `amber watch` without npm dependency.

### Possible Drawbacks

+1 another cli option to maintain.
