### PR TITLE
Update to crystal 0.26

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -51,8 +51,8 @@ dependencies:
     version: ~> 2.0.0
 
   shell-table:
-    github: jwaldrip/shell-table.cr
-    version: ~> 0.9.2
+    github: luckyframework/shell-table.cr
+    commit: 078a04ea58ead5203bb435a3b5fff448ddabaeea
 
   slang:
     github: jeromegn/slang

--- a/shard.yml
+++ b/shard.yml
@@ -16,7 +16,7 @@ targets:
 dependencies:
   amber_router:
     github: amberframework/amber-router
-    version: ~> 0.1.0
+    version: ~> 0.2.0
 
   cli:
     github: mosop/cli

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -6,8 +6,14 @@ module Amber::CLI
 
     class Exec < Command
       command_name "exec"
-      @filename : String = "./tmp/#{Time.now.epoch_ms}_console.cr"
-      @filelogs : String = @filename.sub("console.cr", "console_result.log")
+      @filename : String
+      @filelogs : String
+
+      def initialize(__previous, __argv)
+        @filename = "./tmp/#{Time.now.epoch_ms}_console.cr"
+        @filelogs = @filename.sub("console.cr", "console_result.log")
+        super(__previous, __argv)
+      end
 
       class Options
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""

--- a/src/amber/cli/templates/app/config/initializers/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/initializers/database.cr.ecr
@@ -1,9 +1,10 @@
 <% if @model == "granite" -%>
 require "granite/adapter/<%= @database %>"
 
-Granite.settings.database_url = Amber.settings.database_url
+Granite::Adapters << Granite::Adapter::<%= @database.capitalize %>.new({name: "<%= @database %>", url: Amber.settings.database_url})
 Granite.settings.logger = Amber.settings.logger.dup
 Granite.settings.logger.progname = "Granite"
+
 <% else -%>
 require "<%= @database == "sqlite" ? "sqlite3" : @database %>"
 require "crecto"

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -28,7 +28,7 @@ dependencies:
 <% else -%>
   granite:
     github: amberframework/granite
-    version: ~> 0.12.1
+    version: ~> 0.13.0
 <% end -%>
 
   quartz_mailer:

--- a/src/amber/router/params.cr
+++ b/src/amber/router/params.cr
@@ -68,7 +68,13 @@ module Amber::Router
       params_hash = Types::Params.new
       query.each { |key, _| params_hash[key] = query[key] }
       form.each { |key, _| params_hash[key] = form[key] }
-      route.each_key { |key| params_hash[key] = route[key] }
+
+      route.each_key do |key|
+        if value = route[key]
+          params_hash[key] = value
+        end
+      end
+
       json.each_key { |key| params_hash[key] = json[key].to_s }
       multipart.each_key { |key| params_hash[key] = multipart[key].to_s }
       params_hash

--- a/src/amber/server/server.cr
+++ b/src/amber/server/server.cr
@@ -56,7 +56,13 @@ module Amber
       logger.info "#{version.colorize(:light_cyan)} serving application \"#{settings.name.capitalize}\" at #{host_url.colorize(:light_cyan).mode(:underline)}"
       handler.prepare_pipelines
       server = HTTP::Server.new(handler)
-      server.tls = Amber::SSL.new(settings.ssl_key_file.not_nil!, settings.ssl_cert_file.not_nil!).generate_tls if ssl_enabled?
+
+      if ssl_enabled?
+        ssl_config = Amber::SSL.new(settings.ssl_key_file.not_nil!, settings.ssl_cert_file.not_nil!).generate_tls
+        server.bind_ssl Amber.settings.host, Amber.settings.port, ssl_config
+      else
+        server.bind_tcp Amber.settings.host, Amber.settings.port
+      end
 
       Signal::INT.trap do
         Signal::INT.reset


### PR DESCRIPTION
Replaces #922 
Fixes #927 

- [x] ~update CI to point to crystal 0.26~
- [x] fix ssl code
- [x] specs pass
- [x] organization dependencies updated and released
  - [x] amber-router
  - [x] granite
- [x] external dependencies updated
  - [x] shell-table 


A places for all configuration and code changes which are required to get Amber up to date with Crystal 0.26.0