### PR TITLE
Fixed incompbility with the new version of crystal

### DIFF
--- a/src/amber/cli/templates/app/Dockerfile.ecr
+++ b/src/amber/cli/templates/app/Dockerfile.ecr
@@ -3,7 +3,7 @@ FROM amberframework/amber:v<%= Amber::VERSION %>
 WORKDIR /app
 
 COPY shard.* /app/
-RUN crystal deps
+RUN shards install 
 
 COPY . /app
 


### PR DESCRIPTION

### Description of the Change

The newest version of Crystal depricated the command `crystal deps` so I just changed to the the new one. 
I opened issue #906 about this error.


### Alternate Designs

None

### Benefits

The would be able to work with the newest version of crystal 

### Possible Drawbacks

Old version  of crystal won't be compatible with amber 