### PR TITLE
Improve auth scaffold capitalisation and internationalisation

### DIFF
--- a/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
@@ -12,10 +12,10 @@ class RegistrationController < ApplicationController
 
     if changeset.valid?
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash["success"] = "Created <%= class_name %> successfully."
+      flash["success"] = t("registration.create.success")
       redirect_to "/"
     else
-      flash["danger"] = "Could not create <%= class_name %>!"
+      flash["danger"] = t("registration.create.failure")
       render("new.<%= @language %>")
     end
   end

--- a/src/amber/cli/templates/auth/crecto/src/controllers/session_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/controllers/session_controller.cr.ecr
@@ -9,10 +9,10 @@ class SessionController < ApplicationController
 
     if <%= @name %> && <%= @name %>.authenticate(params["password"].to_s)
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash[:info] = "Successfully logged in"
+      flash[:info] = t("session.create.success")
       redirect_to "/"
     else
-      flash[:danger] = "Invalid email or password"
+      flash[:danger] = t("session.create.failure")
       <%= @name %> = <%= class_name %>.new
       render("new.<%= @language %>")
     end
@@ -20,7 +20,7 @@ class SessionController < ApplicationController
 
   def delete
     session.delete(:<%= @name %>_id)
-    flash[:info] = "Logged out. See ya later!"
+    flash[:info] = t("session.delete.success")
     redirect_to "/"
   end
 end

--- a/src/amber/cli/templates/auth/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -21,10 +21,10 @@ class <%= class_name %>Controller < ApplicationController
     <%= @name %>_changeset = Repo.update(<%= @name %>.as(<%= class_name %>))
 
     if <%= @name %>_changeset.valid?
-      flash[:success] = "Updated Profile successfully."
+      flash[:success] = t("<%= @name %>.update.success")
       redirect_to "/profile"
     else
-      flash[:danger] = "Could not update Profile!"
+      flash[:danger] = t("<%= @name %>.update.failure")
       render("edit.<%= @language %>")
     end
   end

--- a/src/amber/cli/templates/auth/crecto/src/locales/+en.yml.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/locales/+en.yml.ecr
@@ -1,0 +1,16 @@
+registration:
+  create:
+    success: Welcome, your account was created successfully.
+    failure: Your account could not be created.
+
+session:
+  create:
+    success: You've been logged in successfully.
+    failure: Your email or password was invalid.
+  delete:
+    success: You've been logged out successfully.
+
+<%= @name %>:
+  update:
+    success: Your profile was updated successfully.
+    failure: Your profile could not be updated.

--- a/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.ecr.ecr
@@ -14,5 +14,5 @@
     <input class="form-control" type="email" name="email" placeholder="Email" value="<%="<"%>%= <%= @name %>.email %>" />
   </div>
   <%="<"%>%= submit("Update", class: "btn btn-primary btn-sm") %>
-  <%="<"%>%= link_to("profile", "/profile", class: "btn btn-light btn-sm") %>
+  <%="<"%>%= link_to("Profile", "/profile", class: "btn btn-light btn-sm") %>
 </form>

--- a/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.slang.ecr
@@ -10,4 +10,4 @@ h1 Edit Profile
   .form-group
     input.form-control type="email" name="email" placeholder="Email" value="#{<%= @name %>.email}"
   == submit("Update", class: "btn btn-primary btn-sm")
