### PR TITLE
Consistent caption and options

### DIFF
--- a/src/amber/cli/commands.cr
+++ b/src/amber/cli/commands.cr
@@ -19,7 +19,7 @@ module Amber::CLI
     version "Amber CLI (amberframework.org) - v#{VERSION}"
 
     class Help
-      title "\nAmber - Command Line Interface"
+      title "\nAmber CLI"
       header <<-EOS
         The `amber new` command creates a new Amber application with a default
         directory structure and configuration at the path you specify.
@@ -43,12 +43,12 @@ module Amber::CLI
     end
 
     class Options
-      version desc: "# Prints Amber version"
-      help desc: "# Describe available commands and usages"
-      string ["-t", "--template"], desc: "# Preconfigure for selected template engine. Options: slang | ecr", default: "slang"
-      string ["-d", "--database"], desc: "# Preconfigure for selected database. Options: pg | mysql | sqlite", default: "pg"
-      string ["-m", "--model"], desc: "# Preconfigure for selected model. Options: granite | crecto", default: "granite"
-      string ["-r", "--recipe"], desc: "# Use a named recipe.  See documentation at https://docs.amberframework.org/amber/cli/recipes.", default: nil
+      version desc: "prints Amber version"
+      help desc: "describe available commands and usages"
+      string ["-t", "--template"], desc: "preconfigure for selected template engine", any_of: %w(slang ecr), default: "slang"
+      string ["-d", "--database"], desc: "preconfigure for selected database.", any_of: %w(pg mysql sqlite), default: "pg"
+      string ["-m", "--model"], desc: "preconfigure for selected model", any_of: %w(granite crecto), default: "granite"
+      string ["-r", "--recipe"], desc: "use a named recipe. See documentation at https://docs.amberframework.org/amber/cli/recipes.", default: nil
     end
   end
 end

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -19,7 +19,7 @@ module Amber::CLI
 
       class Options
         arg_array "commands", desc: "drop create migrate rollback redo status version seed"
-        bool "--no-color", desc: "# Disable colored output", default: false
+        bool "--no-color", desc: "disable colored output", default: false
         help
       end
 
