### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,8 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+custom: https://liberapay.com/amber-framework/


### PR DESCRIPTION
GitHub recently added a repo sponsorship button that is reasonably flexible and configurable. This simply takes the link from the badge, and adds it to the sponsor button up top.

[Github Sponsors PR page](https://github.com/sponsors)