### PR TITLE
Configure watch via .amber.yml

### DIFF
--- a/src/amber/cli/commands/watch.cr
+++ b/src/amber/cli/commands/watch.cr
@@ -20,8 +20,6 @@ module Amber::CLI
 
       def run
         CLI.toggle_colors(options.no_color?)
-        options.watch << "./config/**/*.cr"
-        options.watch << "./src/views/**/*.slang"
         super
       end
     end

--- a/src/amber/cli/config.cr
+++ b/src/amber/cli/config.cr
@@ -1,20 +1,33 @@
 module Amber::CLI
   def self.config
     if File.exists? AMBER_YML
-      Config.from_yaml File.read(AMBER_YML)
+      begin
+        Config.from_yaml File.read(AMBER_YML)
+      rescue ex : YAML::ParseException
+        logger.error "Couldn't parse #{AMBER_YML} file", "Watcher", :red
+        exit 1
+      end
     else
       Config.new
     end
   end
 
   class Config
+    SHARD_YML    = "shard.yml"
+    DEFAULT_NAME = "[process_name]"
+
+    # see defaults below
+    alias WatchOptions = Hash(String, Hash(String, Array(String)))
+
     property database : String = "pg"
     property language : String = "slang"
     property model : String = "granite"
     property recipe : (String | Nil) = nil
     property recipe_source : (String | Nil) = nil
+    property watch : WatchOptions
 
     def initialize
+      @watch = default_watch_options
     end
 
     YAML.mapping(
@@ -22,7 +35,47 @@ module Amber::CLI
       language: {type: String, default: "slang"},
       model: {type: String, default: "granite"},
       recipe: String | Nil,
-      recipe_source: String | Nil
+      recipe_source: String | Nil,
+      watch: {type: WatchOptions, default: default_watch_options}
     )
+
+    def default_watch_options
+      appname = self.class.get_name
+
+      opts = WatchOptions{
+        "run" => Hash{
+          "build_commands" => [
+            "mkdir -p bin",
+            "crystal build ./src/#{appname}.cr -o bin/#{appname}",
+          ],
+          "run_commands" => [
+            "bin/#{appname}",
+          ],
+          "include" => [
+            "./config/**/*.cr",
+            "./src/**/*.cr",
+            "./src/views/**/*.slang",
+          ],
+        },
+        "npm" => Hash{
+          "build_commands" => [
+            "npm install --loglevel=error",
+          ],
+          "run_commands" => [
+            "npm run watch",
+          ],
+        },
+      }
+    end
+
+    def self.get_name
+      if File.exists?(SHARD_YML) &&
+         (yaml = YAML.parse(File.read SHARD_YML)) &&
+         (name = yaml["name"]?)
+        name.as_s
+      else
+        DEFAULT_NAME
+      end
+    end
   end
 end

--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -34,10 +34,15 @@ module Amber::CLI::Helpers
   end
 
   def self.run(command, wait = true, shell = true)
