### PR TITLE
Dj/update granite

### DIFF
--- a/spec/support/fixtures/cli_fixtures.cr
+++ b/spec/support/fixtures/cli_fixtures.cr
@@ -61,7 +61,7 @@ module CLIFixtures
 
       belongs_to :user
 
-      primar id : Int64
+      primary id : Int64
       field title : String
       field body : String
       field published : Bool

--- a/spec/support/fixtures/cli_fixtures.cr
+++ b/spec/support/fixtures/cli_fixtures.cr
@@ -61,7 +61,7 @@ module CLIFixtures
 
       belongs_to :user
 
-      # id : Int64 primary key is created for you
+      primar id : Int64
       field title : String
       field body : String
       field published : Bool

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -28,7 +28,7 @@ dependencies:
 <% else -%>
   granite:
     github: amberframework/granite
-    version: ~> 0.13.0
+    version: ~> 0.14.0
 <% end -%>
 
   quartz_mailer:

--- a/src/amber/cli/templates/auth/granite/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/models/{{name}}.cr.ecr
@@ -1,9 +1,10 @@
-require "granite/adapter/<%= @database %>"
 require "crypto/bcrypt/password"
 
 class <%= class_name %> < Granite::Base
   include Crypto
   adapter <%= @database %>
+  <%= "table_name #{table_name}" %>
+
   primary id : Int64
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
   field <%= field.name %> : <%= field.cr_type %>

--- a/src/amber/cli/templates/granite_auth.cr
+++ b/src/amber/cli/templates/granite_auth.cr
@@ -13,6 +13,7 @@ module Amber::CLI
     @database : String = CLI.config.database
     @language : String = CLI.config.language
     @timestamp : String
+    @table_name : String?
     @primary_key : String
 
     def initialize(@name, fields)
@@ -28,6 +29,10 @@ module Amber::CLI
 
     def filter(entries)
       entries.reject { |entry| entry.path.includes?("src/views") && !entry.path.includes?(".#{@language}") }
+    end
+
+    def table_name
+      @table_name ||= name_plural
     end
 
     private def setup_routes

--- a/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/granite/src/models/{{name}}.cr.ecr
@@ -5,7 +5,7 @@ class <%= class_name %> < Granite::Base
   belongs_to :<%= field.name %>
 <% end -%>
 
-  # id : Int64 primary key is created for you
+  primary id : Int64
 <% @fields.reject{|f| f.hidden || f.reference? }.each do |field| -%>
   field <%= field.name %> : <%= field.cr_type %>
 <% end -%>

--- a/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -22,16 +22,6 @@ class <%= class_name %>Controller < ApplicationController
     render "edit.<%= @language %>"
   end
 
-  def update
-    <%= @name %>.set_attributes <%= @name %>_params.validate!
-    if <%= @name %>.save
-      redirect_to action: :index, flash: {"success" => "Updated <%= @name %> successfully."}
-    else
-      flash["danger"] = "Could not update <%= class_name %>!"
-      render "edit.<%= @language %>"
-    end
-  end
-
   def create
     <%= @name %> = <%= class_name %>.new <%= @name %>_params.validate!
     if <%= @name %>.save
@@ -39,6 +29,16 @@ class <%= class_name %>Controller < ApplicationController
     else
       flash["danger"] = "Could not create <%= class_name %>!"
       render "new.<%= @language %>"
+    end
+  end
+
+  def update
+    <%= @name %>.set_attributes <%= @name %>_params.validate!
+    if <%= @name %>.save
+      redirect_to action: :index, flash: {"success" => "Updated <%= @name %> successfully."}
+    else
+      flash["danger"] = "Could not update <%= class_name %>!"
+      render "edit.<%= @language %>"
     end
   end
 


### PR DESCRIPTION
### Description of the Change

This updates granite to 0.14.0.  There are some breaking changes in this release to the `has_many` syntax.  Also, we have removed pluralization from Granite so you need to provide the table name if you want to match rails.  

The generator in Amber already generates the pluralized name and overrides the default name in Granite.

This also updates a couple template. 
- Declare the `primary id : Int64` instead of using a comment.  This makes it easier for users to understand how to replace the primary key if they need too.
- Move create method in the controller above the update method.  This was already done for Crecto and this is pretty standard order in rails and other frameworks.

### Alternate Designs

N/A

### Benefits

The `has_many` in Granite is now configurable to provide the foreign key and override the field name and class_name that may not match the one we try to generate.

### Possible Drawbacks

This is not backward compatible so if someone updates Amber, they will need to change their `has_many` declarations

previously: `has_many :posts` needs to be changed to: `has_many posts : Post` if you want the relationship to be pluralized or `has_many :post` if you choose to use the default singular name in granite.

