### PR TITLE
Provide supported options in CLI

### DIFF
--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -7,12 +7,12 @@ module Amber::CLI
     class New < Command
       class Options
         arg "name", desc: "name/path of project", required: true
-        string "-d", desc: "Select the database database engine, can be one of: pg | mysql | sqlite", default: "pg"
+        string "-d", desc: "Select the database database engine", any_of: %w(pg mysql sqlie), default: "pg"
         bool "--deps", desc: "Installs project dependencies, this is the equivalent of running (shards update)", default: false
-        string "-m", desc: "Select the model type, can be one of: granite | crecto", default: "granite"
+        string "-m", desc: "Select the model type", any_of: %w(granite crecto), default: "granite"
         bool "--no-color", desc: "Disable colored output", default: false
-        string "-t", desc: "Selects the template engine language, can be one of: slang | ecr", default: "slang"
-        string "-r", desc: "Use a named recipe.  See documentation at  https://docs.amberframework.org/amber/cli/recipes.", default: nil
+        string "-t", desc: "Selects the template engine language", any_of: %w(slang ecr), default: "slang"
+        string "-r", desc: "Use a named recipe. See documentation at https://docs.amberframework.org/amber/cli/recipes.", default: nil
         help
       end
 

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -7,7 +7,7 @@ module Amber::CLI
     class New < Command
       class Options
         arg "name", desc: "name/path of project", required: true
-        string "-d", desc: "Select the database database engine", any_of: %w(pg mysql sqlie), default: "pg"
+        string "-d", desc: "Select the database database engine", any_of: %w(pg mysql sqlite), default: "pg"
         bool "--deps", desc: "Installs project dependencies, this is the equivalent of running (shards update)", default: false
         string "-m", desc: "Select the model type", any_of: %w(granite crecto), default: "granite"
         bool "--no-color", desc: "Disable colored output", default: false


### PR DESCRIPTION
### Description of the Change
This is meant to support the issue described in #997 where the new app generator would accept arguments that weren't valid - like `sqlite3` instead of the supported `sqlite`. It does this using the `any_of` of the [underlying CLI library](https://github.com/mosop/cli#shell-completion). It appears that this also populates the help text, so no need to include the options there.

### Alternate Designs
We could manually perform argument validation or add some sort of callback mechanism to perform pre-command logic, but it seemed better to utilise functionality already provided by an existing dependency.

### Benefits
Users will be forced to provide valid arguments and cannot generate an app that will not operate.