@@ -28,16 +28,16 @@ module Amber::CLI
           Performs database migrations and maintenance tasks. Powered by micrate (https://github.com/juanedi/micrate)
 
         Commands:
-          drop      # Drops the database
-          create    # Creates the database
-          migrate   # Migrate the database to the most recent version available
-          rollback  # Roll back the database version by 1
-          redo      # Re-run the latest database migration
-          status    # dump the migration status for the current database
-          version   # Print the current version of the database
-          seed      # Initialize the database with seed data
+          drop      drops the database
+          create    dreates the database
+          migrate   migrate the database to the most recent version available
+          rollback  roll back the database version by 1
+          redo      re-run the latest database migration
+          status    dump the migration status for the current database
+          version   print the current version of the database
+          seed      initialize the database with seed data
         EOS
-        caption "# Performs database migrations and maintenance tasks"
+        caption "performs database migrations and maintenance tasks"
       end
 
       def run

--- a/src/amber/cli/commands/encrypt.cr
+++ b/src/amber/cli/commands/encrypt.cr
@@ -5,14 +5,14 @@ module Amber::CLI
     class Encrypt < Command
       class Options
         arg "env", desc: "environment file to encrypt", default: "production"
-        string ["-e", "--editor"], desc: "Preferred editor: [vim, nano, pico, etc]", default: "vim"
-        bool ["--noedit"], desc: "Skip editing and just encrypt", default: false
+        string ["-e", "--editor"], desc: "preferred editor: [vim, nano, pico, etc]", default: "vim"
+        bool ["--noedit"], desc: "skip editing and just encrypt", default: false
         help
       end
 
       class Help
         header "Encrypts environment YAML file."
-        caption "# Encrypts environment YAML file. [env | -e --editor | --noedit]"
+        caption "encrypts environment YAML file"
       end
 
       def run

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -17,15 +17,15 @@ module Amber::CLI
 
       class Options
         arg "code", desc: "Crystal code or .cr file to execute within the application scope", default: ""
-        string ["-e", "--editor"], desc: "Preferred editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
-        string ["-b", "--back"], desc: "Runs previous command files: 'amber exec -b [times_ago]'", default: "0"
-        bool "--no-color", desc: "Disable colored output", default: false
+        string ["-e", "--editor"], desc: "preferred editor: [vim, nano, pico, etc], only used when no code or .cr file is specified", default: "vim"
+        string ["-b", "--back"], desc: "runs previous command files: 'amber exec -b [times_ago]'", default: "0"
+        bool "--no-color", desc: "disable colored output", default: false
         help
       end
 
       class Help
         header "Executes Crystal code within the application scope"
-        caption "# Executes Crystal code within the application scope"
+        caption "executes Crystal code within the application scope"
       end
 
       private def prepare_file

--- a/src/amber/cli/commands/generate.cr
+++ b/src/amber/cli/commands/generate.cr
@@ -9,13 +9,13 @@ module Amber::CLI
         arg "type", desc: "scaffold, api, model, controller, migration, mailer, socket, channel, auth, error", required: true
         arg "name", desc: "name of resource", required: false
         arg_array "fields", desc: "user:reference name:string body:text age:integer published:bool"
-        bool "--no-color", desc: "Disable colored output", default: false
+        bool "--no-color", desc: "disable colored output", default: false
         help
       end
 
       class Help
         header "Generates application based on templates"
-        caption "# Generates application based on templates"
+        caption "Generates application based on templates"
       end
 
       def run
@@ -46,7 +46,7 @@ module Amber::CLI
       end
 
       class Help
-        caption "# Generate Amber classes"
+        caption "generate Amber classes"
       end
     end
   end

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -7,18 +7,18 @@ module Amber::CLI
     class New < Command
       class Options
         arg "name", desc: "name/path of project", required: true
-        string "-d", desc: "Select the database database engine", any_of: %w(pg mysql sqlite), default: "pg"
-        bool "--deps", desc: "Installs project dependencies, this is the equivalent of running (shards update)", default: false
-        string "-m", desc: "Select the model type", any_of: %w(granite crecto), default: "granite"
-        bool "--no-color", desc: "Disable colored output", default: false
-        string "-t", desc: "Selects the template engine language", any_of: %w(slang ecr), default: "slang"
-        string "-r", desc: "Use a named recipe. See documentation at https://docs.amberframework.org/amber/cli/recipes.", default: nil
+        string "-d", desc: "select the database database engine", any_of: %w(pg mysql sqlite), default: "pg"
+        bool "--deps", desc: "installs project dependencies, this is the equivalent of running (shards update)", default: false
+        string "-m", desc: "select the model type", any_of: %w(granite crecto), default: "granite"
+        bool "--no-color", desc: "disable colored output", default: false
+        string "-t", desc: "selects the template engine language", any_of: %w(slang ecr), default: "slang"
+        string "-r", desc: "use a named recipe. See documentation at https://docs.amberframework.org/amber/cli/recipes.", default: nil
         help
       end
 
       class Help
         header "Generates a new Amber project"
-        caption "# Generates a new Amber project"
+        caption "generates a new Amber project"
       end
 
       def run

--- a/src/amber/cli/commands/pipelines.cr
+++ b/src/amber/cli/commands/pipelines.cr
@@ -9,8 +9,8 @@ module Amber::CLI
       property current_pipe : String?
 
       class Options
-        bool "--no-color", desc: "Disable colored output", default: false
-        bool "--no-plugs", desc: "Don't output the plugs", default: false
+        bool "--no-color", desc: "disable colored output", default: false
+        bool "--no-plugs", desc: "don't output the plugs", default: false
         help
       end
 

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -24,11 +24,11 @@ module Amber::CLI
 
       class Help
         header "Prints all defined application routes"
-        caption "# Prints all defined application routes"
+        caption "prints all defined application routes"
       end
 
       class Options
-        bool "--no-color", desc: "Disable colored output", default: false
+        bool "--no-color", desc: "disable colored output", default: false
         help
       end
 

--- a/src/amber/cli/commands/watch.cr
+++ b/src/amber/cli/commands/watch.cr
@@ -9,13 +9,13 @@ module Amber::CLI
       command_name "watch"
 
       class Options
-        bool "--no-color", desc: "# Disable colored output", default: false
+        bool "--no-color", desc: "disable colored output", default: false
         help
       end
 
       class Help
-        header "Starts amber development server and rebuilds on file changes"
-        caption "# Starts amber development server and rebuilds on file changes"
+        header "Starts Amber development server and rebuilds on file changes"
+        caption "starts Amber development server and rebuilds on file changes"
       end
 
       def run


### PR DESCRIPTION
### Description of the Change
I noticed that there was some inconsistent capitalisation and # usage in the Amber CLI.  

This is the default output from the `amber` command.

```
$ /usr/local/bin/amber
Parsing Error: The SUBCOMMAND argument is required.


Amber - Command Line Interface

  The `amber new` command creates a new Amber application with a default
  directory structure and configuration at the path you specify.

  You can specify extra command-line arguments to be used every time
  `amber new` runs in the .amber.yml configuration file in your project
  root directory

  Note that the arguments specified in the .amber.yml file does not affect the
  defaults values shown above in this help message.

  Usage:
  amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto] --deps

Subcommands:
  database   # Performs database migrations and maintenance tasks
  db         alias for database
  e          alias for encrypt
  encrypt    # Encrypts environment YAML file. [env | -e --editor | --noedit]
  exec       # Executes Crystal code within the application scope
  g          alias for generate
  generate   # Generate Amber classes
  n          alias for new
  new        # Generates a new Amber project
  pipelines
  routes     # Prints all defined application routes
  w          alias for watch
  watch      # Starts amber development server and rebuilds on file changes
  x          alias for exec

Options:
  -d, --database  # Preconfigure for selected database. Options: pg | mysql | sqlite
                  (default: pg)
  -m, --model     # Preconfigure for selected model. Options: granite | crecto
                  (default: granite)
  -r, --recipe    # Use a named recipe.  See documentation at https://docs.amberframework.org/amber/cli/recipes.
  -t, --template  # Preconfigure for selected template engine. Options: slang | ecr
                  (default: slang)
  -h, --help      # Describe available commands and usages
  -v, --version   # Prints Amber version

Example:
  amber new ~/Code/Projects/weblog
  This generates a skeletal Amber installation in ~/Code/Projects/weblog.
```

Looking at the output of the `crystal` command which is probably a good reference point the descriptions are lowercase and the language name is capistalised (once, but not in another. I may PR that separately).

```
$ crystal
Usage: crystal [command] [switches] [program file] [--] [arguments]

Command:
    init                     generate a new project
    build                    build an executable
    docs                     generate documentation
    env                      print Crystal environment information
    eval                     eval code from args or standard input
    play                     starts crystal playground server
    run (default)            build and run program
    spec                     build and run specs (in spec directory)
    tool                     run a tool
    help, --help, -h         show this help
    version, --version, -v   show version
```

This PR makes our command descriptions lowercase and removes the random # prefix sprinkled throughout. Makes everything a little more consistent. It provides capitals for Crystal and Amber.

It also adjusts the options on the main command for database/template etc. to use the `any_of` option to ensure only supported options are passed - similar to #1000.

Here is the base output after this change.

```
$ bin/amber
Parsing Error: The SUBCOMMAND argument is required.


Amber CLI

  The `amber new` command creates a new Amber application with a default
  directory structure and configuration at the path you specify.

  You can specify extra command-line arguments to be used every time
  `amber new` runs in the .amber.yml configuration file in your project
  root directory

  Note that the arguments specified in the .amber.yml file does not affect the
  defaults values shown above in this help message.

  Usage:
  amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto] --deps

Subcommands:
  database   performs database migrations and maintenance tasks
  db         alias for database
  e          alias for encrypt
  encrypt    encrypts environment YAML file
  exec       executes Crystal code within the application scope
  g          alias for generate
  generate   generate Amber classes
  n          alias for new
  new        generates a new Amber project
  pipelines
  routes     prints all defined application routes
  w          alias for watch
  watch      starts Amber development server and rebuilds on file changes
  x          alias for exec

Options:
  -d, --database  preconfigure for selected database.
                  one of:
                    pg
                    mysql
                    sqlite
                  (default: pg)
  -m, --model     preconfigure for selected model
                  one of:
                    granite
                    crecto
                  (default: granite)
  -r, --recipe    use a named recipe. See documentation at https://docs.amberframework.org/amber/cli/recipes.
  -t, --template  preconfigure for selected template engine
                  one of:
                    slang
                    ecr
                  (default: slang)
  -h, --help      describe available commands and usages
  -v, --version   prints Amber version

Example:
  amber new ~/Code/Projects/weblog
  This generates a skeletal Amber installation in ~/Code/Projects/weblog.
```

### Alternate Designs
The alternative would be to use proper capitalisation everywhere, but seems better to follow in Crystal's footsteps.

### Benefits
Clearer output and more consistent experience.