### PR TITLE
Update dependencies

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,11 +1,11 @@
 name: amber
 
-version: 0.32.0
+version: 0.31.0
 
 authors:
   - Amber Team and Contributors <amberframework.org>
 
-crystal: 0.31.1
+crystal: 0.32.1
 
 license: MIT
 
@@ -36,19 +36,19 @@ dependencies:
 
   micrate:
     github: amberframework/micrate
-    version: ~> 0.4.0
+    version: ~> 0.4.2
 
   pg:
     github: will/crystal-pg
-    version: ~> 0.19.0
+    version: ~> 0.20.0
 
   mysql:
     github: crystal-lang/crystal-mysql
-    version: ~> 0.9.0
+    version: ~> 0.10.0
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: ~> 0.14.0
+    version: ~> 0.15.0
 
   redis:
     github: stefanwille/crystal-redis


### PR DESCRIPTION
Some DB Shards are out of version sync

### Description of the Change
Bumps DB Versions 

### Benefits

Can compile amber project with Crystal 0.32.1

**Depends On:** amberframework/granite#377
