### PR TITLE
adding a errors method to the validator to reuse the errors

### DIFF
--- a/src/amber/exceptions/exceptions.cr
+++ b/src/amber/exceptions/exceptions.cr
@@ -65,8 +65,10 @@ module Amber
 
     module Validator
       class ValidationFailed < Base
-        def initialize(errors)
-          super("Validation failed. #{errors}")
+        getter errors
+
+        def initialize(@errors : Array(Amber::Validators::Error))
+          super("Validation failed. #{@errors}")
         end
       end
 


### PR DESCRIPTION
### Description of the Change

I'm adding an errors method to the validator errors to be able to get the validation errors. Currently, the errors are passed as strings and when the validation error are thrown, there is no way to get the actual errors that I know of apart from parsing the string.

Example that can be done with this change:

```crystal
def create
    @validation_errors = [] of Amber::Validators::Error
    begin
      user = User.new(registration_params.validate!)
      user.password = params["password"].to_s

      if user.valid? && user.save
        session[:user_id] = user.id
        flash[:success] = "Created User successfully."
        redirect_to "/"
      else
        flash[:danger] = "Could not create User!"
        render("new.ecr")
      end
    rescue e: Amber::Exceptions::Validator::ValidationFailed
      flash[:danger] = "Could not create User!"
      #here is the new thing we can do which was not possible before
      @validation_errors = e.errors.not_nil!
      render("new.ecr")
    end
  end
```

### Alternate Designs

There could be other ways to manage the validation errors, I'm not sure.

### Benefits

With this patch, rescuing the validation errors is now possible.

### Possible Drawbacks

- I'm a beginner Crystal developer, code suggestions are very welcomed, this might look ugly to you guys.
- I had to specify the errors type otherwise it would not compile, some other code which depend on any type be passed could be broken. Please suggest an alternative way to do it if it's not how it should be done.
- I wanted to add tests but did not manage to understand how the ```expect_raise``` spec method works to test that, I would need some small help if you want to add a test for this. 



