### PR TITLE
fixing the "Read Amber quick start guide" link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dependencies:
     github: amberframework/amber
 ```
 
-[Read Amber quick start guide](https://docs.amberframework.org/amber/getting-started/quick-start)
+[Read Amber quick start guide](https://docs.amberframework.org/amber/getting-started)
 
 [Read Amber CLI commands usage](https://docs.amberframework.org/amber/cli)
 


### PR DESCRIPTION
Updating the README to fix the "Read Amber quick start guide"

Issue #1062 