### PR TITLE
`make install` fails with spaces in CWD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX=/usr/local
 INSTALL_DIR=$(PREFIX)/bin
 AMBER_SYSTEM=$(INSTALL_DIR)/amber
 
-OUT_DIR=$(shell pwd)/bin
+OUT_DIR=./bin
 AMBER=$(OUT_DIR)/amber
 AMBER_SOURCES=$(shell find src/ -type f -name '*.cr')
 


### PR DESCRIPTION
Fixes #781 , tested on elementary OS (linux) would appreciate if someone with MacOS could test.

Without the change:

```bash
➜  amber with spaces git:(master) make clean
Makefile:21: warning: overriding recipe for target '/home/epergo/development/workspaces/crystal/amber'
Makefile:17: warning: ignoring old recipe for target '/home/epergo/development/workspaces/crystal/amber'
Makefile:21: warning: overriding recipe for target 'with'
Makefile:17: warning: ignoring old recipe for target 'with'
rm -rf /home/epergo/development/workspaces/crystal/amber with spaces/bin/amber
```
With the change:

```bash
➜  amber with spaces git:(patch-1) make clean
rm -rf ./amber
```