### PR TITLE
Bump Kilt to latest version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -28,7 +28,7 @@ dependencies:
 
   kilt:
     github: jeromegn/kilt
-    version: ~> 0.4.0
+    version: ~> 0.6.0
 
   liquid:
     github: TechMagister/liquid.cr

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -27,7 +27,7 @@ dependencies:
 
   quartz_mailer:
     github: amberframework/quartz-mailer
-    version: ~> 0.5.3
+    version: ~> 0.6.0
 
   jasper_helpers:
     github: amberframework/jasper-helpers


### PR DESCRIPTION
### Description of the Change

Update Kilt's version in the shard.yml

### Alternate Designs

None?

### Benefits

Added jbuilder to kilt engine. Currently, you cannot use jbuilder in an amber project due to dependency issues between kilt & amber.

### Possible Drawbacks

None?
