### PR TITLE
Added a js responder

### DIFF
--- a/spec/amber/controller/respond_with_spec.cr
+++ b/spec/amber/controller/respond_with_spec.cr
@@ -46,6 +46,22 @@ module Amber::Controller
         context.response.status_code.should eq 200
       end
 
+      it "responds with javascript" do
+        expected_result = %(console.log('Everyone <3 Amber'))
+        context.request.headers["Accept"] = "application/javascript"
+        ResponsesController.new(context).index.should eq expected_result
+        context.response.headers["Content-Type"].should eq "application/javascript"
+        context.response.status_code.should eq 200
+      end
+
+      it "responds with javascript having */* at end" do
+        expected_result = %(console.log('Everyone <3 Amber'))
+        context.request.headers["Accept"] = "application/javascript,*/*"
+        ResponsesController.new(context).index.should eq expected_result
+        context.response.headers["Content-Type"].should eq "application/javascript"
+        context.response.status_code.should eq 200
+      end
+
       it "responds with xml" do
         expected_result = "<xml><body><h1>Sort of xml</h1></body></xml>"
         context.request.headers["Accept"] = "application/xml"

--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -116,6 +116,7 @@ class ResponsesController < Amber::Controller::Base
       json type: "json", name: "Amberator"
       xml "<xml><body><h1>Sort of xml</h1></body></xml>"
       text "Hello I'm text!"
+      js "console.log('Everyone <3 Amber')"
     end
   end
 

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -9,6 +9,7 @@ module Amber::Controller::Helpers
         txt:  "text/plain",
         text: "text/plain",
         xml:  "application/xml",
+        js:   "application/javascript",
       }
 
       TYPE_EXT_REGEX         = /\.(#{TYPE.keys.join("|")})$/
@@ -22,7 +23,10 @@ module Amber::Controller::Helpers
       def initialize(@requested_responses)
       end
 
-      # TODO: add JS type similar to rails.
+      def js(js : String | ProcType)
+        @available_responses[TYPE[:js]] = js; self
+      end
+
       def html(html : String | ProcType)
         @available_responses[TYPE[:html]] = html; self
       end


### PR DESCRIPTION
### Description of the Change

Added a js responder to respond with mime type of `application/javascript`

### Benefits

It can come in handy when your requests are xhr for example using remote-forms (jquery_ujs) or just plain ajax requests. And you want to respond with JavaScript code.
