### PR TITLE
Update to Crystal 0.33.0

### DIFF
--- a/src/amber/pipes/static.cr
+++ b/src/amber/pipes/static.cr
@@ -25,7 +25,7 @@ module Amber
         expanded_path += "/" if is_dir_path && !dir_path?(expanded_path)
         is_dir_path = dir_path? expanded_path
         file_path = File.join(@public_dir, expanded_path)
-        root_file = @public_dir + expanded_path + "index.html"
+        root_file = File.join(@public_dir, expanded_path, "index.html")
 
         if is_dir_path && File.exists? root_file
           return if etag(context, root_file)


### PR DESCRIPTION
`@public_dir` is becoming a `Path` in 0.33.0

The following change should be compatible with current Crystal version as well.

To update to 0.33.0 https://github.com/amberframework/micrate/pull/51 is also needed.