### PR TITLE
Remove --deps flag from CLI header text

### DIFF
--- a/src/amber/cli/commands.cr
+++ b/src/amber/cli/commands.cr
@@ -31,7 +31,7 @@ module Amber::CLI
         defaults values shown above in this help message.
 
         Usage:
-        amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto]
+        amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto] [--no-deps]
       EOS
 
       footer <<-EOS

--- a/src/amber/cli/commands.cr
+++ b/src/amber/cli/commands.cr
@@ -31,7 +31,7 @@ module Amber::CLI
         defaults values shown above in this help message.
 
         Usage:
-        amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto] --deps
+        amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto]
       EOS
 
       footer <<-EOS

--- a/src/amber/cli/commands.cr
+++ b/src/amber/cli/commands.cr
@@ -31,7 +31,7 @@ module Amber::CLI
         defaults values shown above in this help message.
 
         Usage:
-        amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto] [--no-deps]
+        amber new [app_name] -d [pg | mysql | sqlite] -t [slang | ecr] -m [granite, crecto] --no-deps
       EOS
 
       footer <<-EOS


### PR DESCRIPTION
This option does not appear to work so it should not be shown to users in this text.

```
$ amber new myapp -d pg -t slang -m granite --deps
Parsing Error: The --deps option is unknown.
```

### Description of the Change

Removes flag from command line in text.

### Benefits

New users will be less confused.

### Possible Drawbacks

Perhaps this flag should work and needs to be fixed?