### PR TITLE
Fix navigation and buttons

### DIFF
--- a/spec/support/fixtures/render_fixtures.cr
+++ b/spec/support/fixtures/render_fixtures.cr
@@ -13,7 +13,7 @@ module RenderFixtures
       <div class="form-group">
         <textarea class="form-control" rows="10" name="content" placeholder="Content">out there in the cold</textarea>
       </div>
-      <button class="btn btn-primary btn-sm" type="submit">Submit</button>
+      <button class="btn btn-success btn-sm" type="submit">Submit</button>
       <a class="btn btn-light btn-sm" href="/posts">back</a>
     </form>
     HTML

--- a/spec/support/sample/views/test/_form.slang
+++ b/spec/support/sample/views/test/_form.slang
@@ -4,5 +4,5 @@ form action="/posts" method="post"
     input.form-control type="text" name="title" placeholder="Title" value="hey you"
   .form-group
     textarea.form-control rows="10" name="content" placeholder="Content" = "out there in the cold"
-  button.btn.btn-primary.btn-sm type="submit" Submit
+  button.btn.btn-info.btn-sm type="submit" Submit
   a.btn.btn-light.btn-sm href="/posts" back

--- a/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.ecr.ecr
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
   </head>
   <body>
-    <nav class="navbar navbar-dark bg-primary">
+    <nav class="navbar navbar-expand navbar-dark bg-primary">
       <div class="container">
         <a href="/" class="navbar-brand">
           <img src="/dist/images/logo.svg" height="30" alt="Amber logo">

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -13,7 +13,7 @@ html
   body
     nav.navbar.navbar-expand.navbar-dark.bg-primary
       .container
-        a.navbar-brand href="#"
+        a.navbar-brand href="/"
             img src="/dist/images/logo.svg" height="30" alt="Amber logo"
         ul.navbar-nav.mr-auto
           == render(partial: "layouts/_nav.slang")

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -14,7 +14,7 @@ html
     nav.navbar.navbar-expand.navbar-dark.bg-primary
       .container
         a.navbar-brand href="/"
-            img src="/dist/images/logo.svg" height="30" alt="Amber logo"
+          img src="/dist/images/logo.svg" height="30" alt="Amber logo"
         ul.navbar-nav.mr-auto
           == render(partial: "layouts/_nav.slang")
 

--- a/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/application.slang.ecr
@@ -11,7 +11,7 @@ html
     link rel="icon" type="image/x-icon" href="/favicon.ico"
 
   body
-    nav.navbar.navbar-dark.bg-primary
+    nav.navbar.navbar-expand.navbar-dark.bg-primary
       .container
         a.navbar-brand href="#"
             img src="/dist/images/logo.svg" height="30" alt="Amber logo"

--- a/src/amber/cli/templates/auth/crecto/src/views/registration/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/registration/new.ecr.ecr
@@ -8,7 +8,7 @@
   <div class="form-group">
     <input class="form-control" type="password" name="password" placeholder="Password"/>
   </div>
-  <button class="btn btn-primary btn-sm" type="submit">Register</button>
+  <button class="btn btn-success btn-sm" type="submit">Register</button>
 </form>
 <hr/>
 <%="<"%>%= link_to("Already have an account?", "/signin") -%>

--- a/src/amber/cli/templates/auth/crecto/src/views/registration/new.slang.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/registration/new.slang.ecr
@@ -6,7 +6,7 @@ form action="/registration" method="post"
     input.form-control type="email" name="email" placeholder="Email"
   .form-group
     input.form-control type="password" name="password" placeholder="Password"
-  button.btn.btn-primary.btn-sm type="submit"
+  button.btn.btn-success.btn-sm type="submit"
     | Register
 <hr/>
 == link_to("Already have an account?", "/signin")

--- a/src/amber/cli/templates/auth/crecto/src/views/session/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/session/new.ecr.ecr
@@ -8,7 +8,7 @@
   <div class="form-group">
     <input class="form-control" type="password" name="password" placeholder="Password"/>
   </div>
-  <button class="btn btn-primary btn-sm" type="submit">Sign In</button>
+  <button class="btn btn-success btn-sm" type="submit">Sign In</button>
 </form>
 <hr/>
 <%="<"%>%= link_to("Don't have an account yet?", "/signup") -%>

--- a/src/amber/cli/templates/auth/crecto/src/views/session/new.slang.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/session/new.slang.ecr
@@ -6,6 +6,6 @@ form action="/session" method="post"
     input.form-control type="email" name="email" placeholder="Email"
   .form-group
     input.form-control type="password" name="password" placeholder="Password"
