### PR TITLE
[Router] Ensures Content-Type header for requests

### DIFF
--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -79,7 +79,10 @@ class HTTP::Server::Context
 
   protected def finalize_response
     response.headers["Connection"] = "Keep-Alive"
-    response.headers.add("Keep-Alive", "timeout=5, max=10000")
+    response.headers.add("Keep-Alive", "timeout=5, max=10000")res
+    unless response.headers["Content-Type"]?
+      response.headers["Content-Type"] = Amber::Support::Mime.mime_type(format)
+    end
     response.print(@content) unless request.method == "HEAD"
   end
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -79,7 +79,7 @@ class HTTP::Server::Context
 
   protected def finalize_response
     response.headers["Connection"] = "Keep-Alive"
-    response.headers.add("Keep-Alive", "timeout=5, max=10000")res
+    response.headers.add("Keep-Alive", "timeout=5, max=10000")
     unless response.headers["Content-Type"]?
       response.headers["Content-Type"] = Amber::Support::Mime.mime_type(format)
     end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -81,7 +81,7 @@ class HTTP::Server::Context
     response.headers["Connection"] = "Keep-Alive"
     response.headers.add("Keep-Alive", "timeout=5, max=10000")
     unless response.headers["Content-Type"]?
-      response.headers["Content-Type"] = Amber::Support::Mime.mime_type(format)
+      response.headers["Content-Type"] = Amber::Support::MimeTypes.mime_type(format)
     end
     response.print(@content) unless request.method == "HEAD"
   end


### PR DESCRIPTION
Issue: https://github.com/amberframework/amber/issues/947

### Description of the Change

Ensures a content-type header is added for all requests. Content-Type defaults to the requested format mime type.