### PR TITLE
keep the scope when generating new routes

### DIFF
--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -2,10 +2,10 @@ module Amber::CLI::Helpers
   def add_routes(pipeline, route)
     routes = File.read("./config/routes.cr")
     replacement = <<-ROUTES
-    routes :#{pipeline.to_s} do
-    #{route}
+    routes :#{pipeline.to_s}\\1 do
+      #{route}
     ROUTES
-    File.write("./config/routes.cr", routes.gsub("routes :#{pipeline.to_s} do", replacement))
+    File.write("./config/routes.cr", routes.gsub(/routes :#{pipeline.to_s}(.*) do/, replacement, backreferences = true))
     system("crystal tool format ./config/routes.cr")
   end
 

--- a/src/amber/cli/helpers/helpers.cr
+++ b/src/amber/cli/helpers/helpers.cr
@@ -5,7 +5,7 @@ module Amber::CLI::Helpers
     routes :#{pipeline.to_s}\\1 do
       #{route}
     ROUTES
-    File.write("./config/routes.cr", routes.gsub(/routes :#{pipeline.to_s}(.*) do/, replacement, backreferences = true))
+    File.write("./config/routes.cr", routes.gsub(/routes :#{pipeline.to_s}(.*) do/, replacement))
     system("crystal tool format ./config/routes.cr")
   end
 


### PR DESCRIPTION
### Description of the Change

This change prevents the scope from being overwritten when a new route is generated. 

### Alternate Designs

n/a

### Benefits

Avoids users having to re-add the scope every time they generate a new route.

### Possible Drawbacks

none