### PR TITLE
Update Docker to crystal 0.27.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.26.0
+FROM crystallang/crystal:0.27.0
 
 # Install Dependencies
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description of the Change

This pull requests updates the Dockerfile to use the crystal 0.27.0 image. The current Docker for amber 0.11 fails on Dockerhub https://hub.docker.com/r/amberframework/amber/builds/.

### Alternate Designs

None

### Benefits

The new amber version can be used via Docker, which is huge for deployment and CI.

### Possible Drawbacks

None
