### PR TITLE
Remove whitespace from request method

### DIFF
--- a/src/amber/pipes/logger.cr
+++ b/src/amber/pipes/logger.cr
@@ -46,7 +46,7 @@ module Amber
       end
 
       private def method(context)
-        context.request.method.colorize(:light_red).to_s + " "
+        context.request.method.colorize(:light_red).to_s
       end
 
       private def http_status(status)


### PR DESCRIPTION
### Description of the Change
I noticed there was a double space between the method and pipeline in the log output for a request.

```
02:00:57 Request    | Status: 200 Method: GET  Pipeline: web Format: html
```

It looks as though the `method` method adds trailing whitespace, but that's already accounted for when the string is built. It doesn't seem right that `method` should return a string with trailing whitespace, so we remove it.

```
02:01:19 Request    | Status: 200 Method: GET Pipeline: web Format: html
```

### Alternate Designs
Leave the trailing whitespace in `method` and then remove the space between the keywords when the string for the output line is built. That would look weird and harder to understand why it's that way.

### Benefits
Consistent spacing between request elements.