### PR TITLE
Use amber local source code instead of remote repository source code for testing

### DIFF
--- a/spec/amber/cli/commands/init_spec.cr
+++ b/spec/amber/cli/commands/init_spec.cr
@@ -75,7 +75,6 @@ module Amber::CLI
       cleanup
       MainCommand.run ["new", TESTING_APP, "--no-deps", "-d", db]
       prepare_yaml(TESTING_APP)
-      MainCommand.run ["shards install"]
 
       describe "#{db}" do
         %w(development test).each do |env|

--- a/spec/amber/cli/commands/init_spec.cr
+++ b/spec/amber/cli/commands/init_spec.cr
@@ -74,6 +74,8 @@ module Amber::CLI
     %w(pg mysql sqlite).each do |db|
       cleanup
       MainCommand.run ["new", TESTING_APP, "--no-deps", "-d", db]
+      prepare_yaml(TESTING_APP)
+      MainCommand.run ["shards install"]
 
       describe "#{db}" do
         %w(development test).each do |env|

--- a/spec/support/helpers/cli_helper.cr
+++ b/spec/support/helpers/cli_helper.cr
@@ -94,6 +94,8 @@ module CLIHelper
       shard = shard.gsub(/github\:\samberframework\/amber\n.*(?=\n)/, "path: ../../../amber")
       File.write("#{path}/shard.yml", shard)
     end
+
+    system("shards install")
   end
 
   def prepare_db_yml(path = ENV_CONFIG_PATH)
@@ -109,7 +111,7 @@ module CLIHelper
   end
 
   def scaffold_app(app_name, *options)
-    Amber::CLI::MainCommand.run ["new", app_name] | options.to_a
+    Amber::CLI::MainCommand.run ["new", app_name, "--no-deps"] | options.to_a
     Dir.cd(app_name)
     prepare_yaml(Dir.current)
   end


### PR DESCRIPTION
### Description of the Change

This change prevents false positives and allows any local changes to be tested and not have the main repository being the source of the tests. In essence, any changes that are made locally to the amber project will be tested instead of the the main amber repository source code.

### Alternate Designs

The proposed change was applied in order to prevent false positives and to allow any local changes to be tested and not have the main repository being the source of the tests.

### Benefits

Test will run off of the local amber project instead of the GitHub repository.

### Possible Drawbacks

Can't think of any.