-  == link_to("profile", "/profile", class: "btn btn-light btn-sm")
+  == link_to("Profile", "/profile", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/auth/crecto/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/{{name}}/show.ecr.ecr
@@ -1,5 +1,5 @@
 <h1>Profile</h1>
 <p>
   <%="<"%>%= <%= @name %>.email %>
-  <%="<"%>%= link_to("edit", "/profile/edit", class: "btn btn-success btn-sm") %>
+  <%="<"%>%= link_to("Edit", "/profile/edit", class: "btn btn-success btn-sm") %>
 </p>

--- a/src/amber/cli/templates/auth/crecto/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/{{name}}/show.slang.ecr
@@ -1,4 +1,4 @@
 h1 Profile
 p
   == <%= @name %>.email
-  == link_to("edit", "/profile/edit", class: "btn btn-success btn-sm")
+  == link_to("Edit", "/profile/edit", class: "btn btn-success btn-sm")

--- a/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
@@ -10,10 +10,10 @@ class RegistrationController < ApplicationController
 
     if <%= @name %>.valid? && <%= @name %>.save
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash["success"] = "Created <%= class_name %> successfully."
+      flash["success"] = t("registration.create.success")
       redirect_to "/"
     else
-      flash["danger"] = "Could not create <%= class_name %>!"
+      flash["danger"] = t("registration.create.failure")
       render("new.<%= @language %>")
     end
   end

--- a/src/amber/cli/templates/auth/granite/src/controllers/session_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/controllers/session_controller.cr.ecr
@@ -8,10 +8,10 @@ class SessionController < ApplicationController
     <%= @name %> = <%= class_name %>.find_by(email: params["email"].to_s)
     if <%= @name %> && <%= @name %>.authenticate(params["password"].to_s)
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash[:info] = "Successfully logged in"
+      flash[:info] = t("session.create.success")
       redirect_to "/"
     else
-      flash[:danger] = "Invalid email or password"
+      flash[:danger] = t("session.create.failure")
       <%= @name %> = <%= class_name %>.new
       render("new.<%= @language %>")
     end
@@ -19,7 +19,7 @@ class SessionController < ApplicationController
 
   def delete
     session.delete(:<%= @name %>_id)
-    flash[:info] = "Logged out. See ya later!"
+    flash[:info] = t("session.delete.success")
     redirect_to "/"
   end
 end

--- a/src/amber/cli/templates/auth/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -14,10 +14,10 @@ class <%= class_name %>Controller < ApplicationController
   def update
     <%= @name %> = current_<%= @name %>
     if update(<%= @name %>)
-      flash[:success] = "Updated Profile successfully."
+      flash[:success] = t("<%= @name %>.update.success")
       redirect_to "/profile"
     elsif <%= @name %>
-      flash[:danger] = "Could not update Profile!"
+      flash[:danger] = t("<%= @name %>.update.failure")
       render("edit.<%= @language %>")
     else
       flash[:info] = "Must be logged in"

--- a/src/amber/cli/templates/auth/granite/src/locales/+en.yml.ecr
+++ b/src/amber/cli/templates/auth/granite/src/locales/+en.yml.ecr
@@ -1,0 +1,16 @@
+registration:
+  create:
+    success: Welcome, your account was created successfully.
+    failure: Your account could not be created.
+
+session:
+  create:
+    success: You've been logged in successfully.
+    failure: Your email or password was invalid.
+  delete:
+    success: You've been logged out successfully.
+
+<%= @name %>:
+  update:
+    success: Your profile was updated successfully.
+    failure: Your profile could not be updated.

--- a/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.ecr.ecr
@@ -14,5 +14,5 @@
     <input class="form-control" type="email" name="email" placeholder="Email" value="<%="<"%>%= <%= @name %>.email %>" />
   </div>
   <%="<"%>%= submit("Update", class: "btn btn-primary btn-sm") %>
-  <%="<"%>%= link_to("profile", "/profile", class: "btn btn-light btn-sm") %>
+  <%="<"%>%= link_to("Profile", "/profile", class: "btn btn-light btn-sm") %>
 </form>

--- a/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.slang.ecr
@@ -10,4 +10,4 @@ h1 Edit Profile
   .form-group
     input.form-control type="email" name="email" placeholder="Email" value="#{<%= @name %>.email}"
   == submit("Update", class: "btn btn-primary btn-sm")
-  == link_to("profile", "/profile", class: "btn btn-light btn-sm")
+  == link_to("Profile", "/profile", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/auth/granite/src/views/{{name}}/show.ecr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/{{name}}/show.ecr.ecr
@@ -1,5 +1,5 @@
 <h1>Profile</h1>
 <p>
   <%="<"%>%= <%= @name %>.email %>
-  <%="<"%>%= link_to("edit", "/profile/edit", class: "btn btn-success btn-sm") %>
+  <%="<"%>%= link_to("Edit", "/profile/edit", class: "btn btn-success btn-sm") %>
 </p>

--- a/src/amber/cli/templates/auth/granite/src/views/{{name}}/show.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/{{name}}/show.slang.ecr
@@ -1,4 +1,4 @@
 h1 Profile
 p
   == <%= @name %>.email
-  == link_to("edit", "/profile/edit", class: "btn btn-success btn-sm")
+  == link_to("Edit", "/profile/edit", class: "btn btn-success btn-sm")

--- a/src/amber/cli/templates/crecto_auth.cr
+++ b/src/amber/cli/templates/crecto_auth.cr
@@ -27,7 +27,7 @@ module Amber::CLI
     end
 
     def filter(entries)
-      entries.reject { |entry| entry.path.includes?("src/views") && !entry.path.includes?(".#{@language}") }
+      entries.reject { |entry| !view_template?(entry) && !locale_template(entry) }
     end
 
     private def setup_routes
@@ -41,6 +41,14 @@ module Amber::CLI
           get "/signup", RegistrationController, :new
           post "/registration", RegistrationController, :create
       ROUTES
+    end
+
+    private def view_template?(entry)
+      entry.path.includes?("src/views") && !entry.path.includes?(".#{@language}")
+    end
+
+    private def locale_template(entry)
+      entry.path.includes?("src/locales") && !entry.path.includes?(".yml")
     end
 
     private def setup_plugs

--- a/src/amber/cli/templates/granite_auth.cr
+++ b/src/amber/cli/templates/granite_auth.cr
@@ -28,11 +28,19 @@ module Amber::CLI
     end
 
     def filter(entries)
-      entries.reject { |entry| entry.path.includes?("src/views") && !entry.path.includes?(".#{@language}") }
+      entries.reject { |entry| !view_template?(entry) && !locale_template(entry) }
     end
 
     def table_name
       @table_name ||= name_plural
+    end
+
+    private def view_template?(entry)
+      entry.path.includes?("src/views") && !entry.path.includes?(".#{@language}")
+    end
+
+    private def locale_template(entry)
+      entry.path.includes?("src/locales") && !entry.path.includes?(".yml")
     end
 
     private def setup_routes


### PR DESCRIPTION
### Description of the Change

This is a semi-followup to #939 by using consistent capitalisation of links in the auth scaffold.

In addition it changes the default flash messages to go through translation out of the box, rather than being hard-coded. At the moment the messages were a little awkward so I think the language was improved.

I would love some feedback around the implementation of the locale files. I think I've got it set up correctly whereby the translations will be appended to the existing locale files, however I could not find a way to test this.

Happy to re-issue this PR if you're uncomfortable with the translation change.

### Benefits

I think the developer experience is improved by having consistent capitalisation of of the box - it's faster to get up and going.

### Possible Drawbacks

As far as using translations go it's a bit of a mixed bag. Some developers may prefer to have the text hard-coded in the controllers so it's easy to go through and make the changes necessary. On the other hand it's a nice gentle nudge to introduce developers to the translation system and get them in the habit of using it. If your site is only ever in a single language (which, I suppose, most sites would be) then it could be considered overkill
