### PR TITLE
Updating 'Allows delete links to post' to ES6 syntax

### DIFF
--- a/assets/js/amber.js
+++ b/assets/js/amber.js
@@ -255,9 +255,9 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 if (!Date.prototype.toGranite) {
-  (() => {
+  (function() {
 
-    let pad = (number) => {
+    function pad(number) {
       if (number < 10) {
         return '0' + number;
       }
@@ -272,5 +272,6 @@ if (!Date.prototype.toGranite) {
         ':' + pad(this.getUTCMinutes()) +
         ':' + pad(this.getUTCSeconds())  ;
     };
-  });
+
+  }());
 }

--- a/assets/js/amber.js
+++ b/assets/js/amber.js
@@ -231,16 +231,15 @@ export default {
 /**
  * Allows delete links to post for security and ease of use similar to Rails jquery_ujs
  */
-document.addEventListener("DOMContentLoaded", function () {
-  var elements = document.querySelectorAll("a[data-method='delete']");
-  var i;
-  for (i = 0; i < elements.length; i++) {
-    elements[i].addEventListener("click", function (e) {
+document.addEventListener("DOMContentLoaded", () => {
+  let elements = document.querySelectorAll("a[data-method='delete']");
+  for (let i = 0; i < elements.length; i++) {
+    elements[i].addEventListener("click", (e) => {
       e.preventDefault();
-      var message = e.target.getAttribute("data-confirm") || "Are you sure?";
+      let message = e.target.getAttribute("data-confirm") || "Are you sure?";
       if (confirm(message)) {
-        var form = document.createElement("form");
-        var input = document.createElement("input");
+        let form = document.createElement("form");
+        let input = document.createElement("input");
         form.setAttribute("action", e.target.getAttribute("href"));
         form.setAttribute("method", "POST");
         input.setAttribute("type", "hidden");
@@ -256,9 +255,9 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 if (!Date.prototype.toGranite) {
-  (function() {
+  (() => {
 
-    function pad(number) {
+    let pad = (number) => {
       if (number < 10) {
         return '0' + number;
       }
@@ -273,6 +272,5 @@ if (!Date.prototype.toGranite) {
         ':' + pad(this.getUTCMinutes()) +
         ':' + pad(this.getUTCSeconds())  ;
     };
-
-  }());
+  };
 }

--- a/assets/js/amber.js
+++ b/assets/js/amber.js
@@ -272,5 +272,5 @@ if (!Date.prototype.toGranite) {
         ':' + pad(this.getUTCMinutes()) +
         ':' + pad(this.getUTCSeconds())  ;
     };
-  };
+  });
 }


### PR DESCRIPTION

### Description of the Change

Lines 234 through 276 were still using 'var' for variable declaration instead of 'let' or 'const', which means they are not block scoped, and with ES6, 'var' is deprecated. 

On line 234 where the event listener is set, you can use an arrow function instead of 'function() {}', as well with line 237.

Line 236/237 declared the initialization variable above the loop, when it can be declared in the same line.

### Alternate Designs

There weren't any alternate designs assessed.

### Benefits

This is consistent with ES6 syntax.

### Possible Drawbacks

Those who are less familiar with ES6 syntax may have a harder time understanding the changes (though, the remainder of the file appears to already have been updated). 
