### PR TITLE
Add constraints support for routes

### DIFF
--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -22,6 +22,15 @@ module Amber
       end
     end
 
+    describe "#to_json" do
+      it "includes constraints key" do
+        route = Route.new("GET", "/", handler, constraints: { "id" => /\d/, "slug" => /\w+/ })
+        obj = JSON.parse(route.to_json)
+        obj["constraints"]["id"].should be_truthy
+        obj["constraints"]["slug"].should be_truthy
+      end
+    end
+
     describe "#call" do
       context "before action" do
         it "does not execute action" do

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -24,7 +24,7 @@ module Amber
 
     describe "#to_json" do
       it "includes constraints key" do
-        route = Route.new("GET", "/", handler, constraints: { "id" => /\d/, "slug" => /\w+/ })
+        route = Route.new("GET", "/", handler, constraints: {"id" => /\d/, "slug" => /\w+/})
         obj = JSON.parse(route.to_json)
         obj["constraints"]["id"].should be_truthy
         obj["constraints"]["slug"].should be_truthy

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -34,7 +34,7 @@ module Amber
           it "uses constraints for defining crud routes" do
             router = Router.new
             router.draw :web do
-              resources "/orders", HelloController, constraints: { "id" => /\d\d\d/ }
+              resources "/orders", HelloController, constraints: {"id" => /\d\d\d/}
             end
 
             # unchanged
@@ -55,7 +55,6 @@ module Amber
             router.match("PATCH", "/orders/511").found?.should be_true
             router.match("DELETE", "/orders/511").found?.should be_true
           end
-
         end
 
         context "when specifying actions" do
@@ -133,7 +132,7 @@ module Amber
         it "registers routes with constraints as Hash" do
           router = Router.new
           router.draw :web do
-            get "/checkout/:cart", HelloController, :world, { "cart" => /\d\d\d/ }
+            get "/checkout/:cart", HelloController, :world, {"cart" => /\d\d\d/}
           end
 
           request = HTTP::Request.new("GET", "/checkout/hello")
@@ -163,7 +162,7 @@ module Amber
             context.content = "hey world"
           }
 
-          route = Route.new("GET", "/posts/:slug", handler, :index, :web, "", "PostsController", { "slug" => /\d\d\-\w+/ })
+          route = Route.new("GET", "/posts/:slug", handler, :index, :web, "", "PostsController", {"slug" => /\d\d\-\w+/})
           router.add(route)
 
           request = HTTP::Request.new("GET", "/posts/hello")

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -31,16 +31,16 @@ module Amber
         end
 
         context "when specifying constraints" do
-          it "uses constraints for defining crud routes" do 
+          it "uses constraints for defining crud routes" do
             router = Router.new
             router.draw :web do
-              resources "/orders", HelloController, constraints: { "id" => /\d\d\d/ } 
+              resources "/orders", HelloController, constraints: { "id" => /\d\d\d/ }
             end
 
             # unchanged
             router.match("POST", "/orders").found?.should be_true
             router.match("GET", "/orders").found?.should be_true
-            
+
             # would have matched without regex constraint
             router.match("GET", "/orders/abc").found?.should be_false
             router.match("GET", "/orders/def/edit").found?.should be_false
@@ -55,7 +55,7 @@ module Amber
             router.match("PATCH", "/orders/511").found?.should be_true
             router.match("DELETE", "/orders/511").found?.should be_true
           end
-          
+
         end
 
         context "when specifying actions" do
@@ -130,11 +130,11 @@ module Amber
           route.path.should eq "get/checkout/:name"
         end
 
-        it "registers routes with constraints as Hash" do 
+        it "registers routes with constraints as Hash" do
           router = Router.new
           router.draw :web do
             get "/checkout/:cart", HelloController, :world, { "cart" => /\d\d\d/ }
-          end    
+          end
 
           request = HTTP::Request.new("GET", "/checkout/hello")
           route = router.match_by_request(request)
@@ -169,7 +169,7 @@ module Amber
           request = HTTP::Request.new("GET", "/posts/hello")
           route = router.match_by_request(request)
           route.found?.should eq false
-          
+
           request = HTTP::Request.new("GET", "/posts/55-hello")
           route = router.match_by_request(request)
           route.found?.should eq true

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -30,6 +30,34 @@ module Amber
           router.match("POST", "/hello").path.should eq "post/hello"
         end
 
