### PR TITLE
 Make optional params truly optional, part 2

### DIFF
--- a/spec/amber/validations/params_spec.cr
+++ b/spec/amber/validations/params_spec.cr
@@ -88,6 +88,19 @@ module Amber::Validators
             validator.valid?.should be_false
             validator.errors.size.should eq 2
           end
+
+          it "is valid when param is present, but blank, and allow_blank = true" do
+            http_params = params_builder("name= &last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              required(:name, allow_blank: true)
+              required(:last_name, allow_blank: true)
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
         end
       end
 
@@ -167,6 +180,19 @@ module Amber::Validators
 
             validator.valid?.should be_true
             validator.errors.size.should eq 0
+          end
+
+          it "is not valid and it has errors when param is present, but blank, and allow_blank = false" do
+            http_params = params_builder("name=%20&last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name, allow_blank: false) { false }
+              optional(:last_name, allow_blank: false) { false }
+            end
+
+            validator.valid?.should be_false
+            validator.errors.size.should eq 2
           end
         end
 

--- a/spec/amber/validations/params_spec.cr
+++ b/spec/amber/validations/params_spec.cr
@@ -48,6 +48,47 @@ module Amber::Validators
             validator.errors.first.param.should eq "name"
           end
         end
+
+        context "when no block passed" do
+          it "is valid and there are no errors when param is present and not blank" do
+            http_params = params_builder("name=elias&last_name=perez&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              required(:name)
+              required(:last_name)
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
+
+          it "is not valid when param is missing" do
+            http_params = params_builder("last_name=perez&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              required(:name)
+              required(:last_name)
+            end
+
+            validator.valid?.should be_false
+            validator.errors.size.should eq 1
+          end
+
+          it "is not valid when param is present, but blank" do
+            http_params = params_builder("name= &last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              required(:name)
+              required(:last_name)
+            end
+
+            validator.valid?.should be_false
+            validator.errors.size.should eq 2
+          end
+        end
       end
 
       context "optional params" do

--- a/spec/amber/validations/params_spec.cr
+++ b/spec/amber/validations/params_spec.cr
@@ -19,7 +19,7 @@ module Amber::Validators
         end
 
         context "when params present" do
-          it "is valid and there is no errors" do
+          it "is valid and there are no errors" do
             http_params = params_builder("name=elias&last_name=perez&middle=j")
             validator = Validators::Params.new(http_params)
 
@@ -92,33 +92,8 @@ module Amber::Validators
       end
 
       context "optional params" do
-        context "when missing" do
-          it "is valid and there is no errors when param not present" do
-            http_params = params_builder("last_name=&middle=j")
-            validator = Validators::Params.new(http_params)
-
-            validator.validation do
-              optional(:name) { |v| !v.nil? }
-            end
-
-            validator.valid?.should be_true
-            validator.errors.size.should eq 0
-          end
-          it "is valid and there is no errors when param present, but blank" do
-            http_params = params_builder("name=&last_name=&middle=j")
-            validator = Validators::Params.new(http_params)
-
-            validator.validation do
-              optional(:name) { |v| !v.nil? }
-            end
-
-            validator.valid?.should be_true
-            validator.errors.size.should eq 0
-          end
-        end
-
         context "when block evaluates to true" do
-          it "passes validation and there is no errors" do
+          it "is valid and there are no errors if param is missing" do
             http_params = params_builder("last_name=&middle=j")
             validator = Validators::Params.new(http_params)
 
@@ -129,10 +104,35 @@ module Amber::Validators
             validator.valid?.should be_true
             validator.errors.size.should eq 0
           end
+
+          it "is valid and there are no errors if param is missing" do
+            http_params = params_builder("last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name) { true }
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
+
+          it "is valid and there are no errors when param is present, but blank" do
+            http_params = params_builder("name= &last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name) { true }
+              optional(:last_name) { true }
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
         end
 
         context "when block evaluates to false" do
-          it "fails validation and it has errors" do
+          it "is not valid and it has errors if param is present and not blank" do
             http_params = params_builder("name=asdf")
             validator = Validators::Params.new(http_params)
 
@@ -143,10 +143,35 @@ module Amber::Validators
             validator.valid?.should be_false
             validator.errors.size.should eq 1
           end
+
+          it "is valid and there are no errors if param is missing" do
+            http_params = params_builder("last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name) { false }
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
+
+          it "is valid and there are no errors when param is present, but blank" do
+            http_params = params_builder("name=&last_name= &middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name) { false }
+              optional(:last_name) { false }
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
         end
 
-        context "when no block given" do
-          it "passes validation and there is no errors when param not present" do
+        context "when no block passed" do
+          it "is valid and there are no errors when param is not present" do
             http_params = params_builder("last_name=&middle=j")
             validator = Validators::Params.new(http_params)
 
@@ -158,8 +183,20 @@ module Amber::Validators
             validator.errors.size.should eq 0
           end
 
-          it "passes validation and there is no errors when param present, but blank" do
-            http_params = params_builder("name=&last_name=&middle=j")
+          it "is valid and there are no errors when param is present" do
+            http_params = params_builder("name=asdf&last_name=&middle=j")
+            validator = Validators::Params.new(http_params)
+
+            validator.validation do
+              optional(:name)
+            end
+
+            validator.valid?.should be_true
+            validator.errors.size.should eq 0
+          end
+
+          it "is valid and there are no errors when param is present, but blank" do
+            http_params = params_builder("name=%20&last_name=&middle=j")
             validator = Validators::Params.new(http_params)
 
             validator.validation do
@@ -170,23 +207,23 @@ module Amber::Validators
             validator.errors.size.should eq 0
           end
         end
+      end
 
-        context "casting" do
-          it "returns false for the given block" do
-            params = params_builder("name=john&number=1&price=3.45&list=[1,2,3]")
-            validator = Validators::Params.new(params)
-            validator.validation do
-              required(:name) { |f| !f.to_s.empty? }
-              required(:number) { |f| f.as(String).to_i > 0 }
-              required(:price) { |f| f.as(String).to_f == 3.45 }
-              required(:list) do |f|
-                list = JSON.parse(f.as(String)).as_a
-                (list == [1, 2, 3] && !list.includes? 6)
-              end
+      context "casting" do
+        it "returns false for the given block" do
+          params = params_builder("name=john&number=1&price=3.45&list=[1,2,3]")
+          validator = Validators::Params.new(params)
+          validator.validation do
+            required(:name) { |f| !f.to_s.empty? }
+            required(:number) { |f| f.as(String).to_i > 0 }
+            required(:price) { |f| f.as(String).to_f == 3.45 }
+            required(:list) do |f|
+              list = JSON.parse(f.as(String)).as_a
+              (list == [1, 2, 3] && !list.includes? 6)
             end
-
-            validator.valid?.should be_truthy
           end
+
+          validator.valid?.should be_truthy
         end
       end
     end

--- a/src/amber/validators/params.cr
+++ b/src/amber/validators/params.cr
@@ -8,12 +8,12 @@ module Amber::Validators
     getter field : String
     getter value : String?
 
-    def initialize(field : String | Symbol, @msg : String?, @allow_blank : Bool)
+    def initialize(field : String | Symbol, @msg : String?, @allow_blank : Bool = true)
       @field = field.to_s
       @predicate = ->(_s : String) { true }
     end
 
-    def initialize(field : String | Symbol, @msg : String?, @allow_blank : Bool, &block : String -> Bool)
+    def initialize(field : String | Symbol, @msg : String?, @allow_blank : Bool = true, &block : String -> Bool)
       @field = field.to_s
       @predicate = block
     end

--- a/src/amber/validators/params.cr
+++ b/src/amber/validators/params.cr
@@ -37,17 +37,19 @@ module Amber::Validators
     end
   end
 
+  # RequiredRule returns false if key is missing or value is blank or if block returns false.
   class RequiredRule < BaseRule
     def apply(params : Amber::Router::Params)
       return false unless params.has_key?(@field)
+      return false if params[@field].blank?
       call_predicate(params)
     end
   end
 
-  # OptionalRule only validates if the key is present.
+  # OptionalRule only validates (evaluates block) if the key is present and the value is not blank.
   class OptionalRule < BaseRule
     def apply(params : Amber::Router::Params)
-      return true unless params.has_key?(@field) && params[@field] != ""
+      return true unless params.has_key?(@field) && !params[@field].blank?
       call_predicate(params)
     end
   end


### PR DESCRIPTION
Continuation of #985 : 

Removed the block requirement for `required` (most of the time it's just { |f| !f.blank? } anyway). The `required` check now works the same way as the new optional check: it requires presence of key + value not blank, and you can omit the block if you don't need anything fancier than that.

I also added an `allow_blank` argument (with a default value) to restore the old behavior for those who depend on it. I didn't see a changelog file or anything like that, but it would be good to mention this change when the next version is released.