### PR TITLE
Load Bootstrap through Webpack

### DIFF
--- a/src/amber/cli/templates/app/package.json.ecr
+++ b/src/amber/cli/templates/app/package.json.ecr
@@ -23,5 +23,10 @@
     "webpack": "^3.12.0",
     "webpack-merge": "^4.1.2",
     "extract-text-webpack-plugin": "^3.0.2"
+  },
+  "dependencies": {
+    "bootstrap": "^4.2.1",
+    "jquery": "^3.3.1",
+    "popper.js": "^1.14.6"
   }
 }

--- a/src/amber/cli/templates/app/src/assets/javascripts/main.js
+++ b/src/amber/cli/templates/app/src/assets/javascripts/main.js
@@ -1,4 +1,2 @@
-import 'jquery';
-import 'popper.js';
 import 'bootstrap';
 import Amber from 'amber'

--- a/src/amber/cli/templates/app/src/assets/javascripts/main.js
+++ b/src/amber/cli/templates/app/src/assets/javascripts/main.js
@@ -1,1 +1,4 @@
+import 'jquery';
+import 'popper.js';
+import 'bootstrap';
 import Amber from 'amber'

--- a/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
+++ b/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
@@ -1,41 +1,13 @@
-$font-stack: "Helvetica Neue", Helvetica, Arial, sans-serif;
-$background-color: #f4994b;
+$primary: #f4994b;
 $nav-item-color: #ffe4cd;
 
-/*
- * Globals
- */
-body {
-  font-family: $font-stack;
-  color: #555;
-}
-
-h1, .h1,
-h2, .h2,
-h3, .h3,
-h4, .h4,
-h5, .h5,
-h6, .h6 {
-  margin-top: 0;
-  font-family: $font-stack;
-  font-weight: normal;
-  color: #333;
-}
-
-/*
- * Override Bootstrap's default container.
- */
-@media (min-width: 1200px) {
-  .container {
-    width: 970px;
-  }
-}
+@import '~bootstrap/scss/bootstrap';
 
 /*
  * Masthead for nav
  */
 .masthead {
-  background-color: $background-color;
+  background-color: $primary;
   -webkit-box-shadow: inset 0 -2px 5px rgba(0,0,0,.1);
           box-shadow: inset 0 -2px 5px rgba(0,0,0,.1);
 }

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -5,7 +5,6 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="/dist/main.bundle.css">
     <link rel="apple-touch-icon" href="/favicon.png">
     <link rel="icon" href="/favicon.png">
@@ -32,9 +31,6 @@
       </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
     <script src="/dist/main.bundle.js"></script>
 
     <%="<"%>%- if Amber.settings.auto_reload? -%><script src="/js/client_reload.js"></script><%="<"%>%- end -%>

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -5,7 +5,6 @@ html
     meta charset="utf-8"
     meta http-equiv="X-UA-Compatible" content="IE=edge"
     meta name="viewport" content="width=device-width, initial-scale=1"
-    link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"
     link rel="stylesheet" href="/dist/main.bundle.css"
     link rel="apple-touch-icon" href="/favicon.png"
     link rel="icon" href="/favicon.png"
@@ -23,9 +22,6 @@ html
 
       .main== content
 
-    script src="https://code.jquery.com/jquery-3.3.1.min.js"
-    script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"
-    script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
     script src="/dist/main.bundle.js"
 
     - if Amber.settings.auto_reload?


### PR DESCRIPTION
### Description of the Change
This adjusts the main template to load Bootstrap and its dependencies through NPM and Webpack - rather than using a CDN in the main application template.

* Sets a precedent for new users to prefer to use NPM and serve assets through a single bundle, rather than loading up additional dependencies through CDNs.
* It removes some additional boilerplate surrounding heading styles and containers and just leaves it up to Bootstrap. I use the existing brand colour variable as the `$primary` colour.
* For developers who do want to continue using Bootstrap it puts them in a good place to customise any variables or only import the parts of Bootstrap they want.
* For developers who don't want to use Bootstrap there is a *tad* more to remove in that they need to remove the references from the main CSS and JS files, as well as ditch the dependencies from `package.json`.

My main thought here is just to encourage developers to just adopt the Webpack pipeline and make it really easy to continue with Bootstrap if they decide to do so.

### Alternate Designs
Some alternate options:
* Leave Bootstrap as-is, no changes.
* Leave Bootstrap as-is, but reduce boilerplate CSS code so developers start with a cleaner slate. This could mean adopting Bootstrap's navbar component so we don't need to ship the custom `.masthead` component styles.
* Remove Bootstrap and ship with some bare-bone styles.

My general preference is to stick with Bootstrap as it's great for when you just want to experiment with something and it gives you a solid building block. However I totally appreciate that many will feel different about it.

### Benefits
Less CSS boilerplate, less reliance on CDNs (I actually came across this because I was playing with an Amber project while on a plane, nothing worked because I had no internet access and nothing could load) and means Amber apps will ship by default with a single CSS and JS file out of the box. Developers will be guided towards using NPM/yarn and Webpack to build their assets.

### Possible Drawbacks
People who don't like Bootstrap or don't intend to use it on a project will need to spend another minute to clear the boilerplate.