### PR TITLE
adding an option to print the routes as json

### DIFF
--- a/spec/amber/cli/commands/routes/routes_spec.cr
+++ b/spec/amber/cli/commands/routes/routes_spec.cr
@@ -48,6 +48,34 @@ module Amber::CLI
           end
         end
 
+        describe "with the default routes as json" do
+          MainCommand.run ["routes", "--json"] { |cmd| output = cmd.out.gets_to_end }
+          routes = route_table_from_json(output)
+          it "outputs the static file handler" do
+            expected = routes.find { |route| route.controller == "Amber::Controller::Static" }
+            expected.nil?.should be_false
+            if expected
+              expected.verb.should eq "get"
+              expected.uri_pattern.should eq "/*"
+              expected.action.should eq "index"
+              expected.pipeline.should eq "static"
+              expected.scope.should eq ""
+            end
+          end
+
+          it "outputs the HomeController index action" do
+            expected = routes.find { |route| route.controller == "HomeController" }
+            expected.nil?.should be_false
+            if expected
+              expected.verb.should eq "get"
+              expected.uri_pattern.should eq "/"
+              expected.action.should eq "index"
+              expected.pipeline.should eq "web"
+              expected.scope.should eq ""
+            end
+          end
+        end
+
         describe "with a websocket route" do
           add_routes :web, %(websocket "/electric", ElectricSocket)
           MainCommand.run %w(routes) { |cmd| output = cmd.out.gets_to_end }

--- a/spec/support/helpers/cli_helper.cr
+++ b/spec/support/helpers/cli_helper.cr
@@ -1,4 +1,16 @@
 require "file_utils"
+require "json"
+
+class RouteJSON
+  JSON.mapping({
+    verb:        String,
+    controller:  String,
+    action:      String,
+    pipeline:    String,
+    scope:       String,
+    uri_pattern: String,
+  })
+end
 
 module CLIHelper
   BASE_ENV_PATH       = "./config/environments/"
@@ -108,5 +120,9 @@ module CLIHelper
 
   def route_table_rows(route_table_text)
     route_table_text.split("\n").reject { |line| line =~ /(─┼─|═╦═|═╩═)/ }
+  end
+
+  def route_table_from_json(route_table_json)
+    Array(RouteJSON).from_json(route_table_json)
   end
 end

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -29,13 +29,18 @@ module Amber::CLI
 
       class Options
         bool "--no-color", desc: "disable colored output", default: false
+        bool "--json", desc: "display the routes as a json-compatible format", default: false
         help
       end
 
       def run
         CLI.toggle_colors(options.no_color?)
         parse_routes
-        print_routes_table
+        if options.json?
+          print_routes_table_json
+        else
+          print_routes_table
+        end
       rescue
         error "Not valid project root directory."
         info "Run `amber routes` in project root directory."
@@ -116,6 +121,12 @@ module Amber::CLI
           @current_pipe = route_match[2]?
           @current_scope = route_match[3]?
         end
+      end
+
+      private def print_routes_table_json
+        puts routes.map { |route|
+          route.transform_keys { |key| key.to_s.downcase.gsub(' ', '_') }
+        }.to_json
       end
 
       private def print_routes_table


### PR DESCRIPTION
### Description of the Change

For some internal stuff I'm building, I would need to print the routes as json, this makes it easier to parse from external tools. I thought this change might be useful for other amber users, if the maintainers don't agree, you can just remove this PR otherwise :)

### Alternate Designs

If we had multiple formats, maybe we could do a ```--format=json``` ? since I've only added this one I thought just adding a ```--json``` would be enough, please let me know what you think of that :)

### Benefits

Being able to reuse the routes in a easier way from external tools. Just a JSON.parse from any language does the trick instead of trying to get the routes manually with some regex.

### Possible Drawbacks

I can't think of any.
