### PR TITLE
Add method `Amber::Validators::Params#to_unsafe_h`

### DIFF
--- a/spec/amber/validations/params_spec.cr
+++ b/spec/amber/validations/params_spec.cr
@@ -345,5 +345,16 @@ module Amber::Validators
         validator.validate!.should eq result
       end
     end
+
+    describe "#to_unsafe_h" do
+      it "returns request raw_params as a hash" do
+        http_params = params_builder("first_name=elias&last_name=perez")
+        validator = Validators::Params.new(http_params)
+
+        validator.to_h.should eq({} of String => String)
+
+        validator.to_unsafe_h.should eq({"first_name" => "elias", "last_name" => "perez"})
+      end
+    end
   end
 end

--- a/src/amber/validators/params.cr
+++ b/src/amber/validators/params.cr
@@ -150,5 +150,9 @@ module Amber::Validators
     def to_h
       @params
     end
+
+    def to_unsafe_h
+      @raw_params.to_h
+    end
   end
 end


### PR DESCRIPTION
Solves #1042 

PR for documentation to be added after.