### PR TITLE
fixes #697 - XSS bug in auth template

### DIFF
--- a/src/amber/cli/templates/auth/granite/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/layouts/+_nav.slang.ecr
@@ -3,7 +3,7 @@
     | Sign Out
   - active = context.request.path == "/profile" ? "active" : ""
   a class="nav-item nav-item-auth nav-item-auth-profile #{active}" href="/profile"
-    == current_<%= @name %>.email
+    = current_<%= @name %>.email
 - else
   - active = context.request.path == "/signup" ? "active" : ""
   a class="nav-item nav-item-auth nav-item-auth-signup #{active}" href="/signup"


### PR DESCRIPTION
### Description of the Change

XSS bug in auth template.  using a `==` in slang is similar to using `html_safe` in erb in rails.  It bypasses the sanitizing of the display.

### Alternate Designs

none

### Benefits

fixes #697 

### Possible Drawbacks

none