### PR TITLE
fix float type difference between mysql and pg

### DIFF
--- a/src/amber/cli/templates/field.cr
+++ b/src/amber/cli/templates/field.cr
@@ -9,7 +9,7 @@ module Amber::CLI
         integer:    ["integer", "Int32", "INT"],
         int64:      ["bigint", "Int64", "BIGINT"],
         bigint:     ["bigint", "Int64", "BIGINT"],
-        float:      ["float", "Float32", "FLOAT"],
+        float:      ["float", "Float64", "FLOAT"],
         float64:    ["real", "Float64", "FLOAT"],
         real:       ["real", "Float64", "REAL"],
         bool:       ["boolean", "Bool", "BOOL"],
@@ -25,6 +25,7 @@ module Amber::CLI
       },
       mysql: {
         string:    ["string", "String", "VARCHAR(255)"],
+        float:     ["float", "Float32", "FLOAT"],
         password:  ["password", "String", "VARCHAR(255)"],
         time:      ["time", "Time", "TIMESTAMP NULL"],
         timestamp: ["time", "Time", "TIMESTAMP NULL"],


### PR DESCRIPTION
### Description of the Change

For Postgres, the default float type is Float64.  For Mysql, the default
is Float32.  This changes the default to Float64 and overrides this as
Float32 for mysql.

### Alternate Designs

Remove the `float` option for generators and force the user to specify float32 or float64

### Benefits

Fixes #916 

### Possible Drawbacks

N/A
