### PR TITLE
Adds ability to specify Logger.color & fixes exception w/ missing config settings

### DIFF
--- a/spec/amber/environment/logger_spec.cr
+++ b/spec/amber/environment/logger_spec.cr
@@ -24,5 +24,34 @@ module Amber::Environment
         end
       end
     end
+    describe "#color" do
+      it "logs messages with passed color attribute" do
+        IO.pipe do |r, w|
+          logger = Logger.new(w)
+          Colorize.enabled = true
+          logger.info "Test", "Amber", :blue
+          r.gets.should match(/\[34mAmber/)
+        end
+      end
+      it "logs messages with default color attribute" do
+        IO.pipe do |r, w|
+          logger = Logger.new(w)
+          logger.progname = "Amber"
+          Colorize.enabled = true
+          logger.info "Test"
+          r.gets.should match(/\[96mAmber/)
+        end
+      end
+      it "logs messages when #color is used" do
+        IO.pipe do |r, w|
+          logger = Logger.new(w)
+          logger.progname = "Amber"
+          logger.color = :green
+          Colorize.enabled = true
+          logger.info "Test"
+          r.gets.should match(/\[32mAmber/)
+        end
+      end
+    end
   end
 end

--- a/spec/amber/environment/settings_spec.cr
+++ b/spec/amber/environment/settings_spec.cr
@@ -26,5 +26,11 @@ module Amber::Environment
       settings.ssl_key_file.should be_nil
       settings.ssl_cert_file.should be_nil
     end
+
+    it "loads logging color setting from yaml file" do
+      color_yaml = File.read(File.expand_path("./spec/support/config/test_with_color.yml"))
+      settings = Amber::Settings.from_yaml(color_yaml)
+      settings.logging.color.should eq :red
+    end
   end
 end

--- a/spec/support/config/test_with_color.yml
+++ b/spec/support/config/test_with_color.yml
@@ -1,0 +1,32 @@
+logging:
+  severity: "warn"
+  colorize: true
+  color: red
+  filter:
+    - password
+    - confirm_password
+  skip:
+    -
+  context:
+    - request
+    - session
+    - headers
+    - cookies
+    - params
+database_url: "mysql://root@localhost:3306/test_settings_test"
+host: 0.0.0.0
+name: test_settings
+port: 3000
+port_reuse: true
+process_count: 1
+redis_url: "redis://localhost:6379"
+secret_key_base: ox7cTo_408i4WZkKZ_5OZZtB5plqJYhD4rxrz2hriA4
+# ssl_key_file:
+# ssl_cert_file:
+session:
+  key: "amber.session"
+  store: "signed_cookie"
+  expires: 0
+secrets:
+  description: "Store your test secrets credentials and settings here."
+

--- a/src/amber/environment/logger.cr
+++ b/src/amber/environment/logger.cr
@@ -3,13 +3,15 @@ require "colorize"
 
 module Amber::Environment
   class Logger < ::Logger
+    property color : Symbol = :light_cyan
+
     {% for name in Severity.constants %}
-      def {{name.id.downcase}}(message, progname = progname, color = :light_cyan)
+      def {{name.id.downcase}}(message, progname = progname, color = @color)
         log(Severity::{{name.id}}, message, progname.ljust(10), color)
       end
     {% end %}
 
-    def log(severity, message, progname = nil, color = :light_cyan)
+    def log(severity, message, progname = nil, color = @color)
       return if severity < level || !@io
       write(severity, Time.now, "#{progname || @progname} |".colorize(color).to_s, message)
     end

--- a/src/amber/environment/logger_builder.cr
+++ b/src/amber/environment/logger_builder.cr
@@ -11,6 +11,7 @@ module Amber::Environment
       @logger = Logger.new(logger_io)
       @logger.level = logging.severity
       @logger.progname = "Server"
+      @logger.color = logging.color
       @logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
         io << datetime.to_s("%I:%M:%S")
         io << " "

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -1,11 +1,6 @@
 module Amber::Environment
   class Logging
-    alias OptionsType = NamedTuple(
-      severity: String,
-      colorize: Bool,
-      filter: Array(String?),
-      skip: Array(String?),
-      context: Array(String?))
+    alias OptionsType = Hash(String, String | Bool | Array(String?))
 
     SEVERITY_MAP = {
       "debug":   Logger::DEBUG,
@@ -16,30 +11,58 @@ module Amber::Environment
       "unknown": Logger::UNKNOWN,
     }
 
-    DEFAULTS = {
-      severity: "debug",
-      colorize: true,
-      filter:   ["password", "confirm_password"] of String?,
-      skip:     [] of String?,
-      context:  ["request", "headers", "cookies", "session", "params"] of String?,
+    COLOR_MAP = {
+      "black":         :black,
+      "red":           :red,
+      "green":         :green,
+      "yellow":        :yellow,
+      "blue":          :blue,
+      "magenta":       :magenta,
+      "cyan":          :cyan,
+      "light_gray":    :light_gray,
+      "dark_gray":     :dark_gray,
+      "light_red":     :light_red,
+      "light_green":   :light_green,
+      "light_yellow":  :light_yellow,
+      "light_blue":    :light_blue,
+      "light_magenta": :light_magenta,
+      "light_cyan":    :light_cyan,
+      "white":         :white,
     }
 
-    setter severity : String
+    DEFAULTS = {
+      "severity" => "debug",
+      "colorize" => true,
+      "color"    => "light_cyan",
+      "filter"   => ["password", "confirm_password"] of String?,
+      "skip"     => [] of String?,
+      "context"  => ["request", "headers", "cookies", "session", "params"] of String?,
+    }
+
+    setter severity : String,
+      color : String
+
     property colorize : Bool,
       context : Array(String?),
       skip : Array(String?),
       filter : Array(String?)
 
-    def initialize(logging : OptionsType)
-      @colorize = logging[:colorize]
-      @severity = logging[:severity]
-      @filter = logging[:filter]
-      @skip = logging[:skip]
-      @context = logging[:context]
+    def initialize(initial_logging : OptionsType)
+      logging = DEFAULTS.merge(initial_logging)
+      @colorize = logging["colorize"].as(Bool)
+      @color = logging["color"].as(String)
+      @severity = logging["severity"].as(String)
+      @filter = logging["filter"].as(Array(String?))
+      @skip = logging["skip"].as(Array(String?))
+      @context = logging["context"].as(Array(String?))
     end
 
     def severity : Logger::Severity
       SEVERITY_MAP[@severity]
+    end
+
+    def color : Symbol
+      COLOR_MAP[@color]
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

This PR adds the ability to specify a log colorizing color when creating an `Amber::Environment::Logger`.  This is done by setting `Logger.color` (similar in style to `Logger.progname`).  I added this because I wanted to be able to set the color for a plugin/related process that uses Amber's logging mechanism.

For example, in Granite's initialization (project/config/initializers/database.cr), the following two lines setup the logging mechanism:

````
Granite.settings.logger = Amber.settings.logger.dup
Granite.settings.logger.progname = "Granite"
````

With this change, one could now add a third line in order to have log lines stand apart from standard Amber processes:

````
Granite.settings.logger.color = :blue
````

While making this change, I also uncovered a small bug in the way settings parameters are loaded.  Currently, in `Amber::Environment::Settings`, the `YAML.mapping` specifies a type (`Logging::OptionsType`) and default (`Logging::DEFAULTS`) for those settings in an environment config.  Because of `Logging::OptionsType` being a NamedTuple, however, if any of the settings are  missing from the `logging:` section of an env yml file, an exception is thrown.

(This is, I believe, because the presence of a `logging:` section in the yml file means that the default is not used, but the lack of an expected key/value pair within that logging block throws an exception.  So you can leave out the entire `logging:` section and the defaults will be applied, but you cannot leave out a key within a section your provide).

So - I've changed `Logging::OptionsType` to be a Hash instead of a NamedTuple and merge the `Logging::DEFAULTS` upon load.  For some reason that I'm not entirely certain of (but having to do with how YAML.mapping works with Hashes vs. NamedTuples), now if you leave a logging setting out of the env yml file, no exception is thrown and the defaults can be applied properly.

(I did this because by adding a `color` option, I certainly didn't want to break all existing installations that don't explicitly specify the color key nor did I want to require it going forward.)

I also added appropriate tests to handle this new behavior & functionality.

### Benefits

This allows for finer-grained configuration of logging settings and for a user to specify the color of both amber and related processes' logging activity.  Hooray for a more colorful terminal!

### Possible Drawbacks

I do think that having `Logging::OptionsType` be an alias'd NamedTuple is quite elegant, and this change is slightly less memory-efficient and requires a bit more verbosity in `Amber::Environment::Logging#initialize`.  But without diving deep into how YAML.mapping works, I'm not sure how to avoid throwing an exception from a missing key when parsing an env config file.  

If I've taken the wrong approach and someone can point me in the right direction, I'm more than happy to make any & all changes!

Thanks in advance for any feedback as well.  This is all a learning process for me, so code/design critique is appreciated.