### PR TITLE
Update to crystal-db ~> 0.7.0 and Crystal 0.31.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -36,7 +36,7 @@ dependencies:
 
   micrate:
     github: amberframework/micrate
-    version: ~> 0.3.4
+    version: ~> 0.3.5
 
   pg:
     github: will/crystal-pg

--- a/shard.yml
+++ b/shard.yml
@@ -40,15 +40,15 @@ dependencies:
 
   pg:
     github: will/crystal-pg
-    version: ~> 0.18.0
+    version: ~> 0.19.0
 
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.8.0
+    version: ~> 0.9.0
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.13.0
+    version: ~> 0.14.0
 
   redis:
     github: stefanwille/crystal-redis

--- a/shard.yml
+++ b/shard.yml
@@ -35,11 +35,8 @@ dependencies:
     #version: ~> 0.3.0
 
   micrate:
-    # TODO wait for https://github.com/amberframework/micrate/pull/40
-    # github: amberframework/micrate
-    # version: ~> 0.3.3
-    github: bcardiff/micrate
-    branch: crystal/0.31.0
+    github: amberframework/micrate
+    version: ~> 0.3.4
 
   pg:
     github: will/crystal-pg

--- a/shard.yml
+++ b/shard.yml
@@ -35,8 +35,11 @@ dependencies:
     #version: ~> 0.3.0
 
   micrate:
-    github: amberframework/micrate
-    version: ~> 0.3.3
+    # TODO wait for https://github.com/amberframework/micrate/pull/40
+    # github: amberframework/micrate
+    # version: ~> 0.3.3
+    github: bcardiff/micrate
+    branch: crystal/0.31.0
 
   pg:
     github: will/crystal-pg

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -22,22 +22,16 @@ dependencies:
     #version: <%= Amber::VERSION %>
 
   granite:
-    github: bcardiff/granite
-    branch: crystal/0.31.0
-    # TODO wait for https://github.com/amberframework/granite/pull/363
-    # github: amberframework/granite
-    # version: ~> 0.17.0
+    github: amberframework/granite
+    version: ~> 0.17.3
 
   quartz_mailer:
     github: amberframework/quartz-mailer
     version: ~> 0.5.3
 
   jasper_helpers:
-    github: bcardiff/jasper-helpers
-    branch: use-markd
-    # TODO wait for https://github.com/amberframework/jasper-helpers/pull/37
-    # github: amberframework/jasper-helpers
-    # version: ~> 0.2.4
+    github: amberframework/jasper-helpers
+    version: ~> 0.2.5
 
 <% case @database when "pg" -%>
   pg:

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -36,15 +36,15 @@ dependencies:
 <% case @database when "pg" -%>
   pg:
     github: will/crystal-pg
-    version: ~> 0.18.0
+    version: ~> 0.19.0
 <% when "mysql" -%>
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.8.0
+    version: ~> 0.9.0
 <% when "sqlite" -%>
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.13.0
+    version: ~> 0.14.0
 <% end -%>
 
   citrine-i18n:

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -22,16 +22,22 @@ dependencies:
     #version: <%= Amber::VERSION %>
 
   granite:
-    github: amberframework/granite
-    version: ~> 0.17.0
+    github: bcardiff/granite
+    branch: crystal/0.31.0
+    # TODO wait for https://github.com/amberframework/granite/pull/363
+    # github: amberframework/granite
+    # version: ~> 0.17.0
 
   quartz_mailer:
     github: amberframework/quartz-mailer
     version: ~> 0.5.3
 
   jasper_helpers:
-    github: amberframework/jasper-helpers
-    version: ~> 0.2.4
+    github: bcardiff/jasper-helpers
+    branch: use-markd
+    # TODO wait for https://github.com/amberframework/jasper-helpers/pull/37
+    # github: amberframework/jasper-helpers
+    # version: ~> 0.2.4
 
 <% case @database when "pg" -%>
   pg:


### PR DESCRIPTION
This PR updates amber to crystal-db 0.7.0 and bump dependencies for proper support of Crystal 0.31.0

The `Temp:` commit should be changed after the following PRs are merged

* https://github.com/amberframework/micrate/pull/40
* https://github.com/amberframework/granite/pull/363
* https://github.com/amberframework/jasper-helpers/pull/37

All the changes should still be compatible with Crystal 0.30