### PR TITLE
Upgrade to Crystal 0.28.0

### DIFF
--- a/src/amber/support/message_encryptor.cr
+++ b/src/amber/support/message_encryptor.cr
@@ -63,7 +63,7 @@ module Amber::Support
     end
 
     private def sign_bytes(data : Bytes)
-      OpenSSL::HMAC.digest(@digest, @secret, data)
+      OpenSSL::HMAC.digest(OpenSSL::Algorithm.parse(@digest.to_s), @secret, data)
     end
   end
 end

--- a/src/amber/support/message_verifier.cr
+++ b/src/amber/support/message_verifier.cr
@@ -47,7 +47,7 @@ module Amber::Support
     end
 
     private def generate_digest(data)
-      encode(OpenSSL::HMAC.digest(@digest, @secret, data))
+      encode(OpenSSL::HMAC.digest(OpenSSL::Algorithm.parse(@digest.to_s), @secret, data))
     end
   end
 end


### PR DESCRIPTION
I found the following changes needed to upgrade to the upcoming Crystal 0.28.0.

If some macro `compare_versions` are added it should be possible to support current versions as well.

Feel free to extract these changes and close the PR if you prefer to handle the migration in a specific way.