### PR TITLE
Uppercase some scaffolded links

### DIFF
--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -32,5 +32,5 @@
   </div>
 <% end -%>
   <%="<"%>%= submit("Submit", class: "btn btn-primary btn-sm") -%>
-  <%="<"%>%= link_to("back", "/<%= name_plural %>", class: "btn btn-light btn-sm") -%>
+  <%="<"%>%= link_to("Back", "/<%= name_plural %>", class: "btn btn-light btn-sm") -%>
 </form>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -21,4 +21,4 @@
   <%- end -%>
 <%- end -%>
   == submit("Submit", class: "btn btn-primary btn-sm")
-  == link_to("back", "/<%= name_plural %>", class: "btn btn-light btn-sm")
+  == link_to("Back", "/<%= name_plural %>", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -24,9 +24,9 @@
 <% end -%>
         <td>
           <span>
-            <%="<"%>%= link_to("read", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm") -%>
-            <%="<"%>%= link_to("edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
-            <%="<"%>%= link_to("delete", "/<%= name_plural %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
+            <%="<"%>%= link_to("Show", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm") -%>
+            <%="<"%>%= link_to("Edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
+            <%="<"%>%= link_to("Delete", "/<%= name_plural %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
           </span>
         </td>
       </tr>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -19,6 +19,6 @@
           <%- end -%>
           td
             span
-              == link_to("read", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm")
-              == link_to("edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
-              == link_to("delete", "/<%= name_plural %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")
+              == link_to("Show", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm")
+              == link_to("Edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
+              == link_to("Delete", "/<%= name_plural %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.ecr.ecr
@@ -4,7 +4,7 @@
 <p><%="<"%>%= <%= @name %>.<%= field.name %><% if field.reference? %><% if @model == "crecto" %>_id<% else %>.id<% end %><% end %> %></p>
 <% end -%>
 <p>
-  <%="<"%>%= link_to("back", "/<%= name_plural %>", class: "btn btn-light btn-sm") -%>
-  <%="<"%>%= link_to("edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
-  <%="<"%>%= link_to("delete", "/<%= name_plural %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
+  <%="<"%>%= link_to("Back", "/<%= name_plural %>", class: "btn btn-light btn-sm") -%>
+  <%="<"%>%= link_to("Edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
+  <%="<"%>%= link_to("Delete", "/<%= name_plural %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
 </p>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/show.slang.ecr
@@ -3,6 +3,6 @@ h1 Show <%= display_name %>
 p = <%= @name %>.<%= field.name %><% if field.reference? %><% if @model == "crecto" %>_id<% else %>.id<% end %><% end %>
 <% end -%>
 p
-  == link_to("back", "/<%= name_plural %>", class: "btn btn-light btn-sm")
-  == link_to("edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
-  == link_to("delete", "/<%= name_plural %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")
+  == link_to("Back", "/<%= name_plural %>", class: "btn btn-light btn-sm")
+  == link_to("Edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
+  == link_to("Delete", "/<%= name_plural %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")


### PR DESCRIPTION
### Description of the Change

This makes some very minor changes to the templates used in the scaffolds. There was some inconsistency between links/buttons with a capital first letter and some that were all lowercase.

* This gives all the links/buttons in the resource scaffold a capital letter.
* This renames the "read" link to "show".

### Alternate Designs

I understand that "read" fits in with the CRUD, but if we are going that route we should probably rename "new" to "create" to line up. I think "show" makes much better sense in this context, especially to an end-user.

### Benefits

Just a little more polish in the scaffold which is a nicer experience.

### Possible Drawbacks

I suppose if you were running integration tests over your scaffolds that expected lowercase links then you would need to consider that going forward. It won't affect any existing scaffolds.
