### PR TITLE
Makes settings.secrets usable for end users.

### DIFF
--- a/spec/amber/environment/settings_spec.cr
+++ b/spec/amber/environment/settings_spec.cr
@@ -20,6 +20,7 @@ module Amber::Environment
       settings.redis_url.should eq "redis://localhost:6379"
       settings.secret_key_base.should_not be_nil
       settings.secrets.should eq({"description" => "Store your test secrets credentials and settings here."})
+      settings.secrets.is_a?(Hash(String, String)?).should be_true
       settings.session.should eq({
         :key => "amber.session", :store => :signed_cookie, :expires => 0,
       })

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -60,7 +60,7 @@ module Amber::Environment
       process_count: {type: Int32, default: 1},
       redis_url: {type: String?, default: nil},
       secret_key_base: {type: String, default: Random::Secure.urlsafe_base64(32)},
-      secrets: {type: Hash(String, String)?, default: nil},
+      secrets: {type: Hash(String, String), default: Hash(String, String).new},
       session: {type: Hash(String, Int32 | String), default: {
         "key" => "amber.session", "store" => "signed_cookie", "expires" => 0,
       }},


### PR DESCRIPTION
### Description of the Change

Currently `settings.secrets` is of type `Hash(String, String) | Nil` This means that it's impossible to use it for its intended purpose.

```cr
Amber.settings.secrets["aws_key"] will error with `No method [] for Nil class` because of the Union type.
```

### Benefits

Secrets are usable again.

### Possible Drawbacks

None
