### PR TITLE
Update Auth Generator to use new Bcrypt Verify Method

### DIFF
--- a/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
@@ -44,7 +44,7 @@ class <%= class_name %> < Granite::Base
   end
 
   def authenticate(password : String)
-    (bcrypt_pass = self.password) ? bcrypt_pass == password : false
+    (bcrypt_pass = self.password) ? bcrypt_pass.verify(password) : false
   end
 
   private getter new_password : String?


### PR DESCRIPTION
As discussed in Gitter (https://gitter.im/amberframework/amber?at=5d8df7ba0e829f6047367ca5) the Auth generator uses a deprecated Bcrypt verification method. This PR uses the new `.verify()` method for authentication.