### PR TITLE
Generated controllers no longer require param value presence (only key presence)

### DIFF
--- a/src/amber/cli/templates/api/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/api/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -76,7 +76,7 @@ class <%= class_name %>Controller < ApplicationController
   def <%= @name %>_params
     params.validation do
       <%- @fields_hash.keys.each do |k| -%>
-      required(:<%= k %>, nil, true)
+      required(:<%= k %>, msg: nil, allow_blank: true)
       <%- end -%>
     end
   end

--- a/src/amber/cli/templates/api/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/api/controller/crecto/src/controllers/{{name}}_controller.cr.ecr
@@ -76,7 +76,7 @@ class <%= class_name %>Controller < ApplicationController
   def <%= @name %>_params
     params.validation do
       <%- @fields_hash.keys.each do |k| -%>
-      required(:<%= k %>) { |f| !f.nil? }
+      required(:<%= k %>, nil, true)
       <%- end -%>
     end
   end

--- a/src/amber/cli/templates/api/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/api/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -72,7 +72,7 @@ class <%= class_name %>Controller < ApplicationController
   def <%= @name %>_params
     params.validation do
       <%- @fields_hash.keys.each do |k| -%>
-      required(:<%= k %>) { |f| !f.nil? }
+      required(:<%= k %>, nil, true)
       <%- end -%>
     end
   end

--- a/src/amber/cli/templates/api/controller/granite/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/api/controller/granite/src/controllers/{{name}}_controller.cr.ecr
@@ -72,7 +72,7 @@ class <%= class_name %>Controller < ApplicationController
   def <%= @name %>_params
     params.validation do
       <%- @fields_hash.keys.each do |k| -%>
-      required(:<%= k %>, nil, true)
+      required(:<%= k %>, msg: nil, allow_blank: true)
       <%- end -%>
     end
   end

--- a/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
@@ -27,8 +27,8 @@ class RegistrationController < ApplicationController
 
   private def registration_params
     params.validation do
-      required(:email, nil, true)
-      required(:password, nil, true)
+      required(:email, msg: nil, allow_blank: true)
+      required(:password, msg: nil, allow_blank: true)
     end
   end
 end

--- a/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/crecto/src/controllers/registration_controller.cr.ecr
@@ -27,8 +27,8 @@ class RegistrationController < ApplicationController
 
   private def registration_params
     params.validation do
-      required(:email) { |f| !f.nil? }
-      required(:password) { |f| !f.nil? }
+      required(:email, nil, true)
+      required(:password, nil, true)
     end
   end
 end

--- a/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
@@ -24,8 +24,8 @@ class RegistrationController < ApplicationController
 
   private def registration_params
     params.validation do
-      required(:email, nil, true)
-      required(:password, nil, true)
+      required(:email, msg: nil, allow_blank: true)
+      required(:password, msg: nil, allow_blank: true)
     end
   end
 end

--- a/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/granite/src/controllers/registration_controller.cr.ecr
@@ -24,8 +24,8 @@ class RegistrationController < ApplicationController
 
   private def registration_params
     params.validation do
-      required(:email) { |f| !f.nil? }
-      required(:password) { |f| !f.nil? }
+      required(:email, nil, true)
+      required(:password, nil, true)
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

**BEFORE / CURRENTLY**

**Problem:** Generated controllers (and generated registration/auth controllers) throw a 500 error when the NEW or EDIT forms are left empty/blank. Instead of causing a 500 error the controller should re-render the form and display (model) validation errors if the fields are indeed required at the model level. 

**Cause:** These generated controllers currently validate `required` params for both key _AND_ value presence. This results in a 500 error triggered by a deliberate `raise` in `params.validate!` when attempting to register for an account with blank email and/or pwd fields. 

**AFTER FIX**
Generated controllers now validate `required` params for key presence _only_, not value presence. They do this by passing `true` for the `allow_blank` (3rd) argument to `required`. 

Fixes #1085 (please see issue for details on the problem)

### Alternate Designs

Another alternative would be to change the default value of `allow_blank` argument for [`RequiredRule`](https://github.com/amberframework/amber/blob/master/src/amber/validators/params.cr#L65) from `false` to `true`. 

I believe this is the _right thing to do_ long term, but could potentially have breaking changes for existing Amber apps. That said, the reason I feel that that is the better change is the difference in definition between Rails and Amber for required params.

**Rails' (and also my) definition:** _"The param key is required to be there in the request body, but it doesn't need a value"._  
**Amber's (current) definition: _"The param key is required to be there in the request body, and the value for it must also not be blank."_

If we agree on switching to the (imho better) Rails definition of _required param_, then let's merge this PR and open an issue (referencing this one) to fix that issue. If we disagree on that change, then let's merge this PR and no other action is required (perhaps an issue to be more explicit about this change?).

### Benefits

As a new-comer to Amber, I was immediately confused and perplexed by causing a 500 error in my scaffolded auth controller (`registration_controller`) by simply leaving the email/password fields blank. Instead it should re-render the form with validation errors triggered by the model. 

See #1085 for details. 

### Possible Drawbacks

- The generated code now passes in `nil` and then `true` into `required`, which can be confusing to understand without proper docs. Should we add some comments in the generated controller code? I did not for this PR b/c that also felt a bit hacky and/or overkill to me.
