### PR TITLE
fixing firefox reload bug, issue #1023

### DIFF
--- a/src/amber/cli/templates/app/public/js/client_reload.js
+++ b/src/amber/cli/templates/app/public/js/client_reload.js
@@ -48,8 +48,5 @@ if ('WebSocket' in window) {
         refreshCSS();
       }
     };
-    socket.onclose = function () {
-      tryReload();
-    }
   })();
 }


### PR DESCRIPTION
This fixes the Firefox auto reload bug of #1023.

This happened because when you click on another page, the socket is closed, so the browser reload the page and so the navigation does not work. I guess Chrome stops the socket right after the navigation occurs but on Firefox, as soon as you click on the other page, it's closed instantly.