### PR TITLE
Make optional params truly optional

### DIFF
--- a/spec/amber/validations/params_spec.cr
+++ b/spec/amber/validations/params_spec.cr
@@ -52,8 +52,19 @@ module Amber::Validators
 
       context "optional params" do
         context "when missing" do
-          it "is valid and there is no errors" do
+          it "is valid and there is no errors when param not present" do
             http_params = params_builder("last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name) { |v| !v.nil? }
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
+          it "is valid and there is no errors when param present, but blank" do
+            http_params = params_builder("name=&last_name=&middle=j")
             validator = Validators::Params.new(http_params)
 
             validator.validation do
@@ -81,7 +92,7 @@ module Amber::Validators
 
         context "when block evaluates to false" do
           it "fails validation and it has errors" do
-            http_params = params_builder("name=")
+            http_params = params_builder("name=asdf")
             validator = Validators::Params.new(http_params)
 
             validator.validation do
@@ -90,6 +101,32 @@ module Amber::Validators
 
             validator.valid?.should be_false
             validator.errors.size.should eq 1
+          end
+        end
+
+        context "when no block given" do
+          it "passes validation and there is no errors when param not present" do
+            http_params = params_builder("last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name)
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
+
+          it "passes validation and there is no errors when param present, but blank" do
+            http_params = params_builder("name=&last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name)
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
           end
         end
 

--- a/src/amber/validators/params.cr
+++ b/src/amber/validators/params.cr
@@ -10,7 +10,7 @@ module Amber::Validators
 
     def initialize(field : String | Symbol, @msg : String?)
       @field = field.to_s
-      @predicate = ->(_s : String){ true }
+      @predicate = ->(_s : String) { true }
     end
 
     def initialize(field : String | Symbol, @msg : String?, &block : String -> Bool)

--- a/src/amber/validators/params.cr
+++ b/src/amber/validators/params.cr
@@ -8,6 +8,11 @@ module Amber::Validators
     getter field : String
     getter value : String?
 
+    def initialize(field : String | Symbol, @msg : String?)
+      @field = field.to_s
+      @predicate = ->(_s : String){ true }
+    end
+
     def initialize(field : String | Symbol, @msg : String?, &block : String -> Bool)
       @field = field.to_s
       @predicate = block
@@ -34,7 +39,7 @@ module Amber::Validators
 
   class RequiredRule < BaseRule
     def apply(params : Amber::Router::Params)
-      return false unless params.has_key? @field
+      return false unless params.has_key?(@field)
       call_predicate(params)
     end
   end
@@ -42,7 +47,7 @@ module Amber::Validators
   # OptionalRule only validates if the key is present.
   class OptionalRule < BaseRule
     def apply(params : Amber::Router::Params)
-      return true unless params.has_key? @field
+      return true unless params.has_key?(@field) && params[@field] != ""
       call_predicate(params)
     end
   end
@@ -54,6 +59,10 @@ module Amber::Validators
 
     def required(param : String | Symbol, msg : String? = nil, &b : String -> Bool)
       _validator.add_rule RequiredRule.new(param, msg, &b)
+    end
+
+    def optional(param : String | Symbol, msg : String? = nil)
+      _validator.add_rule OptionalRule.new(param, msg)
     end
 
     def optional(param : String | Symbol, msg : String? = nil, &b : String -> Bool)


### PR DESCRIPTION
### Description of the Change / Benefits

1. Make optional params truly optional (either key is absent, or key is present but value is "")

This means that the optional param can be present on a form, but it is okay if the user does not fill it in. (Previously, it was only optional in the sense that it was considered okay if the param was not present on the form.)

2. Make block for optional params optional (no need to pass { true })

This always seemed weird to me. I want to get the value of this param from the validated params object, but I don't really care what it looks like, or whether it is blank.

### Possible Drawbacks

It doesn't break anything coded in the previous style, so there shouldn't be any (aside from the code bloat from adding these options).