### PR TITLE
Fix collapsed navbar items

### DIFF
--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -11,14 +11,16 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
   </head>
   <body>
-    <nav class="navbar navbar-dark bg-primary">
+    <nav class="navbar navbar-dark navbar-expand bg-primary">
       <div class="container">
         <a href="/" class="navbar-brand">
           <img src="/dist/images/logo.svg" height="30" alt="Amber logo">
         </a>
-        <ul class="navbar-nav mr-auto">
-          <%="<"%>%= render(partial: "layouts/_nav.ecr") %>
-        </ul>
+        <div class="navbar-collapse">
+          <ul class="navbar-nav mr-auto">
+            <%="<"%>%= render(partial: "layouts/_nav.ecr") %>
+          </ul>
+        </div>
       </div>
     </div>
 

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -11,12 +11,13 @@ html
     link rel="icon" type="image/x-icon" href="/favicon.ico"
 
   body
-    nav.navbar.navbar-dark.bg-primary
+    nav.navbar.navbar-dark.navbar-expand.bg-primary
       .container
         a.navbar-brand href="#"
             img src="/dist/images/logo.svg" height="30" alt="Amber logo"
-        ul.navbar-nav.mr-auto
-          == render(partial: "layouts/_nav.slang")
+        .navbar-collapse
+          ul.navbar-nav.mr-auto
+            == render(partial: "layouts/_nav.slang")
 
     .container
       - flash.each do |key, value|


### PR DESCRIPTION
### Description of the Change
I thought I could get away without using the `navbar-collapse` classes but turns out they are required either way. This adds the necessary classes to prevent the navbar from stacking links vertically. Apologies for not getting this right the first time around.

![image](https://user-images.githubusercontent.com/1100408/50553375-aa982b00-0cf9-11e9-8b89-dcc01f2cc49f.png)