### PR TITLE
fixed makefile so link and force_link functions create symlinks using

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PREFIX=/usr/local
 INSTALL_DIR=$(PREFIX)/bin
 AMBER_SYSTEM=$(INSTALL_DIR)/amber
 
-OUT_DIR=./bin
+OUT_DIR=$(CURDIR)/bin
 AMBER=$(OUT_DIR)/amber
 AMBER_SOURCES=$(shell find src/ -type f -name '*.cr')
 


### PR DESCRIPTION
The makefile was creating symlinks using the relative path "./bin" so the link would not point to the correct location. I changed it to use the absolute path of the amber location so the symlink points to it correctly. 