### PR TITLE
Fix typo in application.cr.ecr

### DIFF
--- a/src/amber/cli/templates/app/config/application.cr.ecr
+++ b/src/amber/cli/templates/app/config/application.cr.ecr
@@ -64,7 +64,7 @@ Amber::Server.configure do |settings|
   # Port Reuse: Amber supports clustering mode which allows to spin
   # multiple app instances per core. This setting allows to bind the different
   # instances to the same port. Default this setting to true if the number or process
-  # is grater than 1.
+  # is greater than 1.
   #
   # > Read more about Linux PORT REUSE https://lwn.net/Articles/542629/
   #


### PR DESCRIPTION
### Description of the Change

Just fixing a typo I noticed in the comments relating to Port Reuse.
