### PR TITLE
Bump granite version

### DIFF
--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -23,7 +23,7 @@ dependencies:
 
   granite:
     github: amberframework/granite
-    version: ~> 0.17.3
+    version: ~> 0.18.0
 
   quartz_mailer:
     github: amberframework/quartz-mailer


### PR DESCRIPTION
Granite was released as a patch 0.17.3 but there were breaking changes
related to the crystal-db so we deleted the patch 0.17.3 and created a
minor release 0.18.0.  This should resolve the conflicts we were
getting in Amber 0.30.0.