### PR TITLE
allow saving a blank value to an Optional param (to clear out a previously saved value)

### DIFF
--- a/spec/amber/validations/optional_rule_spec.cr
+++ b/spec/amber/validations/optional_rule_spec.cr
@@ -11,6 +11,7 @@ module Amber::Validators
         end
 
         rule.apply(params).should be_true
+        rule.value.should be_nil
       end
 
       it "applies rule when field is present" do
@@ -21,6 +22,20 @@ module Amber::Validators
         end
 
         rule.apply(params).should be_true
+        rule.value.should_not be_nil
+        rule.value.should eq "val"
+      end
+
+      it "allows an empty value" do
+        params = params_builder("field=")
+        error_message = "You must provide this field"
+        rule = OptionalRule.new("field", error_message) do
+          true
+        end
+
+        rule.apply(params).should be_true
+        rule.value.should_not be_nil
+        rule.value.should eq ""
       end
     end
   end

--- a/spec/amber/validations/optional_rule_spec.cr
+++ b/spec/amber/validations/optional_rule_spec.cr
@@ -22,7 +22,6 @@ module Amber::Validators
         end
 
         rule.apply(params).should be_true
-        rule.value.should_not be_nil
         rule.value.should eq "val"
       end
 
@@ -34,7 +33,6 @@ module Amber::Validators
         end
 
         rule.apply(params).should be_true
-        rule.value.should_not be_nil
         rule.value.should eq ""
       end
     end

--- a/src/amber/validators/params.cr
+++ b/src/amber/validators/params.cr
@@ -33,6 +33,9 @@ module Amber::Validators
     private def call_predicate(params : Amber::Router::Params)
       @value = params[@field]
       @present = params.has_key?(@field)
+
+      return true if (params[@field].blank? && @allow_blank)
+
       @predicate.call params[@field] unless @predicate.nil?
     end
 
@@ -50,11 +53,10 @@ module Amber::Validators
     end
   end
 
-  # OptionalRule only validates (evaluates block) if the key is present and the value is not blank.
+  # OptionalRule only validates (evaluates block) if the key is present and the value is not blank (see call_predicate).
   class OptionalRule < BaseRule
     def apply(params : Amber::Router::Params)
       return true if !params.has_key?(@field)
-      return true if params.has_key?(@field) && (@allow_blank && params[@field].blank?)
       call_predicate(params)
     end
   end


### PR DESCRIPTION
### Description of the Change

This is a small, but important fix for the optional param PR I submitted a couple months back.

I'm not sure how I didn't notice it all this time, but currently, you can't clear out the value of an optional param by submitting a blank value (e.g. empty string). You can only replace the current value with another non-blank string.

This PR fixes that, so that you can set the value of an optional param to an empty or blank string if you want to.

### Possible Drawbacks

I didn't make any acoommodation for people who might be depending on the existing behavior.