### PR TITLE
Changed required crystal-redis version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -48,7 +48,7 @@ dependencies:
 
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.0.0
+    version: ~> 2.0
 
   shell-table:
     github: luckyframework/shell-table.cr


### PR DESCRIPTION
### Description of the Change

Changed required crystal-redis version from `~> 2.0.0` which equivalent of `>= 2.0.0 && < 2.1.0` to `~> 2.0` which equivalent of `>= 2.0.0 && < 3.0`

### Benefits

- Amber will be reusable with gem having the latest crystal-redis version. (example: https://github.com/robacarp/mosquito/issues/33)
- No more pull requests to update minor version of crystal-redis (plus it don't break user who still want to force crystal-redis 2.0.0)

### Possible Drawbacks

Amber will encounter problems if crystal-redis push a minor breaking change.
