### PR TITLE
added reload pipe and specs back

### DIFF
--- a/spec/amber/pipes/reload_spec.cr
+++ b/spec/amber/pipes/reload_spec.cr
@@ -1,49 +1,49 @@
 # TODO: remove this file after https://github.com/amberframework/amber/pull/860 is merged
 
-# class FakeEnvironment < Amber::Environment::Env
-#   def development?
-#     true
-#   end
-# end
+class FakeEnvironment < Amber::Environment::Env
+  def development?
+    true
+  end
+end
 
-# module Amber
-#   module Pipe
-#     describe Reload do
-#       headers = HTTP::Headers.new
-#       headers["Accept"] = "text/html"
-#       request = HTTP::Request.new("GET", "/reload", headers)
+module Amber
+  module Pipe
+    describe Reload do
+      headers = HTTP::Headers.new
+      headers["Accept"] = "text/html"
+      request = HTTP::Request.new("GET", "/reload", headers)
 
-#       Amber::Server.router.draw :web do
-#         get "/reload", HelloController, :index
-#       end
+      Amber::Server.router.draw :web do
+        get "/reload", HelloController, :index
+      end
 
-#       context "when environment is in development mode" do
-#         pipeline = Pipeline.new
-#         pipeline.build :web do
-#           plug Amber::Pipe::Reload.new(FakeEnvironment.new)
-#         end
-#         pipeline.prepare_pipelines
+      context "when environment is in development mode" do
+        pipeline = Pipeline.new
+        pipeline.build :web do
+          plug Amber::Pipe::Reload.new(FakeEnvironment.new)
+        end
+        pipeline.prepare_pipelines
 
-#         it "contains injected code in response.body" do
-#           response = create_request_and_return_io(pipeline, request)
+        it "contains injected code in response.body" do
+          response = create_request_and_return_io(pipeline, request)
 
-#           response.body.should contain "Code injected by Amber Framework"
-#         end
-#       end
+          response.body.should contain "Code injected by Amber Framework"
+        end
+      end
 
-#       context "when environment is NOT in development mode" do
-#         pipeline = Pipeline.new
-#         pipeline.build :web do
-#           plug Amber::Pipe::Reload.new
-#         end
-#         pipeline.prepare_pipelines
+      context "when environment is NOT in development mode" do
+        pipeline = Pipeline.new
+        pipeline.build :web do
+          plug Amber::Pipe::Reload.new
+        end
+        pipeline.prepare_pipelines
 
-#         it "does not have injected reload code in response.body" do
-#           response = create_request_and_return_io(pipeline, request)
+        it "does not have injected reload code in response.body" do
+          response = create_request_and_return_io(pipeline, request)
 
-#           response.body.should_not contain "Code injected by Amber Framework"
-#         end
-#       end
-#     end
-#   end
-# end
+          response.body.should_not contain "Code injected by Amber Framework"
+        end
+      end
+    end
+  end
+end

--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -10,6 +10,8 @@ Amber::Server.configure do
     plug Amber::Pipe::Session.new
     plug Amber::Pipe::Flash.new
     plug Amber::Pipe::CSRF.new
+    # Reload clients browsers (development only)
+    plug Amber::Pipe::Reload.new if Amber.env.development?
   end
 
   pipeline :api do

--- a/src/amber/pipes/reload.cr
+++ b/src/amber/pipes/reload.cr
@@ -1,0 +1,26 @@
+require "../../support/client_reload"
+
+module Amber
+  module Pipe
+    # Reload clients browsers using `ClientReload`.
+    #
+    # NOTE: Amber::Pipe::Reload is intended for use in a development environment.
+    # ```
+    # pipeline :web do
+    #   plug Amber::Pipe::Reload.new
+    # end
+    # ```
+    class Reload < Base
+      def initialize(@env : Amber::Environment::Env = Amber.env)
+        Support::ClientReload.new
+      end
+
+      def call(context : HTTP::Server::Context)
+        if @env.development? && context.format == "html"
+          context.response << Support::ClientReload::INJECTED_CODE
+        end
+        call_next(context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of the Change

Adds back reload pipe. This was a useful feature although it wasn't perfect.  Injecting the JS at the beginning of the response had some issues and messed up styles sometimes, as @faustinoaq pointed out in https://github.com/amberframework/amber/pull/865 and @samholst pointed out in https://github.com/amberframework/amber/pull/959.

This should be addressed. Hopefully we can finish the `configurable watch` PR that @faustinoaq started soon. Although @samholst's is more of a single issue fix.

My recommendation would be to merge this back in and then work on improving it. @drujensen had talked about working on configurable watch.