-  button.btn.btn-primary.btn-sm type="submit" Sign In
+  button.btn.btn-success.btn-sm type="submit" Sign In
 <hr/>
 == link_to("Don't have an account yet?", "/signup")

--- a/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.ecr.ecr
@@ -13,6 +13,6 @@
   <div class="form-group">
     <input class="form-control" type="email" name="email" placeholder="Email" value="<%="<"%>%= <%= @name %>.email %>" />
   </div>
-  <%="<"%>%= submit("Update", class: "btn btn-primary btn-sm") %>
+  <%="<"%>%= submit("Update", class: "btn btn-success btn-sm") %>
   <%="<"%>%= link_to("Profile", "/profile", class: "btn btn-light btn-sm") %>
 </form>

--- a/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/{{name}}/edit.slang.ecr
@@ -9,5 +9,5 @@ h1 Edit Profile
   == csrf_tag
   .form-group
     input.form-control type="email" name="email" placeholder="Email" value="#{<%= @name %>.email}"
-  == submit("Update", class: "btn btn-primary btn-sm")
+  == submit("Update", class: "btn btn-success btn-sm")
   == link_to("Profile", "/profile", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/auth/granite/src/views/layouts/+_nav.ecr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/layouts/+_nav.ecr.ecr
@@ -1,18 +1,18 @@
 <%="<"%>%- if (current_<%= @name %> = context.current_<%= @name %>) %>
-  <li class="nav-item">
-    <a class="nav-link" href="/signout">Sign Out</a>
-  </li>
   <%="<"%>%- active = context.request.path == "/profile" ? "active" : "" %>
   <li class="nav-item <%="<"%>%= active %>">
     <a class="nav-link" href="/profile"><%="<"%>%= current_<%= @name %>.email %></a>
   </li>
-<%="<"%>%- else %>
-  <%="<"%>%- active = context.request.path == "/signup" ? "active" : "" %>
-  <li class="nav-item <%="<"%>%= active %>">
-    <a class="nav-link" href="/signup">Sign Up</a>
+  <li class="nav-item">
+    <a class="nav-link" href="/signout">Sign Out</a>
   </li>
+<%="<"%>%- else %>
   <%="<"%>%- active = context.request.path == "/signin" ? "active" : "" %>
   <li class="nav-item <%="<"%>%= active %>">
     <a class="nav-link" href="/signin">Sign In</a>
+  </li>
+  <%="<"%>%- active = context.request.path == "/signup" ? "active" : "" %>
+  <li class="nav-item <%="<"%>%= active %>">
+    <a class="nav-link" href="/signup">Sign Up</a>
   </li>
 <%="<"%>%- end %>

--- a/src/amber/cli/templates/auth/granite/src/views/layouts/+_nav.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/layouts/+_nav.slang.ecr
@@ -1,15 +1,14 @@
 - if (current_<%= @name %> = context.current_<%= @name %>)
-  li.nav-item
-    a.nav-item.nav-item-auth.nav-item-auth-signout href="/signout" Sign Out
   - active = context.request.path == "/profile" ? "active" : ""
   li.nav-item class=active
     a.nav-link href="/profile"
       == current_<%= @name %>.email
-
+  li.nav-item
+    a.nav-link href="/signout" Sign Out
 - else
-  - active = context.request.path == "/signup" ? "active" : ""
-  li.nav-item class=active
-    a.nav-link href="/signup" Sign Up
   - active = context.request.path == "/signin" ? "active" : ""
   li.nav-item class=active
     a.nav-link href="/signin" Sign In
+  - active = context.request.path == "/signup" ? "active" : ""
+  li.nav-item class=active
+    a.nav-link href="/signup" Sign Up

--- a/src/amber/cli/templates/auth/granite/src/views/registration/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/registration/new.ecr.ecr
@@ -16,7 +16,7 @@
   <div class="form-group">
     <input class="form-control" type="password" name="password" placeholder="Password"/>
   </div>
-  <button class="btn btn-primary btn-sm" type="submit">Register</button>
+  <button class="btn btn-success btn-sm" type="submit">Register</button>
 </form>
 <hr/>
 <%="<"%>%= link_to("Already have an account?", "/signin") -%>

--- a/src/amber/cli/templates/auth/granite/src/views/registration/new.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/registration/new.slang.ecr
@@ -11,7 +11,7 @@ form action="/registration" method="post"
     input.form-control type="email" name="email" placeholder="Email"
   .form-group
     input.form-control type="password" name="password" placeholder="Password"
-  button.btn.btn-primary.btn-sm type="submit"
+  button.btn.btn-success.btn-sm type="submit"
     | Register
 <hr/>
 == link_to("Already have an account?", "/signin")

--- a/src/amber/cli/templates/auth/granite/src/views/session/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/session/new.ecr.ecr
@@ -16,7 +16,7 @@
   <div class="form-group">
     <input class="form-control" type="password" name="password" placeholder="Password"/>
   </div>
-  <button class="btn btn-primary btn-sm" type="submit">Sign In</button>
+  <button class="btn btn-success btn-sm" type="submit">Sign In</button>
 </form>
 <hr/>
 <%="<"%>%= link_to("Don't have an account yet?", "/signup") -%>

--- a/src/amber/cli/templates/auth/granite/src/views/session/new.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/session/new.slang.ecr
@@ -11,6 +11,6 @@ form action="/session" method="post"
     input.form-control type="email" name="email" placeholder="Email"
   .form-group
     input.form-control type="password" name="password" placeholder="Password"
-  button.btn.btn-primary.btn-sm type="submit" Sign In
+  button.btn.btn-success.btn-sm type="submit" Sign In
 <hr/>
 == link_to("Don't have an account yet?", "/signup")

--- a/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.ecr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.ecr.ecr
@@ -13,6 +13,6 @@
   <div class="form-group">
     <input class="form-control" type="email" name="email" placeholder="Email" value="<%="<"%>%= <%= @name %>.email %>" />
   </div>
-  <%="<"%>%= submit("Update", class: "btn btn-primary btn-sm") %>
+  <%="<"%>%= submit("Update", class: "btn btn-success btn-sm") %>
   <%="<"%>%= link_to("Profile", "/profile", class: "btn btn-light btn-sm") %>
 </form>

--- a/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/{{name}}/edit.slang.ecr
@@ -9,5 +9,5 @@ h1 Edit Profile
   == csrf_tag
   .form-group
     input.form-control type="email" name="email" placeholder="Email" value="#{<%= @name %>.email}"
-  == submit("Update", class: "btn btn-primary btn-sm")
+  == submit("Update", class: "btn btn-success btn-sm")
   == link_to("Profile", "/profile", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -31,6 +31,6 @@
 <% end -%>
   </div>
 <% end -%>
-  <%="<"%>%= submit("Submit", class: "btn btn-primary btn-sm") -%>
+  <%="<"%>%= submit("Submit", class: "btn btn-success btn-sm") -%>
   <%="<"%>%= link_to("Back", "/<%= name_plural %>", class: "btn btn-light btn-sm") -%>
 </form>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -20,5 +20,5 @@
     == text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control")
   <%- end -%>
 <%- end -%>
-  == submit("Submit", class: "btn btn-primary btn-sm")
+  == submit("Submit", class: "btn btn-success btn-sm")
   == link_to("Back", "/<%= name_plural %>", class: "btn btn-light btn-sm")

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.ecr.ecr
@@ -24,7 +24,7 @@
 <% end -%>
         <td>
           <span>
-            <%="<"%>%= link_to("Show", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm") -%>
+            <%="<"%>%= link_to("Show", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-info btn-sm") -%>
             <%="<"%>%= link_to("Edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm") -%>
             <%="<"%>%= link_to("Delete", "/<%= name_plural %>/#{<%= @name %>.id}?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm") -%>
           </span>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/index.slang.ecr
@@ -19,6 +19,6 @@
           <%- end -%>
           td
             span
-              == link_to("Show", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-primary btn-sm")
+              == link_to("Show", "/<%= name_plural %>/#{<%= @name %>.id}", class: "btn btn-info btn-sm")
               == link_to("Edit", "/<%= name_plural %>/#{<%= @name %>.id}/edit", class: "btn btn-success btn-sm")
               == link_to("Delete", "/<%= name_plural %>/#{ <%= @name %>.id }?_csrf=#{csrf_token}", "data-method": "delete", "data-confirm": "Are you sure?", class: "btn btn-danger btn-sm")


### PR DESCRIPTION
### Description of the Change

The navigation component `navbar-nav` requires either expand or collapse
to be specified in the `navbar`

This also fixes the buttons by changing them from using `btn-primary` to `btn-success` so we can use the `$primary` for the nav-bar background and remove the special styling.

This does not fix right justification of the authentication nav items.  I will look into fixing this when we move the auth to its own shard.

### Alternate Designs

none

### Benefits

avoids the flex-column being added to the nav items

### Possible Drawbacks

none