### PR TITLE
reload the i18n locale files automatically

### DIFF
--- a/src/amber/cli/templates/app/.amber.yml.ecr
+++ b/src/amber/cli/templates/app/.amber.yml.ecr
@@ -21,6 +21,7 @@ watch:
       <%- if @language == "slang" -%>
       - ./src/views/**/*.slang
       <%- end -%>
+      - ./src/locales/*.yml
     # exclude: # NOTE simplistic implementation: (1) enumerate all includes and excludes; (2) return (includes - excludes)
     #  - ./src/some_irrelevant_file.cr
   spec:


### PR DESCRIPTION
fixing #1070

Currently, the 18n locale files do not reload automatically unless you specify them in the list of things to watch.
With this patch they are included by default in the template so that when you create a new project, you can edit them right away and see the i18n changes.

### Possible Drawbacks

I might have to submit the same patch for the recipes 