### PR TITLE
Update docker image to crystal 0.28.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.27.0
+FROM crystallang/crystal:0.28.0
 
 # Install Dependencies
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
### Description of the Change

This updates the docker image to use Crystal 0.28.0.  I also fixed the automated build on docker hub and rebuilt `amberframework/amber:v0.28.0`

Fixes #1099 

### Alternate Designs

N/A

### Benefits

Fixes docker for generated projects

### Possible Drawbacks

N/A