### PR TITLE
adding error validation to the authentication

### DIFF
--- a/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
@@ -5,6 +5,8 @@ class RegistrationController < ApplicationController
   end
 
   def create
+    @validation_errors = [] of Amber::Validators::Error
+    registration_params.validate!
     <%= @name %> = <%= class_name %>.new
     <%= @name %>.email = params["email"].to_s
     <%= @name %>.password = params["password"].to_s
@@ -18,6 +20,9 @@ class RegistrationController < ApplicationController
       flash[:danger] = "Could not create <%= class_name %>!"
       render("new.<%= config.language %>")
     end
+  rescue e : Amber::Exceptions::Validator::ValidationFailed
+    @validation_errors = e.errors
+    render("new.<%= config.language %>") 
   end
 
   private def registration_params

--- a/src/amber/cli/templates/auth/crecto/src/views/registration/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/registration/new.ecr.ecr
@@ -1,5 +1,13 @@
 <h1>Sign Up</h1>
 
+<%="<"%>%- if @validation_errors %>
+  <ul class="errors">
+   <%="<"%>%-  @validation_errors.not_nil!.each do |error| %>
+      <li><%="<"%>%= error.message %></li>
+   <%="<"%>%- end %>
+  </ul>
+<%="<"%>%- end %>
+
 <form action="/registration" method="post">
   <%="<"%>%= csrf_tag %>
   <div class="form-group">

--- a/src/amber/cli/templates/auth/crecto/src/views/registration/new.slang.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/views/registration/new.slang.ecr
@@ -1,5 +1,9 @@
 h1 Sign Up
 
+- if @validation_errors
+  - @validation_errors.not_nil!.each do |error|
+      li = error.message
+
 form action="/registration" method="post"
   == csrf_tag
   .form-group

--- a/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
@@ -5,6 +5,7 @@ class RegistrationController < ApplicationController
   end
 
   def create
+    @validation_errors = [] of Amber::Validators::Error
     <%= @name %> = <%= class_name %>.new(registration_params.validate!)
     <%= @name %>.password = params["password"].to_s
 
@@ -16,6 +17,9 @@ class RegistrationController < ApplicationController
       flash[:danger] = "Could not create <%= class_name %>!"
       render("new.<%= config.language %>")
     end
+  rescue e : Amber::Exceptions::Validator::ValidationFailed
+    @validation_errors = e.errors
+    render("new.<%= config.language %>")
   end
 
   private def registration_params

--- a/src/amber/cli/templates/auth/granite/src/views/registration/new.ecr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/registration/new.ecr.ecr
@@ -1,10 +1,19 @@
 <h1>Sign Up</h1>
 
-<%="<"%>%- if <%= @name %>.errors %>
-  <ul class="errors">
-  <%="<"%>%- <%= @name %>.errors.each do |error| %>
-    <li><%="<"%>%= error.to_s %></li>
+<%="<"%>%- if user %>
+  <%="<"%>%- if <%= @name %>.errors %>
+    <ul class="errors">
+    <%="<"%>%- <%= @name %>.errors.each do |error| %>
+      <li><%="<"%>%= error.to_s %></li>
+    <%="<"%>%- end %>
+    </ul>
   <%="<"%>%- end %>
+<%="<"%>%- end %>
+<%="<"%>%- if @validation_errors %>
+  <ul class="errors">
+   <%="<"%>%-  @validation_errors.not_nil!.each do |error| %>
+      <li><%="<"%>%= error.message %></li>
+   <%="<"%>%- end %>
   </ul>
 <%="<"%>%- end %>
 

--- a/src/amber/cli/templates/auth/granite/src/views/registration/new.slang.ecr
+++ b/src/amber/cli/templates/auth/granite/src/views/registration/new.slang.ecr
@@ -1,9 +1,13 @@
 h1 Sign Up
 
-- if <%= @name %>.errors
-  ul.errors
-  - <%= @name %>.errors.each do |error|
-    li = error.to_s
+- if <%= @name %>
+  - if <%= @name %>.errors
+    ul.errors
+    - <%= @name %>.errors.each do |error|
+      li = error.to_s
+- if @validation_errors
+  - @validation_errors.not_nil!.each do |error|
+      li = error.message
 
 form action="/registration" method="post"
   == csrf_tag


### PR DESCRIPTION
### Description of the Change

This a followup of #1069, the changes done to the validator allowed me to improve the authentication template.

Currently, when you use the auth template and click on "Sign Up" without filling anything, you just have a 500 error because these validation errors were not caught.

This patch is rescuing the validation errors and putting them in the template files so it results in something like this instead of a 500 error:

![screenshot_2019-02-23 abc using amber](https://user-images.githubusercontent.com/1898825/53286797-75163800-37a6-11e9-8237-e6d52502df02.png)


### Alternate Designs

Maybe we could have removed the validation completely & let granite or crecto do it?

### Benefits

By default the sign up works without throwing a 500 error.

### Possible Drawbacks

I have to specify a not_nil! in the template, which is very strange since I do a if check just before, maybe someone more experimented in Crystal could help me to understand why.

