### PR TITLE
Default to $EDITOR for amber encrypt command

### DIFF
--- a/src/amber/cli/commands/encrypt.cr
+++ b/src/amber/cli/commands/encrypt.cr
@@ -5,7 +5,7 @@ module Amber::CLI
     class Encrypt < Command
       class Options
         arg "env", desc: "environment file to encrypt", default: "production"
-        string ["-e", "--editor"], desc: "preferred editor: [vim, nano, pico, etc]", default: "vim"
+        string ["-e", "--editor"], desc: "preferred editor: [vim, nano, pico, etc]", default: ENV.fetch("EDITOR", "vim")
         bool ["--noedit"], desc: "skip editing and just encrypt", default: false
         help
       end


### PR DESCRIPTION
### Description of the Change

This pull request changes the default editor for the `amber encrypt` command. 

The old default was `vim`, with this PR the default is the editor specified in the users
$EDITOR environment variable, if present. When $EDITOR is not present, vim is used.

The impetus for submitting this was using vim by default was unexpected behavior. I'm an nvim user, and have $EDITOR set as my default. I still have vim installed, so vim opened, but errored. This was unexpected behavior.

### Alternate Designs

No other alternate designs were considered; the combination of environment default coupled with the ability to override with the `-e` flag covers the most common scenarios

### Benefits

- This is a fairly common mac/linux behavior that I think improves upon the existing behavior (`-e` flag) for users who have set the $EDITOR environment variable. 
- Users on mac/linux will see expected behavior if they've set the $EDITOR environment variable
- Reduces need for a configuration flag per application, or for amber; this uses the commonly configured environment variable

### Possible Drawbacks

- Nothing I can think of that would be as a result of this behavior (e.g. user sets invalid $EDITOR command, path issues, etc) or that isn't recoverable with the -e flag. 