### PR TITLE
Change flash message grammar

### DIFF
--- a/src/amber/cli/templates/scaffold/controller/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/src/controllers/{{name}}_controller.cr.ecr
@@ -25,7 +25,7 @@ class <%= class_name %>Controller < ApplicationController
   def create
     <%= @name %> = <%= class_name %>.new <%= @name %>_params.validate!
     if <%= @name %>.save
-      redirect_to action: :index, flash: {"success" => "Created <%= @name %> successfully."}
+      redirect_to action: :index, flash: {"success" => "<%= @name.capitalize %> has been created."}
     else
       flash[:danger] = "Could not create <%= class_name %>!"
       render "new.<%= config.language %>"
@@ -35,7 +35,7 @@ class <%= class_name %>Controller < ApplicationController
   def update
     <%= @name %>.set_attributes <%= @name %>_params.validate!
     if <%= @name %>.save
-      redirect_to action: :index, flash: {"success" => "Updated <%= @name %> successfully."}
+      redirect_to action: :index, flash: {"success" => "<%= @name.capitalize %> has been updated."}
     else
       flash[:danger] = "Could not update <%= class_name %>!"
       render "edit.<%= config.language %>"
@@ -44,7 +44,7 @@ class <%= class_name %>Controller < ApplicationController
 
   def destroy
     <%= @name %>.destroy
-    redirect_to action: :index, flash: {"success" => "Deleted <%= @name %> successfully."}
+    redirect_to action: :index, flash: {"success" => "<%= @name.capitalize %> has been deleted."}
   end
 
   private def <%= @name %>_params


### PR DESCRIPTION
### Description of the Change

Currently, if we create resources using `amber g scaffold` command, the controllers set flash messages like below:

```  
Created project successfully.
```

The pull request would change it to:
```
Project has been created successfully.
```

The same message in Rails scaffold would appear as:
```
Project was successfully created.
```
### Alternate Designs
```
Project has successfully been created.
```
