### PR TITLE
Fixes no such file or directory

### DIFF
--- a/src/amber/cli/templates/template.cr
+++ b/src/amber/cli/templates/template.cr
@@ -53,7 +53,7 @@ module Amber::CLI
           App.new(name, options.d, options.t, options.m).render(directory, list: true, color: true)
           if options.deps?
             info "Installing Dependencies"
-            Helpers.run("cd #{name} && shards update")
+            Helpers.run("cd #{directory} && shards update")
           end
         end
       when "migration"


### PR DESCRIPTION
### Description of the Change

Changes `name` variable by `directory` variable when `--deps` is used.

### Alternate Designs

1. Do remove `--deps` flag?
2. Do not change name to be underscore?

### Benefits

Fixes #968 

### Possible Drawbacks

None AFAIK
