### PR TITLE
Don’t override Bootstrap alert styles

### DIFF
--- a/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
+++ b/src/amber/cli/templates/app/src/assets/stylesheets/main.scss
@@ -5,16 +5,3 @@ $primary: #f4994b;
 .main {
   padding-top: 20px;
 }
-
-.table td, .table th {
-  vertical-align: middle;
-}
-
-.alert {
-  margin-top: 1em;
-
-  p {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-}

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -24,8 +24,8 @@
 
     <div class="container">
       <%="<"%>%- flash.each do |key, value| %>
-        <div class="alert alert-<%="<"%>%= key %>">
-          <p><%="<"%>%= flash[key] %></p>
+        <div class="alert alert-<%="<"%>%= key %>" role="alert">
+          <%="<"%>%= flash[key] %>
         </div>
       <%="<"%>%- end %>
 

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -20,8 +20,8 @@ html
 
     .container
       - flash.each do |key, value|
-        div class="alert alert-#{key}"
-          p = flash[key]
+        div class="alert alert-#{key}" role="alert"
+          = flash[key]
 
       .main== content
 

--- a/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
@@ -12,10 +12,10 @@ class RegistrationController < ApplicationController
 
     if changeset.valid?
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash["success"] = "Created <%= class_name %> successfully."
+      flash[:success"] = "Created <%= class_name %> successfully."
       redirect_to "/"
     else
-      flash["danger"] = "Could not create <%= class_name %>!"
+      flash[:danger"] = "Could not create <%= class_name %>!"
       render("new.<%= @language %>")
     end
   end

--- a/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
@@ -10,10 +10,10 @@ class RegistrationController < ApplicationController
 
     if <%= @name %>.valid? && <%= @name %>.save
       session[:<%= @name %>_id] = <%= @name %>.id
-      flash["success"] = "Created <%= class_name %> successfully."
+      flash[:success] = "Created <%= class_name %> successfully."
       redirect_to "/"
     else
-      flash["danger"] = "Could not create <%= class_name %>!"
+      flash[:danger] = "Could not create <%= class_name %>!"
       render("new.<%= @language %>")
     end
   end

--- a/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -29,7 +29,7 @@ class <%= class_name %>Controller < ApplicationController
     changeset = Repo.insert <%= @name %>
 
     if changeset.errors.any?
-      flash["danger"] = "Could not create <%= class_name %>!"
+      flash[:danger] = "Could not create <%= class_name %>!"
       render "new.<%= @language %>"
     else
       redirect_to action: :index, flash: {"success" => "Created <%= @name %> successfully."}
@@ -41,7 +41,7 @@ class <%= class_name %>Controller < ApplicationController
     changeset = Repo.update <%= @name %>
 
     if changeset.errors.any?
-      flash["danger"] = "Could not update <%= class_name %>!"
+      flash[:danger] = "Could not update <%= class_name %>!"
       render "edit.<%= @language %>"
     else
       redirect_to action: :index, flash: {"success" => "Updated <%= @name %> successfully."}

--- a/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -27,7 +27,7 @@ class <%= class_name %>Controller < ApplicationController
     if <%= @name %>.save
       redirect_to action: :index, flash: {"success" => "Created <%= @name %> successfully."}
     else
-      flash["danger"] = "Could not create <%= class_name %>!"
+      flash[:danger] = "Could not create <%= class_name %>!"
       render "new.<%= @language %>"
     end
   end
@@ -37,7 +37,7 @@ class <%= class_name %>Controller < ApplicationController
     if <%= @name %>.save
       redirect_to action: :index, flash: {"success" => "Updated <%= @name %> successfully."}
     else
-      flash["danger"] = "Could not update <%= class_name %>!"
+      flash[:danger] = "Could not update <%= class_name %>!"
       render "edit.<%= @language %>"
     end
   end


### PR DESCRIPTION
### Description of the Change
This removes some additional boilerplate around the alert component and just leverages the Bootstrap alert as-is.


* Adjusts all generators to use symbols for flash message names.
* Adds the `role="alert"` attribute to the alert component.
* Removes some table styles to allow Bootstrap to handle it.

### Benefits
Less stylesheet boilerplate, no weird mix-match between Bootstrap's alert component and custom overrides.

### Possible Drawbacks
More reliance on Bootstrap styles, but it was already reliant on the Bootstrap alert component as-is.
