### PR TITLE
Make logger accept auto-generated configuration

### DIFF
--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -43,6 +43,8 @@ describe Amber do
           server.logger.level = ::Logger::INFO
           server.logging.colorize = false
           server.logging.context = %w(request headers cookies session params)
+          server.logging.filter = %w(password confirm_password)
+          # server.logging.skip = %w()
         end
 
         settings = Amber.settings
@@ -52,6 +54,8 @@ describe Amber do
         settings.logging.colorize.should eq false
         settings.secret_key_base.should eq "ox7cTo_408i4WZkKZ_5OZZtB5plqJYhD4rxrz2hriA4"
         settings.logging.context.should eq %w(request headers cookies session params)
+        settings.logging.filter.should eq %w(password confirm_password)
+        # settings.logging.skip.should eq %w()
       end
 
       it "retains environment.yml settings that haven't been overwritten" do

--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -42,6 +42,7 @@ describe Amber do
           server.logger = Amber::Environment::Logger.new(STDOUT)
           server.logger.level = ::Logger::INFO
           server.logging.colorize = false
+          server.logging.context = %w(request headers cookies session params)
         end
 
         settings = Amber.settings
@@ -50,6 +51,7 @@ describe Amber do
         settings.port.should eq 8080
         settings.logging.colorize.should eq false
         settings.secret_key_base.should eq "ox7cTo_408i4WZkKZ_5OZZtB5plqJYhD4rxrz2hriA4"
+        settings.logging.context.should eq %w(request headers cookies session params)
       end
 
       it "retains environment.yml settings that haven't been overwritten" do

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -3,8 +3,8 @@ module Amber::Environment
     alias OptionsType = NamedTuple(
       severity: String,
       colorize: Bool,
-      filter: Array(String?),
-      skip: Array(String?),
+      filter: Array(String),
+      skip: Array(String),
       context: Array(String))
 
     SEVERITY_MAP = {
@@ -19,16 +19,16 @@ module Amber::Environment
     DEFAULTS = {
       severity: "debug",
       colorize: true,
-      filter:   ["password", "confirm_password"] of String?,
-      skip:     [] of String?,
+      filter:   ["password", "confirm_password"],
+      skip:     [] of String,
       context:  ["request", "headers", "cookies", "session", "params"],
     }
 
     setter severity : String
     property colorize : Bool,
       context : Array(String),
-      skip : Array(String?),
-      filter : Array(String?)
+      skip : Array(String),
+      filter : Array(String)
 
     def initialize(logging : OptionsType)
       @colorize = logging[:colorize]

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -5,7 +5,7 @@ module Amber::Environment
       colorize: Bool,
       filter: Array(String?),
       skip: Array(String?),
-      context: Array(String?))
+      context: Array(String))
 
     SEVERITY_MAP = {
       "debug":   Logger::DEBUG,
@@ -21,12 +21,12 @@ module Amber::Environment
       colorize: true,
       filter:   ["password", "confirm_password"] of String?,
       skip:     [] of String?,
-      context:  ["request", "headers", "cookies", "session", "params"] of String?,
+      context:  ["request", "headers", "cookies", "session", "params"],
     }
 
     setter severity : String
     property colorize : Bool,
-      context : Array(String?),
+      context : Array(String),
       skip : Array(String?),
       filter : Array(String?)
 

--- a/src/amber/pipes/logger.cr
+++ b/src/amber/pipes/logger.cr
@@ -1,13 +1,13 @@
 module Amber
   module Pipe
     class Logger < Base
-      alias Params = Array(String?)
+      alias Params = Array(String)
       Colorize.enabled = Amber.settings.logging.colorize
       FILTERED_TEXT = "FILTERED".colorize(:white).mode(:underline)
 
       def initialize(@filter : Params = log_config.filter,
                      @skip : Params = log_config.skip,
-                     @context : Array(String) = log_config.context)
+                     @context : Params = log_config.context)
       end
 
       def call(context : HTTP::Server::Context)

--- a/src/amber/pipes/logger.cr
+++ b/src/amber/pipes/logger.cr
@@ -7,7 +7,7 @@ module Amber
 
       def initialize(@filter : Params = log_config.filter,
                      @skip : Params = log_config.skip,
-                     @context : Params = log_config.context)
+                     @context : Array(String) = log_config.context)
       end
 
       def call(context : HTTP::Server::Context)


### PR DESCRIPTION
I would like to begin by saying hello, and thank you for your awesome work on amber, it is a pleasure to tinker with : )

### Description of the Change

Auto-generated `config/application.cr` file contains this line:

```
  # settings.logging.context = %w(request headers cookies session params)
```

however uncommenting it produces a compile time error: 

```
instance variable '@context' of Amber::Environment::Logging must be Array(String | Nil), not Array(String)
```

It seems reasonable that:
  - uncommenting generated config should work out of the box
  - this config should accept an array of strings

I therefore went ahead and implemented this change.

### Alternate Designs

Alternative approach could be auto-generating the documentation as 

```
# settings.logging.context = %w(request headers cookies session params) as String?
```

But this, in my opinion, contains unnecessary knowledge and raises unneeded questions when reading the setting.

This could go even further and introduce some sort of enum. This would introduce more type safety at the cost of readability.

### Benefits

Uncommenting application config should always work, and this is fixing an issue where it was not the case. Also the suggested behavior presents the simplest api for interacting with the config.

### Possible Drawbacks

This issue seems like a very minor oversight rather than a design decision. If I am wrong and there is a reason behind current design, I am happy to learn and correct my thinking: )
