### PR TITLE
output to logger on 403, 404, 500

### DIFF
--- a/src/amber/pipes/error.cr
+++ b/src/amber/pipes/error.cr
@@ -11,14 +11,17 @@ module Amber
         context.response.status_code = 403
         error = Amber::Controller::Error.new(context, ex)
         context.response.print(error.forbidden)
+        Amber.logger.warn error.forbidden, "Error: 403", :yellow
       rescue ex : Amber::Exceptions::RouteNotFound
         context.response.status_code = 404
         error = Amber::Controller::Error.new(context, ex)
         context.response.print(error.not_found)
+        Amber.logger.warn error.not_found, "Error: 404", :yellow
       rescue ex : Exception
         context.response.status_code = 500
         error = Amber::Controller::Error.new(context, ex)
         context.response.print(error.internal_server_error)
+        Amber.logger.error error.internal_server_error, "Error: 500", :red
       end
     end
   end


### PR DESCRIPTION
### Description of the Change

Had a really frustrating day once where amber was outputting absolutely nothing at all anywhere, so I thought I must be using something wrong. Ended up writing this small patch and found that there was indeed a 500 error occurring that was preventing the page from rendering.

(Looking at this again, it might also be good to limit the `context.response.print` to non-production envs, but that's sort of a separate issue.)