### PR TITLE
Update crystal-redis dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -52,7 +52,7 @@ dependencies:
 
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.2.0
+    version: ~> 2.5.0
 
   shell-table:
     github: luckyframework/shell-table.cr

--- a/spec/amber/router/session/redis_store_spec.cr
+++ b/spec/amber/router/session/redis_store_spec.cr
@@ -140,6 +140,22 @@ module Amber::Router::Session
       end
     end
 
+    describe "#to_h" do
+      it "returns an hash of available keys/values" do
+        cookies = new_cookie_store
+        cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
+
+        cookie_store["a"] = "a"
+        cookie_store["b"] = "b"
+        cookie_store["c"] = "c"
+
+        cookie_store.delete("ses")
+
+        cookie_store.to_h.keys.should eq %w(a b c)
+        cookie_store.to_h["c"].should eq "c"
+      end
+    end
+
     describe "#update" do
       it "updates all keys by hash" do
         cookies = new_cookie_store

--- a/spec/amber/router/session/redis_store_spec.cr
+++ b/spec/amber/router/session/redis_store_spec.cr
@@ -145,14 +145,14 @@ module Amber::Router::Session
         cookies = new_cookie_store
         cookie_store = RedisStore.new(REDIS_STORE, cookies, "ses", EXPIRES)
 
-        cookie_store["a"] = "a"
-        cookie_store["b"] = "b"
-        cookie_store["c"] = "c"
+        cookie_store["a"] = "z"
+        cookie_store["b"] = "y"
+        cookie_store["c"] = "x"
 
         cookie_store.delete("ses")
 
         cookie_store.to_h.keys.should eq %w(a b c)
-        cookie_store.to_h["c"].should eq "c"
+        cookie_store.to_h["c"].should eq "x"
       end
     end
 

--- a/src/amber/router/session/redis_store.cr
+++ b/src/amber/router/session/redis_store.cr
@@ -56,7 +56,7 @@ module Amber::Router::Session
     end
 
     def to_h
-      store.hmget(session_id).each_slice(2).to_h
+      store.hgetall(session_id).each_slice(2).to_h
     end
 
     def update(hash : Hash(String, String))


### PR DESCRIPTION
### Description of the Change

- Updated crystal-redis version from 2.2.0 to 2.5.0
- Replaced `hmget` method from crystal redis by `hgetall` in session/redis_store `#to_h` method, since it was wrongly used (https://redis.io/commands/hmget) and broke with crystal-redis 2.5.2 (https://github.com/stefanwille/crystal-redis/releases/tag/v2.5.2)
- Added missing spec for session/redis_store `#to_h` method

### Benefits

Amber will be reusable with gem having the latest crystal-redis version.
