### PR TITLE
command change

### DIFF
--- a/src/amber/cli/templates/app/Dockerfile.ecr
+++ b/src/amber/cli/templates/app/Dockerfile.ecr
@@ -3,7 +3,7 @@ FROM amberframework/amber:v<%= Amber::VERSION %>
 WORKDIR /app
 
 COPY shard.* /app/
-RUN crystal deps
+RUN shrads install
 
 COPY . /app
 


### PR DESCRIPTION


### Description of the Change
Changed 
```crystal deps``` to ```shrads install``` because  the old command is no longer supported and it breaking the app. 
I opened issue number #906 about it :-)


### Alternate Designs

None 

### Benefits

The will work with docker successfully 

### Possible Drawbacks
 No compatibility with older versions of Crystal. 