### PR TITLE
Ensure compatibility with crystal 0.27.0

### DIFF
--- a/src/amber/router/file.cr
+++ b/src/amber/router/file.cr
@@ -1,9 +1,8 @@
 require "http/headers"
-require "tempfile"
 
 module Amber::Router
   struct File
-    getter file : Tempfile
+    getter file : File
     getter filename : String?
     getter headers : HTTP::Headers
     getter creation_time : Time?
@@ -13,7 +12,7 @@ module Amber::Router
 
     def initialize(upload)
       @filename = upload.filename
-      @file = Tempfile.new(filename)
+      @file = File.tempfile(filename)
       ::File.open(@file.path, "w") do |f|
         ::IO.copy(upload.body, f)
       end


### PR DESCRIPTION
Hi,

According to https://github.com/crystal-lang/crystal/blob/master/CHANGELOG.md, there is some **breaking change** in `crystal`.

This `PR` is a starting point for compatibility.

`Tempfile` does not exists anymore, `file.tempfile` is used instead 
https://github.com/crystal-lang/crystal/pull/6485

Regards,