### PR TITLE
Change log time to local rather than utc

### DIFF
--- a/src/amber/environment/logger.cr
+++ b/src/amber/environment/logger.cr
@@ -13,7 +13,7 @@ module Amber::Environment
 
     def log(severity, message, progname = nil, color = @color)
       return if severity < level || !@io
-      write(severity, Time.utc, "#{progname || @progname} |".colorize(color).to_s, message)
+      write(severity, Time.local, "#{progname || @progname} |".colorize(color).to_s, message)
     end
   end
 end


### PR DESCRIPTION
### Description of the Change
Fixes #1154 
This is my first "code" PR. I think it's very simple. I just changed the log method to write `Time.local` rather than `Time.utc`.

### Alternate Designs
This seemed pretty straight forward to me.


### Benefits
Users from non-UTC timezone can now see logs on their local time :smile: 

### Possible Drawbacks
I can't see a possible drawback. Maybe add a configuration so users could choose in what timezone they want to see their logs?