### PR TITLE
Quick fix for auth template, see issue #1174

### DIFF
--- a/src/amber/cli/templates/auth/src/controllers/{{name}}_controller.cr.ecr
+++ b/src/amber/cli/templates/auth/src/controllers/{{name}}_controller.cr.ecr
@@ -19,6 +19,9 @@ class <%= class_name %>Controller < ApplicationController
 
   def create
     <%= @name %> = <%= class_name %>.new <%= @name %>_params.validate!
+    pass = <%= @name %>_params.validate!["password"]
+    <%= @name %>.password = pass if pass
+
     if <%= @name %>.save
       session[:<%= @name %>_id] = <%= @name %>.id
       redirect_to "/", flash: {"success" => "Created <%= class_name %> successfully."}


### PR DESCRIPTION
Description of the Change
This PR is meant to be a quick fix for issue #1174
This isn't meant to be a permanent change. You can read my reasoning in the issue.

Alternate Designs
Any alternates would have to be in either Granite or Amber Router but i believe it's a granite issue as Param#validate! successfully returns the proper hash.

Benefits
Users of amberframework have access to a working auth template. Currently, the auth template builds but fails to actually work.

Possible Drawbacks
No drawbacks that i am aware of, minus being ugly. I would love if someone more experienced can let me know if i am wrong. But we still call Params#validate! to ensure the params are safe.