### PR TITLE
Recipes: Fixes regex check of filename for liquid templates

### DIFF
--- a/src/amber/cli/recipes/file_entries.cr
+++ b/src/amber/cli/recipes/file_entries.cr
@@ -44,15 +44,15 @@ module Amber::Recipes
           # process the filename with liquid
           template = Liquid::Template.parse filename
           filename = template.render @ctx.as(Liquid::Context)
-
-          if /^(.+)\.lqd$|^(.+)\.liquid$/ =~ filename
+	  
+          if /^(.+)\.lqd$/ =~ filename || /^(.+)\.liquid$/ =~ filename
             # process the file with liquid
             pack_liquid files, absolute_path, $1
           else
             # pack the file without processing
             pack_blob files, absolute_path, filename
           end
-        end
+	end
       end
     end
 

--- a/src/amber/cli/recipes/file_entries.cr
+++ b/src/amber/cli/recipes/file_entries.cr
@@ -44,7 +44,7 @@ module Amber::Recipes
           # process the filename with liquid
           template = Liquid::Template.parse filename
           filename = template.render @ctx.as(Liquid::Context)
-	  
+
           if /^(.+)\.lqd$/ =~ filename || /^(.+)\.liquid$/ =~ filename
             # process the file with liquid
             pack_liquid files, absolute_path, $1
@@ -52,7 +52,7 @@ module Amber::Recipes
             # pack the file without processing
             pack_blob files, absolute_path, filename
           end
-	end
+        end
       end
     end
 


### PR DESCRIPTION
### Description of the Change

Issue #905 Removes the regex 'or' in favor of two distinct patterns using the (||) operator.

### Alternate Designs

Alternatively, we could just split the filename, prune the extension off and join it again rather than using $1

### Benefits

Forces $1 to be set

### Possible Drawbacks

Some minor overhead?
