### PR TITLE
update micrate to 0.4.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -36,7 +36,7 @@ dependencies:
 
   micrate:
     github: amberframework/micrate
-    version: ~> 0.3.5
+    version: ~> 0.4.0
 
   pg:
     github: will/crystal-pg


### PR DESCRIPTION
### Description of the Change

This fixes the crystal-db mismatch in master.  There are other crystal-0.31.0 errors but this is necessary to continue testing.
