### PR TITLE
Prevent commented routes from showing in the routes CLI

### DIFF
--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -57,6 +57,7 @@ module Amber::CLI
       end
 
       private def set_route(route_string)
+        return if route_string.to_s.lstrip.starts_with?("#")
         if route_match = route_string.to_s.match(VERB_ROUTE_REGEX)
           return unless ACTION_MAPPING.keys.includes?(route_match[1]?.to_s)
           build_route(route_match)


### PR DESCRIPTION
This is a fix for issue https://github.com/amberframework/amber/issues/951

I have tested this locally and it's working fine. If I've done this wrong (again I'm new to this project) then let me know 🙂

fixes #951 