### PR TITLE
[Response] Adds Content-Type headers when missing

### DIFF
--- a/spec/amber/pipes/pipeline_spec.cr
+++ b/spec/amber/pipes/pipeline_spec.cr
@@ -35,36 +35,42 @@ module Amber
           request = HTTP::Request.new("GET", "/index/elias")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Hello World!"
+          response.headers[HTTP::Server::Context::CONTENT_TYPE].should eq "text/html"
         end
 
         it "responds to GET request" do
           request = HTTP::Request.new("GET", "/hello")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Index"
+          response.headers[HTTP::Server::Context::CONTENT_TYPE].should eq "text/html"
         end
 
         it "responds to PUT request" do
           request = HTTP::Request.new("PUT", "/hello/1")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Update"
+          response.headers[HTTP::Server::Context::CONTENT_TYPE].should eq "text/html"
         end
 
         it "responds to PATCH request" do
           request = HTTP::Request.new("PATCH", "/hello/1")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Update"
+          response.headers[HTTP::Server::Context::CONTENT_TYPE].should eq "text/html"
         end
 
         it "responds to POST request" do
           request = HTTP::Request.new("POST", "/hello")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Create"
+          response.headers[HTTP::Server::Context::CONTENT_TYPE].should eq "text/html"
         end
 
         it "responds to DELETE request" do
           request = HTTP::Request.new("DELETE", "/hello/1")
           response = create_request_and_return_io(pipeline, request)
           response.body.should eq "Destroy"
+          response.headers[HTTP::Server::Context::CONTENT_TYPE].should eq "text/html"
         end
 
         it "responds to HEAD request" do
@@ -72,6 +78,7 @@ module Amber
           response = create_request_and_return_io(pipeline, request)
           response.headers["Content-Length"].should eq "0"
           response.body.empty?.should be_true
+          response.headers[HTTP::Server::Context::CONTENT_TYPE].should eq "text/html"
         end
       end
     end

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -17,7 +17,7 @@ describe HTTP::Server::Context do
   end
   {% end %}
 
-   describe "#requested_url" do
+  describe "#requested_url" do
     it "returns the url requested by the client" do
       url = "http://www.requested-url.com/hello"
       request = HTTP::Request.new("GET", url)

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -17,7 +17,7 @@ describe HTTP::Server::Context do
   end
   {% end %}
 
-  describe "#requested_url" do
+   describe "#requested_url" do
     it "returns the url requested by the client" do
       url = "http://www.requested-url.com/hello"
       request = HTTP::Request.new("GET", url)
@@ -26,7 +26,7 @@ describe HTTP::Server::Context do
     end
   end
 
-  describe "port" do
+  describe "#port" do
     it "gets the port from the requested URL" do
       url = "http://localhost:9450"
       request = HTTP::Request.new("GET", url)

--- a/src/amber/pipes/pipeline.cr
+++ b/src/amber/pipes/pipeline.cr
@@ -18,7 +18,7 @@ module Amber
           context.process_websocket_request
         elsif @drain[context.valve]
           @drain[context.valve].call(context)
-          context.finalize_response
+          context.finalize_response!
         end
       rescue e : Amber::Exceptions::Base
         Amber::Pipe::Error.new.call(context)

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -5,6 +5,7 @@ require "./flash"
 
 class HTTP::Server::Context
   METHODS = %i(get post put patch delete head)
+  CONTENT_TYPE = "Content-Type"
 
   include Amber::Router::Session
   include Amber::Router::Flash
@@ -61,7 +62,7 @@ class HTTP::Server::Context
   end
 
   def halt!(status_code : Int32 = 200, @content = "")
-    response.headers["Content-Type"] = "text/plain"
+    response.headers[CONTENT_TYPE] = "text/plain"
     response.status_code = status_code
   end
 
@@ -77,9 +78,12 @@ class HTTP::Server::Context
     request.route.call(self)
   end
 
-  protected def finalize_response
+  protected def finalize_response!
     response.headers["Connection"] = "Keep-Alive"
     response.headers.add("Keep-Alive", "timeout=5, max=10000")
+    unless response.headers[CONTENT_TYPE]?
+      response.headers[CONTENT_TYPE] = Amber::Support::MimeTypes.mime_type(format, "text/html")
+    end
     response.print(@content) unless request.method == "HEAD"
   end
 end

--- a/src/amber/router/context.cr
+++ b/src/amber/router/context.cr
@@ -4,7 +4,7 @@ require "./session"
 require "./flash"
 
 class HTTP::Server::Context
-  METHODS = %i(get post put patch delete head)
+  METHODS      = %i(get post put patch delete head)
   CONTENT_TYPE = "Content-Type"
 
   include Amber::Router::Session

--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -624,9 +624,13 @@ module Amber
       # Amber::Support::Mime.mime_type("unknown")               # => "application/octet-stream"
       # Amber::Support::Mime.mime_type("unknown", "text/plain") # => "text/plain"
       # ```
-      def self.mime_type(format, fallback = DEFAULT_MIME_TYPE)
+      def self.mime_type(format : String, fallback = DEFAULT_MIME_TYPE)
         format = format[1..-1] if format.starts_with?('.')
         MIME_TYPES.fetch(format, fallback)
+      end
+
+      def self.mime_type(format : Nil, fallback = DEFAULT_MIME_TYPE)
+        fallback
       end
 
       def self.zip_types(path)


### PR DESCRIPTION
fixes https://github.com/amberframework/amber/issues/947

### Description of the Change

> Amber don't return any Content-Type (for the default example while using
amber new myapp). Currently when rendering a view the Content-Type header
is not set.

- Ensures a content type is set based on the requested format or
defaults to `text/html`.

Alls responses should contain a content type based on the format
requested, if no format is requested it will default to `text/html`

### Alternate Solution:

A more long term solution is to have `render` implicitly parse the the content-type
for the response.

`render("some_view.html.slang") == Content-Type: text/html`
`render("some_view.txt.slang") == Content-Type: text/plain`
`render("some_view.json.slang") == Content-Type: application/plain`

### Benefits

- Ensures all responses have a content-type

### Possible Drawbacks

- It defaults to `text/html` content when no response content-type header is found.
