### PR TITLE
Update to crystal 0.26

### DIFF
--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -6,8 +6,14 @@ module Amber::CLI
 
     class Exec < Command
       command_name "exec"
-      @filename : String = "./tmp/#{Time.now.epoch_ms}_console.cr"
-      @filelogs : String = @filename.sub("console.cr", "console_result.log")
+      @filename : String
+      @filelogs : String
+
+      def initialize(__previous, __argv)
+        @filename = "./tmp/#{Time.now.epoch_ms}_console.cr"
+        @filelogs = @filename.sub("console.cr", "console_result.log")
+        super(__previous, __argv)
+      end
 
       class Options
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""


### PR DESCRIPTION
Note: This changes should be backward compatible with 0.25.1
Ref: https://github.com/crystal-lang/crystal/pull/6414

ivar initializers will be evaluated without `self` in context.

Disclaimer: I've only checked that the source build with crystal nightly together with this patch.