+        context "when specifying constraints" do
+          it "uses constraints for defining crud routes" do 
+            router = Router.new
+            router.draw :web do
+              resources "/orders", HelloController, constraints: { "id" => /\d\d\d/ } 
+            end
+
+            # unchanged
+            router.match("POST", "/orders").found?.should be_true
+            router.match("GET", "/orders").found?.should be_true
+            
+            # would have matched without regex constraint
+            router.match("GET", "/orders/abc").found?.should be_false
+            router.match("GET", "/orders/def/edit").found?.should be_false
+            router.match("PUT", "/orders/3ghifds").found?.should be_false
+            router.match("PATCH", "/orders/3ghifds").found?.should be_false
+            router.match("DELETE", "/orders/abb").found?.should be_false
+
+            # will match due to constraints
+            router.match("GET", "/orders/554").found?.should be_true
+            router.match("GET", "/orders/511/edit").found?.should be_true
+            router.match("PUT", "/orders/511").found?.should be_true
+            router.match("PATCH", "/orders/511").found?.should be_true
+            router.match("DELETE", "/orders/511").found?.should be_true
+          end
+          
+        end
+
         context "when specifying actions" do
           it "defines only specified resources" do
             router = Router.new
@@ -101,6 +129,21 @@ module Amber
           route.found?.should eq true
           route.path.should eq "get/checkout/:name"
         end
+
+        it "registers routes with constraints as Hash" do 
+          router = Router.new
+          router.draw :web do
+            get "/checkout/:cart", HelloController, :world, { "cart" => /\d\d\d/ }
+          end    
+
+          request = HTTP::Request.new("GET", "/checkout/hello")
+          route = router.match_by_request(request)
+          route.found?.should eq false
+
+          request = HTTP::Request.new("GET", "/checkout/he110")
+          route = router.match_by_request(request)
+          route.found?.should eq true
+        end
       end
 
       describe "#add" do
@@ -112,6 +155,25 @@ module Amber
 
           route = Route.new("GET", "/some/joe", handler)
           router.add(route)
+        end
+
+        it "correctly passes constraints from Route as Hash" do
+          router = Router.new
+          handler = ->(context : HTTP::Server::Context) {
+            context.content = "hey world"
+          }
+
+          route = Route.new("GET", "/posts/:slug", handler, :index, :web, "", "PostsController", { "slug" => /\d\d\-\w+/ })
+          router.add(route)
+
+          request = HTTP::Request.new("GET", "/posts/hello")
+          route = router.match_by_request(request)
+          route.found?.should eq false
+          
+          request = HTTP::Request.new("GET", "/posts/55-hello")
+          route = router.match_by_request(request)
+          route.found?.should eq true
+          route.path.should eq "get/posts/:slug"
         end
       end
 

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -8,7 +8,7 @@ module Amber::DSL
   record Router, router : Amber::Router::Router, valve : Symbol, scope : String do
     RESOURCES = [:get, :post, :put, :patch, :delete, :options, :head, :trace, :connect]
 
-    macro route(verb, resource, controller, action)
+    macro route(verb, resource, controller, action, constraints = {} of String => Regex)
       %handler = ->(context : HTTP::Server::Context){
         controller = {{controller.id}}.new(context)
         controller.run_before_filter({{action}}) unless context.content
@@ -19,7 +19,7 @@ module Amber::DSL
       }
       %verb = {{verb.upcase.id.stringify}}
       %route = Amber::Route.new(
-        %verb, {{resource}}, %handler, {{action}}, valve, scope, "{{controller.id}}"
+        %verb, {{resource}}, %handler, {{action}}, valve, scope, "{{controller.id}}", {{constraints}}
       )
 
       router.add(%route)
@@ -38,7 +38,7 @@ module Amber::DSL
       end
     {% end %}
 
-    macro resources(resource, controller, only = nil, except = nil)
+    macro resources(resource, controller, only = nil, except = nil, constraints = {} of String => Regex)
       {% actions = [:index, :new, :create, :show, :edit, :update, :destroy] %}
 
       {% if only %}
@@ -48,26 +48,26 @@ module Amber::DSL
       {% end %}
 
       {% for action in actions %}
-        define_action({{resource}}, {{controller}}, {{action}})
+        define_action({{resource}}, {{controller}}, {{action}}, {{constraints}})
       {% end %}
     end
 
-    private macro define_action(path, controller, action)
+    private macro define_action(path, controller, action, constraints = {} of String => Regex)
       {% if action == :index %}
-        get "{{path.id}}", {{controller}}, :index
+        get "{{path.id}}", {{controller}}, :index, {{constraints}}
       {% elsif action == :show %}
