### PR TITLE
Fix class capitalization in _form template

### DIFF
--- a/src/amber/cli/templates/field.cr
+++ b/src/amber/cli/templates/field.cr
@@ -86,5 +86,10 @@ module Amber::CLI
     def reference?
       self.type == "reference"
     end
+
+    def class_name
+      Inflector.classify(@name)
+    end
+
   end
 end

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -25,7 +25,7 @@
   end -%>
 <% when "reference" -%>
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>
-    <%="<"%>%= select_field(name: "<%= field.name %>_id", collection: <% if @model == "crecto" %>Repo.all(<%= field.name.capitalize %>)<% else %><%= field.name.capitalize %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control") -%>
+    <%="<"%>%= select_field(name: "<%= field.name %>_id", collection: <% if @model == "crecto" %>Repo.all(<%= field.class_name %>)<% else %><%= field.class_name %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control") -%>
 <% else -%>
     <%="<"%>%= text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control") -%>
 <% end -%>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -15,7 +15,7 @@
         == check_box(<%=":#{field.name}, checked: #{@name}.#{field.name}.to_s == \"1\""%>)
   <%- when "reference" -%>
     == label(<%=":#{field.name}"%>)
-    == select_field(name: "<%= field.name %>_id", collection: <% if @model == "crecto" %>Repo.all(<%= field.name.capitalize %>)<% else %><%= field.name.capitalize %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control")
+    == select_field(name: "<%= field.name %>_id", collection: <% if @model == "crecto" %>Repo.all(<%= field.class_name %>)<% else %><%= field.class_name %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control")
   <%- else -%>
     == text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control")
   <%- end -%>


### PR DESCRIPTION
This fixes the class capitalization of reference fields in
the _form templates.

Fixes #907 