### PR TITLE
Add homebrew tap instruction to macOS installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Read Amber documentation on https://docs.amberframework.org
 #### macOS
 
 ```
+brew tap amberframework/amber
 brew install amber
 ```
 


### PR DESCRIPTION
### Description of the Change

The macOS installation instructions in the README are incomplete, this adds the required `brew tap` command to the documentation, which makes it match the [quick start](https://docs.amberframework.org/amber/getting-started/quick-start#macos) instructions.
