### PR TITLE
Only output exception message to log, not entire html response

### DIFF
--- a/src/amber/pipes/error.cr
+++ b/src/amber/pipes/error.cr
@@ -11,17 +11,17 @@ module Amber
         context.response.status_code = 403
         error = Amber::Controller::Error.new(context, ex)
         context.response.print(error.forbidden)
-        Amber.logger.warn error.forbidden, "Error: 403", :yellow
+        Amber.logger.warn ex.message, "Error: 403", :yellow
       rescue ex : Amber::Exceptions::RouteNotFound
         context.response.status_code = 404
         error = Amber::Controller::Error.new(context, ex)
         context.response.print(error.not_found)
-        Amber.logger.warn error.not_found, "Error: 404", :yellow
+        Amber.logger.warn ex.message, "Error: 404", :yellow
       rescue ex : Exception
         context.response.status_code = 500
         error = Amber::Controller::Error.new(context, ex)
         context.response.print(error.internal_server_error)
-        Amber.logger.error error.internal_server_error, "Error: 500", :red
+        Amber.logger.error ex.message, "Error: 500", :red
       end
     end
   end


### PR DESCRIPTION
Was getting super annoyed by the cluttered log when the error page showed. Heres a PR to improve that by only outputing the exception message to log, not the entire html response. Fixes #1003 