### PR TITLE
update to crystal 0.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.25.0
+FROM crystallang/crystal:0.26.0
 
 # Install Dependencies
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description of the Change

Update docker to latest crystal version 0.26.0

### Alternate Designs

none

### Benefits

Allows docker to be used

### Possible Drawbacks

none
