### PR TITLE
Updates for Crystal 0.29

### DIFF
--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 struct UserSocket < Amber::WebSockets::ClientSocket; end
 

--- a/spec/amber/controller/base_spec.cr
+++ b/spec/amber/controller/base_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Controller
   describe Base do

--- a/spec/amber/controller/filters_spec.cr
+++ b/spec/amber/controller/filters_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Controller
   describe Base do

--- a/spec/amber/controller/redirect_spec.cr
+++ b/spec/amber/controller/redirect_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Controller::Helpers
   describe Redirector do

--- a/spec/amber/controller/render_spec.cr
+++ b/spec/amber/controller/render_spec.cr
@@ -1,5 +1,5 @@
-require "../../../spec_helper"
-require "../../../support/fixtures/render_fixtures"
+require "../../spec_helper"
+require "../../support/fixtures/render_fixtures"
 
 include RenderFixtures
 

--- a/spec/amber/controller/respond_with_spec.cr
+++ b/spec/amber/controller/respond_with_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Controller
   describe Base do

--- a/spec/amber/dsl/server_spec.cr
+++ b/spec/amber/dsl/server_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   module DSL

--- a/spec/amber/environment/env_spec.cr
+++ b/spec/amber/environment/env_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Environment
   describe Env do

--- a/spec/amber/environment/loader_spec.cr
+++ b/spec/amber/environment/loader_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Environment
   describe Loader do

--- a/spec/amber/environment/settings_spec.cr
+++ b/spec/amber/environment/settings_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Environment
   describe Settings do

--- a/spec/amber/extensions/http_spec.cr
+++ b/spec/amber/extensions/http_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Extensions
   describe HTTPServerContext do

--- a/spec/amber/extensions/number_spec.cr
+++ b/spec/amber/extensions/number_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Extensions
   describe Number do

--- a/spec/amber/extensions/string_spec.cr
+++ b/spec/amber/extensions/string_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Extensions
   describe String do

--- a/spec/amber/pipes/cors_spec.cr
+++ b/spec/amber/pipes/cors_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Pipe
   describe CORS do

--- a/spec/amber/router/context_spec.cr
+++ b/spec/amber/router/context_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 describe HTTP::Server::Context do
   {% for request_method in HTTP::Server::Context::METHODS %}

--- a/spec/amber/router/cookies_spec.cr
+++ b/spec/amber/router/cookies_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Router
   describe Cookies::Store do

--- a/spec/amber/router/params_spec.cr
+++ b/spec/amber/router/params_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Router
   describe Params do

--- a/spec/amber/router/parsers/json_spec.cr
+++ b/spec/amber/router/parsers/json_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber::Router::Parsers
   describe JSON do

--- a/spec/amber/router/request_spec.cr
+++ b/spec/amber/router/request_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber::Router
   describe HTTP::Request do

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   describe Route do

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   module Router

--- a/spec/amber/router/scope_spec.cr
+++ b/spec/amber/router/scope_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   module Router

--- a/spec/amber/router/session/cookie_store_spec.cr
+++ b/spec/amber/router/session/cookie_store_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 
 module Amber::Router::Session
   COOKIE_STORE = Amber::Router::Cookies::Store.new

--- a/spec/amber/router/session/redis_store_spec.cr
+++ b/spec/amber/router/session/redis_store_spec.cr
@@ -1,4 +1,4 @@
-require "../../../../spec_helper"
+require "../../../spec_helper"
 require "redis"
 
 # TODO: This test can't run on it's own because it needs the EXPIRES constant which is set elsewhere.

--- a/spec/amber/router/session_spec.cr
+++ b/spec/amber/router/session_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 include SessionHelper
 
 module Amber::Router

--- a/spec/amber/ssl/ssl_spec.cr
+++ b/spec/amber/ssl/ssl_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   describe SSL do

--- a/spec/amber/support/file_encryptor.cr
+++ b/spec/amber/support/file_encryptor.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 describe Amber::Support::FileEncryptor do
   secret_key = "mnDiAY4OyVjqg5u0wvpr0MoBkOGXBeYo7_ysjwsNzmw"

--- a/spec/amber/websockets/channel_spec.cr
+++ b/spec/amber/websockets/channel_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   describe WebSockets::ClientSocket do

--- a/spec/amber/websockets/client_socket_spec.cr
+++ b/spec/amber/websockets/client_socket_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   describe WebSockets::ClientSocket do

--- a/spec/amber/websockets/client_sockets_spec.cr
+++ b/spec/amber/websockets/client_sockets_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 module Amber
   describe WebSockets::ClientSockets do

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -10,7 +10,7 @@ module Amber::CLI
       @filelogs : String
 
       def initialize(__previous, __argv)
-        @filename = "./tmp/#{Time.now.to_unix_ms}_console.cr"
+        @filename = "./tmp/#{Time.utc.to_unix_ms}_console.cr"
         @filelogs = @filename.sub("console.cr", "console_result.log")
         super(__previous, __argv)
       end

