### PR TITLE
Remove X-Powered-By header by default

### DIFF
--- a/src/amber/cli/templates/app/config/routes.cr
+++ b/src/amber/cli/templates/app/config/routes.cr
@@ -2,7 +2,7 @@ Amber::Server.configure do
   pipeline :web do
     # Plug is the method to use connect a pipe (middleware)
     # A plug accepts an instance of HTTP::Handler
-    plug Amber::Pipe::PoweredByAmber.new
+    # plug Amber::Pipe::PoweredByAmber.new
     # plug Amber::Pipe::ClientIp.new(["X-Forwarded-For"])
     plug Citrine::I18n::Handler.new
     plug Amber::Pipe::Error.new


### PR DESCRIPTION
This pull request removes the X-Powered-By header being included in new Amber applications by default.