-        get "{{path.id}}/:id", {{controller}}, :show
+        get "{{path.id}}/:id", {{controller}}, :show, {{constraints}}
       {% elsif action == :new %}
-        get "{{path.id}}/new", {{controller}}, :new
+        get "{{path.id}}/new", {{controller}}, :new, {{constraints}}
       {% elsif action == :edit %}
-        get "{{path.id}}/:id/edit", {{controller}}, :edit
+        get "{{path.id}}/:id/edit", {{controller}}, :edit, {{constraints}}
       {% elsif action == :create %}
-        post "{{path.id}}", {{controller}}, :create
+        post "{{path.id}}", {{controller}}, :create, {{constraints}}
       {% elsif action == :update %}
-        put "{{path.id}}/:id", {{controller}}, :update
-        patch "{{path.id}}/:id", {{controller}}, :update
+        put "{{path.id}}/:id", {{controller}}, :update, {{constraints}}
+        patch "{{path.id}}/:id", {{controller}}, :update, {{constraints}}
       {% elsif action == :destroy %}
-        delete "{{path.id}}/:id", {{controller}}, :destroy
+        delete "{{path.id}}/:id", {{controller}}, :destroy, {{constraints}}
       {% else %}
         {% raise "Invalid route action '#{action}'" %}
       {% end %}

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -21,7 +21,7 @@ module Amber
           json.field "valve", valve.to_s
           json.field "scope", scope
           json.field "resource", resource
-          json.field "constraints" do 
+          json.field "constraints" do
             json.object do
               constraints.each do |key, value|
                 json.field key, value.to_s

--- a/src/amber/router/route.cr
+++ b/src/amber/router/route.cr
@@ -1,6 +1,6 @@
 module Amber
   struct Route
-    property :handler, :action, :verb, :resource, :valve, :params, :scope, :controller
+    property :handler, :action, :verb, :resource, :valve, :params, :scope, :controller, :constraints
 
     def initialize(@verb : String,
                    @resource : String,
@@ -8,7 +8,8 @@ module Amber
                    @action : Symbol = :index,
                    @valve : Symbol = :web,
                    @scope : String = "",
-                   @controller : String = "")
+                   @controller : String = "",
+                   @constraints : Hash = {} of String => Regex)
     end
 
     def to_json
@@ -20,6 +21,13 @@ module Amber
           json.field "valve", valve.to_s
           json.field "scope", scope
           json.field "resource", resource
+          json.field "constraints" do 
+            json.object do
+              constraints.each do |key, value|
+                json.field key, value.to_s
+              end
+            end
+          end
         end
       end
     end

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -32,7 +32,7 @@ module Amber
 
       def add(route : Route)
         build_node(route.verb, route.resource)
-        @routes.add(route.trail, route)
+        @routes.add(route.trail, route, route.constraints)
         @routes_hash["#{route.controller.downcase}##{route.action.to_s.downcase}"] = route
       end
 


### PR DESCRIPTION
### Description of the Change

Constraints can now be passed into route definitions.

They can be passed in through the `get`, `post`, etc macros, and also the `resources` macros in the Amber router. 

This is done by passing constraints through to amber-router's RouteSet: https://github.com/amberframework/amber-router/blob/master/spec/amber_router/route_set/matching/routes_with_variables_spec.cr#L41

**Rails (_example from the RoR guides_):**
```ruby
get '/:id', to: 'articles#show', constraints: { id: /\d.+/ }
get '/:username', to: 'users#show'
```

**Amber**
```crystal
get "/:id", ArticlesController, :show, constraints: {"id" => /\d.+/}
get "/:username", UsersController, :show
```

Resolves #1089

### Alternate Designs

Only Hashes are supported at the moment. Not sure if we should also be supporting NamedTuple here? 

### Out of Scope

- Unlike with Rails, we have to explicitly pass in the constraints key/argument (`constraints: {...}`). In Rails there is shorthand for this but I'm not a fan of having too much shorthand support to begin with. I prefer a healthy balance of explicit vs implicit, and Rails sometimes goes too far to the right, imho. 
- Specific constraint keys like `subdomain` are not supported in this PR

### Benefits

Much like with [constraints in Rails](https://guides.rubyonrails.org/routing.html#segment-constraints), Amber devs can now pass request param value constraints using the `constraints` optional argument in the `routes.cr` file. 

### Possible Drawbacks

1. NamedTuple for constraints are not supported, but they should be, I think? Looking for actionable advice there.
2. I _think_ that the regex here is only looking for the pattern to be present in the request segment, but not fully matching the segment. This would result in different behavior than what is expected from constraints in the Rails dispatcher. 