--- a/src/amber/cli/generators/generator.cr
+++ b/src/amber/cli/generators/generator.cr
@@ -24,7 +24,7 @@ module Amber::CLI
       @table_name ||= name_plural
       @fields = parse_fields(params)
       @fields_hash = parse_fields_hash
-      @timestamp = Time.now.to_s("%Y%m%d%H%M%S%L")
+      @timestamp = Time.utc.to_s("%Y%m%d%H%M%S%L")
     end
 
     def filter(entries)
@@ -76,7 +76,7 @@ module Amber::CLI
       when "bool", "boolean"
         "true"
       when "time", "timestamp"
-        Time.now.to_s
+        Time.utc.to_s
       when "ref", "reference", "references"
         rand(100).to_s
       else

--- a/src/amber/cli/recipes/scaffold/controller.cr
+++ b/src/amber/cli/recipes/scaffold/controller.cr
@@ -71,7 +71,7 @@ module Amber::Recipes::Scaffold
       when "bool", "boolean"
         "true"
       when "time", "timestamp"
-        Time.now.to_s
+        Time.utc.to_s
       when "ref", "reference", "references"
         rand(100).to_s
       else

--- a/src/amber/environment/logger.cr
+++ b/src/amber/environment/logger.cr
@@ -13,7 +13,7 @@ module Amber::Environment
 
     def log(severity, message, progname = nil, color = @color)
       return if severity < level || !@io
-      write(severity, Time.now, "#{progname || @progname} |".colorize(color).to_s, message)
+      write(severity, Time.utc, "#{progname || @progname} |".colorize(color).to_s, message)
     end
   end
 end

--- a/src/amber/pipes/logger.cr
+++ b/src/amber/pipes/logger.cr
@@ -11,10 +11,10 @@ module Amber
       end
 
       def call(context : HTTP::Server::Context)
-        time = Time.now
+        time = Time.utc
         call_next(context)
         status = context.response.status_code
-        elapsed = elapsed_text(Time.now - time)
+        elapsed = elapsed_text(Time.utc - time)
         request(context, time, elapsed, status, :magenta) if @context.includes? "request"
         log_other(context.request.headers, "Headers") if @context.includes? "headers"
         log_other(context.request.cookies, "Cookies", :light_blue) if @context.includes? "cookies"

--- a/src/amber/router/session/cookie_store.cr
+++ b/src/amber/router/session/cookie_store.cr
@@ -76,7 +76,7 @@ module Amber::Router::Session
     end
 
     def expires_at
-      Time.now + expires.seconds if @expires > 0
+      Time.utc + expires.seconds if @expires > 0
     end
 
     def current_session

--- a/src/amber/router/session/redis_store.cr
+++ b/src/amber/router/session/redis_store.cr
@@ -86,7 +86,7 @@ module Amber::Router::Session
     end
 
     def expires_at
-      (Time.now + expires.seconds) if @expires > 0
+      (Time.utc + expires.seconds) if @expires > 0
     end
 
     def current_session

--- a/src/amber/server/server.cr
+++ b/src/amber/server/server.cr
@@ -52,7 +52,7 @@ module Amber
     end
 
     def start
-      time = Time.now
+      time = Time.local
       logger.info "#{version.colorize(:light_cyan)} serving application \"#{settings.name.capitalize}\" at #{host_url.colorize(:light_cyan).mode(:underline)}"
       handler.prepare_pipelines
       server = HTTP::Server.new(handler)
@@ -73,7 +73,7 @@ module Amber
       loop do
         begin
           logger.info "Server started in #{Amber.env.colorize(:yellow)}."
-          logger.info "Startup Time #{Time.now - time}".colorize(:white)
+          logger.info "Startup Time #{Time.local - time}".colorize(:white)
           server.listen
           break
         rescue e : Errno

--- a/src/amber/websockets/client_socket.cr
+++ b/src/amber/websockets/client_socket.cr
@@ -68,7 +68,7 @@ module Amber
         @raw_params = @context.params
         @params = Amber::Validators::Params.new(@raw_params)
         @socket.on_pong do
-          @pongs.push(Time.now)
+          @pongs.push(Time.utc)
           @pongs.delete_at(0) if @pongs.size > 3
         end
       end
@@ -93,7 +93,7 @@ module Amber
       protected def beat
         @socket.send("ping")
         @socket.ping
-        @pings.push(Time.now)
+        @pings.push(Time.utc)
         @pings.delete_at(0) if @pings.size > 3
         check_alive!
       rescue ex : IO::Error


### PR DESCRIPTION
Tracking updates to support Crystal 0.29:

- [x] There a couple of relative paths used in `require`s that needs to be fixed for Crystal 0.29.0
- [x] Fix deprecation warnings for Time.now
- [ ] Ameba reference updated
  - [x] Waiting on merges: https://github.com/veelenga/ameba/pull/106 and https://github.com/veelenga/ameba/pull/108
  - [x] [Ameba 0.10 is released](https://github.com/veelenga/ameba/releases/tag/v0.10.0)
- [ ] Granite reference updated
  - [x] https://github.com/amberframework/granite/issues/337 fixed