-    if wait
-      Process.run(command, shell: shell, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
-    else
-      Process.new(command, shell: shell, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+    begin
+      if wait
+        Process.run(command, shell: shell, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      else
+        Process.new(command, shell: shell, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
+      end
+    rescue ex : Errno
+      # typically means we could not find the executable
+      ex
     end
   end
 end

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -2,27 +2,26 @@ require "./helpers"
 
 module Sentry
   class ProcessRunner
-    property processes = [] of Process
+    property processes = Hash(String, Array(Process)).new
     property process_name : String
-    property files = [] of String
     @logger : Amber::Environment::Logger
-    FILE_TIMESTAMPS = {} of String => String
+    FILE_TIMESTAMPS = Hash(String, Int64).new
 
     def initialize(
       @process_name : String,
-      @build_command : String,
-      @run_command : String,
-      @build_args : Array(String) = [] of String,
-      @run_args : Array(String) = [] of String,
-      files = [] of String,
+      @build_commands = Hash(String, String).new,  # { "task1" => [ ... ], "task2" => [ ... ] }
+      @run_commands = Hash(String, String).new,    # { "task1" => [ ... ], "task2" => [ ... ] }
+      @includes = Hash(String, Array(String)).new, # { "task1" => [ ... ], "task2" => [ ... ] }
+      @excludes = Hash(String, Array(String)).new, # { "task1" => [ ... ], "task2" => [ ... ] }
       @logger = Amber::CLI.logger
     )
-      @files = files
-      @npm_process = false
       @app_running = false
     end
 
     def run
+      scan_files(no_actions: true)
+      start_processes
+
       loop do
         scan_files
         check_processes
@@ -30,96 +29,165 @@ module Sentry
       end
     end
 
-    # Compiles and starts the application
-    def start_app
-      time = Time.monotonic
-      build_result = build_app_process
-      return unless build_result.is_a? Process::Status
+    private def scan_files(no_actions = false)
+      # build a list of all files, with their associated tasks
+      all_files = Hash(String, Array(String)).new # { "file" => [ "task1", "task2" ]}
+      changed_files = Array(String).new
 
-      if build_result.success?
-        log "Compiled in #{(Time.monotonic - time)}"
-        stop_all_processes if @app_running
-        create_all_processes
-        @app_running = true
-      elsif !@app_running
-        log "Compile time errors detected. Shutting down..."
-        exit 1
+      @includes.each do |task, includes|
+        excluded_files = Array(String).new
+        if (excludes = @excludes[task]?)
+          excludes.each { |glob| excluded_files += Dir.glob(glob) }
+        end
+        includes.each do |glob|
+          Dir.glob(glob).each do |f|
+            next if excluded_files.includes?(f)
+            all_files[f] ||= Array(String).new
+            all_files[f] << task
+          end
+        end
       end
-    end
 
-    private def scan_files
-      file_counter = 0
-      Dir.glob(files) do |file|
+      all_files.each do |file, tasks|
         timestamp = get_timestamp(file)
         if FILE_TIMESTAMPS[file]? != timestamp
-          log "File changed: #{file.colorize(:light_gray)}" if @app_running
           FILE_TIMESTAMPS[file] = timestamp
-          file_counter += 1
+          unless no_actions
+            log :scan, "File changed: #{file.colorize(:light_gray)} (will notify: #{tasks.join(", ")})"
+            changed_files << file
+          end
         end
       end
-      if file_counter > 0
-        log "#{file_counter} file(s) changed. Recompiling..." if @app_running
-        start_app
+
+      return if no_actions || changed_files.empty?
+
+      tasks_to_run = Hash(String, Int32).new
+      changed_files.each do |file|
+        all_files[file].each do |task|
+          tasks_to_run[task] ||= 0
+          tasks_to_run[task] += 1
+        end
+      end
+
+      tasks_to_run.each do |task, changed_file_count|
+        log task, "#{changed_file_count} file(s) changed."
+        start_processes(task)
       end
     end
 
+    # restart dead processes (currently limited to run task)
     private def check_processes
-      @processes.reject!(&.terminated?)
-      if @processes.empty?
-        log "All processed died. Trying to start..."
-        if (process = create_watch_process).is_a? Process
-          @processes << process
+      @processes.each do |task, procs|
+        # clean up process list and restart if terminated
+        if procs.any?
+          procs.reject!(&.terminated?)
+
+          if procs.empty?
+            # restarting currently limited to run task (server process), otherwise just notify
+            if task == "run"
+              log task, "All processes died. Trying to restart..."
+              start_processes(task, skip_build: true)
+            else
+              log task, "Exited"
+            end
+          end
         end
       end
     end
 
-    private def stop_all_processes
-      log "Terminating app #{project_name}..."
-      @processes.each do |process|
-        process.kill unless process.terminated?
+    private def stop_processes(task = :all)
+      @processes.each do |task, procs|
+        next unless task == :all || task.to_s == task
+
+        if task == "run"
+          log task, "Terminating app #{project_name}..."
+        else
+          log task, "Terminating process..."
+        end
+        procs.each do |process|
+          process.kill unless process.terminated?
+        end
+        procs.clear
       end
-      processes.clear
     end
 
-    private def create_all_processes
-      process = create_watch_process
-      @processes << process if process.is_a? Process
-      unless @npm_process
-        create_npm_process
-        @npm_process = true
+    private def start_processes(task_to_start = :all, skip_build = false)
+      if task_to_start == :all || task_to_start == "run"
+        # handle run task first, exit immediately if it fails
+        if (build_command = @build_commands["run"]) && (run_command = @run_commands["run"])
+          ok_to_run = false
+          if skip_build
+            ok_to_run = true
+          else
+            log :run, "Building..."
+            time = Time.monotonic
+            build_result = Amber::CLI::Helpers.run(build_command)
+            exit 1 unless build_result.is_a? Process::Status
+            if build_result.success?
+              log :run, "Compiled in #{(Time.monotonic - time)}"
+              stop_processes("run") if @app_running
+              ok_to_run = true
+            elsif !@app_running # first run
+              log :run, "Compile time errors detected, exiting...", :red
+              exit 1
+            end
+          end
+
+          if ok_to_run
+            process = Amber::CLI::Helpers.run(run_command, wait: false, shell: false)
+            if process.is_a? Process
+              @processes["run"] ||= Array(Process).new
+              @processes["run"] << process
+            elsif process.is_a? Exception
+              log :run, "Could not run (#{process.message}), exiting...", :red
+              log :run, "Please check your watch config and try again.", :red
+              exit 1
+            end
+
+            @app_running = true
+          end
+        else
+          log :run, "Build or run commands missing for run task, exiting...", :red
+          exit 1
+        end
       end
-    end
 
-    private def build_app_process
-      log "Building project #{project_name}..."
-      Amber::CLI::Helpers.run(@build_command)
-    end
+      @run_commands.each do |task, run_command|
+        next if task == "run" # already handled
+        next unless task_to_start == :all || task_to_start.to_s == task
 
-    private def create_watch_process
-      log "Starting #{project_name}..."
-      Amber::CLI::Helpers.run(@run_command, wait: false, shell: false)
-    end
+        if (build_command = @build_commands[task]?) && !skip_build
+          log task, "Building..."
+          build_result = Amber::CLI::Helpers.run(build_command)
+          next unless build_result.is_a? Process::Status
 
-    private def create_npm_process
-      node_log "Installing dependencies..."
-      Amber::CLI::Helpers.run("npm install --loglevel=error && npm run watch", wait: false)
-      node_log "Watching public directory"
+          if build_result.success?
+            Amber::CLI::Helpers.run(build_command)
+          else
+            log task, "Build step failed."
+            next # don't continue to run command step
+          end
+        end
+
+        log task, "Starting..."
+        process = Amber::CLI::Helpers.run(run_command, wait: false, shell: true)
+        if process.is_a? Process
+          @processes[task] ||= Array(Process).new
+          @processes[task] << process
+        end
+      end
     end
 
     private def get_timestamp(file : String)
-      File.info(file).modification_time.to_s("%Y%m%d%H%M%S")
+      File.info(file).modification_time.to_unix
     end
 
     private def project_name
       process_name.capitalize.colorize(:white)
     end
 
-    private def log(msg)
-      @logger.info msg, "Watcher", :light_gray
-    end
-
-    private def node_log(msg)
-      @logger.info msg, "NodeJS", :dark_gray
+    private def log(task, msg, color = :light_gray)
+      @logger.info msg, "Watch #{task}", color
     end
   end
 end

--- a/src/amber/cli/helpers/sentry.cr
+++ b/src/amber/cli/helpers/sentry.cr
@@ -5,28 +5,17 @@ require "./process_runner"
 module Sentry
   class SentryCommand < Cli::Command
     command_name "sentry"
-    SHARD_YML    = "shard.yml"
-    DEFAULT_NAME = "[process_name]"
 
     class Options
       def self.defaults
-        name = Options.get_name
+        name = Amber::CLI::Config.get_name
         {
           name:         name,
           process_name: "./bin/#{name}",
-          build:        "mkdir -p bin && crystal build ./src/#{name}.cr -o bin/#{name}",
-          watch:        ["./src/**/*.cr", "./src/**/*.ecr"],
+          build:        join_commands(Amber::CLI.config.watch["run"]["build_commands"]),
+          run:          join_commands(Amber::CLI.config.watch["run"]["run_commands"]),
+          watch:        Amber::CLI.config.watch["run"]["include"],
         }
-      end
-
-      def self.get_name
-        if File.exists?(SHARD_YML) &&
-           (yaml = YAML.parse(File.read SHARD_YML)) &&
-           (name = yaml["name"]?)
-          name.as_s
-        else
-          DEFAULT_NAME
-        end
       end
 
       string %w(-n --name), desc: "Sets the name of the app process",
@@ -35,22 +24,27 @@ module Sentry
       string %w(-b --build), desc: "Overrides the default build command",
         default: Options.defaults[:build]
 
-      string "--build-args", desc: "Specifies arguments for the build command"
-
       string %w(-r --run), desc: "Overrides the default run command",
-        default: Options.defaults[:process_name]
-
-      string "--run-args", desc: "Specifies arguments for the run command"
+        default: Options.defaults[:run]
 
       array %w(-w --watch),
         desc: "Overrides default files and appends to list of watched files",
         default: Options.defaults[:watch]
 
       bool %w(-i --info),
-        desc: "Shows the values for build/run commands, build/run args, and watched files",
+        desc: "Shows the values for build/run commands, and watched files",
         default: false
 
       help
+
+      def self.join_commands(command_array : Array(String)) : String
+        case command_array.size
+        when 0 then "echo"
+        when 1 then command_array.first
+        else
+          command_array.map { |c| "(#{c})" }.join(" && ")
+        end
+      end
     end
 
     def run
@@ -58,32 +52,34 @@ module Sentry
         puts <<-INFO
           name:       #{options.name?}
           build:      #{options.build?}
-          build args: #{options.build_args?}
           run:        #{options.run?}
-          run args:   #{options.run_args?}
           files:      #{options.watch}
         INFO
         exit! code: 0
       end
 
-      build_args = if ba = options.build_args?
-                     ba.split " "
-                   else
-                     [] of String
-                   end
-      run_args = if ra = options.run_args?
-                   ra.split " "
-                 else
-                   [] of String
-                 end
+      build_commands = Hash(String, String).new
+      run_commands = Hash(String, String).new
+      includes = Hash(String, Array(String)).new
+      excludes = Hash(String, Array(String)).new
+      (watch = Amber::CLI.config.watch).each do |task, opts|
+        build_commands[task] = Options.join_commands(opts["build_commands"]) if opts.has_key?("build_commands")
+        run_commands[task] = Options.join_commands(opts["run_commands"]) if opts.has_key?("run_commands")
+        includes[task] = opts["include"] if opts.has_key?("include")
+        excludes[task] = opts["exclude"] if opts.has_key?("exclude")
 
+        if task == "run" # can override via command line args
+          build_commands[task] = options.build
+          run_commands[task] = options.run
+          includes[task] = options.watch
+        end
+      end
       process_runner = Sentry::ProcessRunner.new(
         process_name: options.name,
-        build_command: options.build,
-        run_command: options.run,
-        build_args: build_args,
-        run_args: run_args,
-        files: options.watch,
+        build_commands: build_commands,
+        run_commands: run_commands,
+        includes: includes,
+        excludes: excludes,
         logger: Amber::CLI.logger
       )
 

--- a/src/amber/cli/templates/app/.amber.yml.ecr
+++ b/src/amber/cli/templates/app/.amber.yml.ecr
@@ -2,3 +2,33 @@ type: app
 database: <%= @database %>
 language: <%= @language %>
 model: <%= @model %>
+
+# list of tasks to be run by `amber watch`
+watch:
+  # NOTE: names that match crystal commands are special (e.g. run, spec)
+  run:
+    # commands will be joined with && (join them yourself if need || or ;)
+    build_commands:
+      - mkdir -p bin
+      - crystal build ./src/<%= @name %>.cr -o bin/<%= @name %>
+    run_commands:
+      - bin/<%= @name %>
+    include:
+      - ./config/**/*.cr
+      - ./src/**/*.cr
+      - ./src/**/*.ecr
+      <%- if @language == "slang" -%>
+      - ./src/views/**/*.slang
+      <%- end -%>
+    # exclude: # NOTE simplistic implementation: (1) enumerate all includes and excludes; (2) return (includes - excludes)
+    #  - ./src/some_irrelevant_file.cr
+  spec:
+    run_commands:
+      - crystal spec
+    include:
+      - ./spec/**/*.cr
+  npm:
+    build_commands:
+      - npm install --loglevel=error
+    run_commands:
+      - npm run watch


### PR DESCRIPTION
### Description of the Change

Allow user to configure `amber watch` from `.amber.yml`. Configuring this way is optional (there is still a default config, and it is the same as before), and you can continue to use the command line switches if you want (if you have a config in `.amber.yml`, command line switches will override it).

A sample `.amber.yml`:

```yml
type: app
language: ecr
model: granite

# list of tasks to be run by `amber watch`
watch:
  # NOTE: names that match crystal commands are special (e.g. run, spec)
  run:
    # commands will be joined with && (join them yourself if need || or ;)
    build_commands:
      - mkdir -p bin
      - crystal build ./src/rcwebcr.cr -o bin/rcwebcr
    run_commands:
      - bin/rcwebcr
    include:
      - ./config/**/*.cr
      - ./src/**/*.cr
      - ./src/**/*.ecr
    exclude: # NOTE simplistic implementation: (1) enumerate all includes and excludes; (2) return (includes - excludes)
      - ./src/dont_restart_when_i_am_changed.cr
  spec:
    run_commands:
      - crystal spec
    include:
      - ./spec/**/*.cr
    exclude:
      - ./spec/dont_run_specs_when_i_am_changed.cr
  npm:
    build_commands:
      - npm install --loglevel=error
    run_commands:
      - npm run watch
```

### Alternate Designs

The config is too complex to configure solely via command line switches/arguments, and leaving it non-user-configurable is creating unhappiness among users.

### Benefits

Developers are now free to choose `yarn` over `npm`, or even nothing at all. Additionally, they can use `amber watch` to run other processes as well.

### Possible Drawbacks

Mainly some code bloat. It's certainly possible that this is not something the amber project should handle directly.