### PR TITLE
set AMBER_ENV to 'test' when testing

### DIFF
--- a/src/amber/cli/templates/app/.amber.yml.ecr
+++ b/src/amber/cli/templates/app/.amber.yml.ecr
@@ -25,7 +25,7 @@ watch:
     #  - ./src/some_irrelevant_file.cr
   spec:
     run_commands:
-      - crystal spec
+      - AMBER_ENV=test crystal spec
     include:
       - ./spec/**/*.cr
   npm:


### PR DESCRIPTION
During the process of creating a recipe I use a script to automate the process of creating a new app with the new recipe and to run the scaffold generator to create application artifacts.  The script populates the database with some test records for each model with 'amber db seed'.  Upon starting the application with 'amber watch' the database was empty.  This was due to the crystal spec command clearing out each database table because the AMBER_ENV was 'development' rather than 'test'.  This change ensures that by default the AMBER_ENV environment variable is 'test' when running the specs.

### Description of the Change

* prepend AMBER_ENV=test to the amber watch spec run_commands

### Alternate Designs
none

### Benefits
You don't wipe out your development database

### Possible Drawbacks

test environment is hard wired in amber.yml to 'test'
