### PR TITLE
Adding more details in the 500 errors, issue #1064

### DIFF
--- a/src/amber/pipes/error.cr
+++ b/src/amber/pipes/error.cr
@@ -21,7 +21,11 @@ module Amber
         context.response.status_code = 500
         error = Amber::Controller::Error.new(context, ex)
         context.response.print(error.internal_server_error)
-        Amber.logger.error ex.message, "Error: 500", :red
+        if ex.backtrace && ex.class.name
+          Amber.logger.error "#{ex.class.name} #{ex.message} #{ex.backtrace.join('\n')}", "Error: 500", :red
+        else
+          Amber.logger.error ex.message, "Error: 500", :red
+        end
       end
     end
   end


### PR DESCRIPTION
### Description of the Change

I'm adding a little bit more information to the logs, in some cases the errors are not very descriptive.
 if the pg connection fails for example, you just get something like:

```
Error: 500 (ERROR)
```

This happens because the error class itself is what happens, there's no message in this case.

If we add more information in `pipes/error.cr`, the error becomes more obvious:

```
Error: 500 | (ERROR) DB::ConnectionRefused  lib/pg/src/pg/connection.cr:16:9 in 'initialize'
lib/pg/src/pg/connection.cr:7:5 in 'new'
lib/pg/src/pg/driver.cr:3:5 in 'build_connection'
lib/db/src/db/database.cr:51:9 in '->'
lib/db/src/db/pool.cr:255:3 in 'build_resource'
lib/db/src/db/pool.cr:17:34 in 'initialize'
lib/db/src/db/pool.cr:15:5 in 'new:initial_pool_size:max_pool_size:max_idle_pool_size:checkout_timeout:retry_attempts:retry_delay'
lib/db/src/db/database.cr:50:7 in 'initialize'
lib/db/src/db/database.cr:43:5 in 'new'
[... more traceback stuff]
```

### Alternate Designs

I'm a beginner developer in Crystal / Amber so suggestions would be appreciated if that change looks ugly to you guys.

### Benefits

We can now clearly see the Errors in the logs.

### Possible Drawbacks

I can't think any drawback.
