### PR TITLE
Replace Logger with Log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ services:
   - postgresql
   - redis-server
 
-addons:
-  postgresql: "10.1"
-
 cache:
   directories:
     - bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ services:
   - postgresql
   - redis-server
 
+addons:
+  postgresql: "10.1"
+
 cache:
   directories:
     - bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
   - TEST_SUITE=./spec/build_spec_granite.cr
   - TEST_SUITE=./spec/amber
 
+before-install:
+  - sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'password';"
+
 script:
   - bin/ameba
   - crystal tool format --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - TEST_SUITE=./spec/amber
 
 before-install:
-  - sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'password';"
+  - psql -U postgres -c "ALTER USER postgres WITH PASSWORD 'password';"
 
 script:
   - bin/ameba

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '2'
 services:
   db:
-    image: postgres:10.1
+    image: postgres:10.2
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_DB: test_app_development
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: test_app
   redis:
     image: redis:5.0-alpine
     command: redis-server
@@ -12,6 +13,7 @@ services:
     build: .
     working_dir: /opt/amber
     environment:
+      DATABASE_URL: 'postgres://postgres:password@db:5432/test_app'
       REDIS_URL: 'redis://redis:6379'
       AMBER_ENV: test
       CI: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '2'
 services:
   db:
-    image: postgres:10.2
+    image: postgres:10.1
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_DB=test_app_development
+      POSTGRES_USER: postgres
+      POSTGRES_DB: test_app_development
   redis:
     image: redis:5.0-alpine
     command: redis-server

--- a/shard.yml
+++ b/shard.yml
@@ -36,7 +36,7 @@ dependencies:
 
   micrate:
     github: amberframework/micrate
-    version: ~> 0.7.0
+    version: ~> 0.8.0
 
   pg:
     github: will/crystal-pg

--- a/spec/amber/amber_spec.cr
+++ b/spec/amber/amber_spec.cr
@@ -40,7 +40,7 @@ describe Amber do
           server.name = "Hello World App"
           server.port = 8080
           server.logger = Amber::Environment::Logger.new(STDOUT)
-          server.logger.level = ::Logger::INFO
+          server.logger.level = ::Log::Severity::Info
           server.logging.colorize = false
           server.logging.context = %w(request headers cookies session params)
           server.logging.filter = %w(password confirm_password)

--- a/spec/amber/cli/commands/database_spec.cr
+++ b/spec/amber/cli/commands/database_spec.cr
@@ -25,13 +25,13 @@ module Amber::CLI
         end
 
         it "creates the database when db migrate" do
-          scaffold_app("#{TESTING_APP}", "-d", "sqlite")
-          Amber::CLI.env = "development"
-          Amber::CLI.settings.logger = Amber::Environment::Logger.new(nil)
           env_yml = prepare_test_app
+          CLI.settings.database_url = env_yml["database_url"].to_s
+
           MainCommand.run ["generate", "model", "-y", "Post"]
           MainCommand.run ["db", "migrate"]
-          db_filename = env_yml["database_url"].to_s.gsub("sqlite3:", "")
+
+          db_filename = CLI.settings.database_url.to_s.gsub("sqlite3:", "")
           File.exists?(db_filename).should be_true
           File.info(db_filename).size.should_not eq 0
           cleanup
@@ -39,10 +39,13 @@ module Amber::CLI
 
         it "deletes the database when db drop" do
           env_yml = prepare_test_app
-          db_filename = env_yml["database_url"].to_s.gsub("sqlite3:", "")
+          CLI.settings.database_url = env_yml["database_url"].to_s
+
           MainCommand.run ["generate", "model", "-y", "Post"]
           MainCommand.run ["db", "migrate"]
           MainCommand.run ["db", "drop"]
+
+          db_filename = CLI.settings.database_url.gsub("sqlite3:", "")
           File.exists?(db_filename).should be_false
           cleanup
         end

--- a/spec/amber/cli/commands/database_spec.cr
+++ b/spec/amber/cli/commands/database_spec.cr
@@ -43,7 +43,7 @@ module Amber::CLI
           MainCommand.run ["generate", "model", "-y", "Post"]
           MainCommand.run ["db", "migrate"]
           MainCommand.run ["db", "drop"]
-          File.exists?(db_filename).should be_false
+          # File.exists?(db_filename).should be_false
           cleanup
         end
       end

--- a/spec/amber/cli/commands/database_spec.cr
+++ b/spec/amber/cli/commands/database_spec.cr
@@ -43,7 +43,7 @@ module Amber::CLI
           MainCommand.run ["generate", "model", "-y", "Post"]
           MainCommand.run ["db", "migrate"]
           MainCommand.run ["db", "drop"]
-          # File.exists?(db_filename).should be_false
+          File.exists?(db_filename).should be_false
           cleanup
         end
       end

--- a/spec/amber/environment/logger_spec.cr
+++ b/spec/amber/environment/logger_spec.cr
@@ -10,10 +10,10 @@ module Amber::Environment
           logger.debug "debug:skip"
           logger.info "info:show"
 
-          logger.level = Logger::DEBUG
+          logger.level = Log::Severity::Debug
           logger.debug "debug:show"
 
-          logger.level = Logger::WARN
+          logger.level = Log::Severity::Warning
           logger.debug "debug:skip:again"
           logger.info "info:skip"
           logger.error "error:show"

--- a/spec/amber/environment/logger_spec.cr
+++ b/spec/amber/environment/logger_spec.cr
@@ -5,6 +5,8 @@ module Amber::Environment
     describe "#log" do
       it "logs messages with progname" do
         IO.pipe do |r, w|
+          Colorize.enabled = false
+
           logger = Logger.new(w)
           logger.progname = "Amber"
           logger.debug "debug:skip"
@@ -18,9 +20,9 @@ module Amber::Environment
           logger.info "info:skip"
           logger.error "error:show"
 
-          #          r.gets.should match(/\e[96mAmber\e[0m | info:show/)
-          #          r.gets.should match(/\e[96mAmber\e[0m | debug:show/)
-          #          r.gets.should match(/\e[96mAmber\e[0m | error:show/)
+          r.gets.should match(/Amber | info:show/)
+          r.gets.should match(/Amber | debug:show/)
+          r.gets.should match(/Amber | error:show/)
         end
       end
     end

--- a/spec/amber/environment/logger_spec.cr
+++ b/spec/amber/environment/logger_spec.cr
@@ -18,9 +18,9 @@ module Amber::Environment
           logger.info "info:skip"
           logger.error "error:show"
 
-          r.gets.should match(/Amber\t| info:show/)
-          r.gets.should match(/Amber\t| debug:show/)
-          r.gets.should match(/Amber\t| error:show/)
+          #          r.gets.should match(/\e[96mAmber\e[0m | info:show/)
+          #          r.gets.should match(/\e[96mAmber\e[0m | debug:show/)
+          #          r.gets.should match(/\e[96mAmber\e[0m | error:show/)
         end
       end
     end

--- a/spec/amber/environment/settings_spec.cr
+++ b/spec/amber/environment/settings_spec.cr
@@ -9,7 +9,7 @@ module Amber::Environment
       settings = Amber::Settings.from_yaml(test_yaml)
 
       settings.logger.should be_a Logger
-      settings.logging.severity.should eq Logger::WARN
+      settings.logging.severity.should eq Log::Severity::Warning
       settings.logging.colorize.should eq true
       settings.database_url.should eq "mysql://root@localhost:3306/test_settings_test"
       settings.host.should eq "0.0.0.0"

--- a/spec/support/config/fake_env.yml
+++ b/spec/support/config/fake_env.yml
@@ -1,5 +1,5 @@
 logging:
-  severity: "warn"
+  severity: "warning"
   colorize: true
   filter:
     - password

--- a/spec/support/config/test.yml
+++ b/spec/support/config/test.yml
@@ -1,5 +1,5 @@
 logging:
-  severity: "warn"
+  severity: "warning"
   colorize: true
   filter:
     - password

--- a/spec/support/config/test_with_color.yml
+++ b/spec/support/config/test_with_color.yml
@@ -1,6 +1,6 @@
 secret_key_base: ox7cTo_408i4WZkKZ_5OZZtB5plqJYhD4rxrz2hriA4
 logging:
-  severity: "warn"
+  severity: "warning"
   colorize: true
   color: red
   filter:

--- a/spec/support/helpers/cli_helper.cr
+++ b/spec/support/helpers/cli_helper.cr
@@ -39,7 +39,7 @@ module CLIHelper
   def expected_db_url(db_key, env)
     case db_key
     when "pg"
-      "postgres://postgres:@localhost:5432/#{TEST_APP_NAME}_#{env}"
+      "postgres://postgres:password@localhost:5432/#{TEST_APP_NAME}_#{env}"
     when "mysql"
       "#{db_key}://root@localhost:3306/#{TEST_APP_NAME}_#{env}"
     else

--- a/spec/support/helpers/cli_helper.cr
+++ b/spec/support/helpers/cli_helper.cr
@@ -27,8 +27,8 @@ module CLIHelper
 
   def prepare_test_app
     cleanup
-    scaffold_app("#{TESTING_APP}", "-d", "sqlite")
-    environment_yml(ENV["AMBER_ENV"], "#{Dir.current}/config/environments/")
+    scaffold_app(TESTING_APP, "-d", "sqlite")
+    environment_yml(CURRENT_ENVIRONMENT, "#{Dir.current}/config/environments/")
   end
 
   def dirs(for app)

--- a/src/amber.cr
+++ b/src/amber.cr
@@ -1,5 +1,5 @@
 require "http"
-require "logger"
+require "log"
 require "json"
 require "colorize"
 require "random/secure"

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -5,9 +5,6 @@ require "sqlite3"
 
 module Amber::CLI
   CLI.logger.progname = "Database"
-  Micrate.logger = settings.logger
-  Micrate.logger.progname = "Database"
-  Micrate.logger.level = Logger::DEBUG
 
   class MainCommand < ::Cli::Supercommand
     command "db", aliased: "database"
@@ -58,12 +55,12 @@ module Amber::CLI
           Micrate::DB.connection_url = database_url
           case command
           when "drop"
-            Micrate.logger.info drop_database
+            Micrate.logger.info { drop_database }
           when "create"
-            Micrate.logger.info create_database
+            Micrate.logger.info { create_database }
           when "seed"
             Helpers.run("crystal db/seeds.cr", wait: true, shell: true)
-            Micrate.logger.info "Seeded database"
+            Micrate.logger.info { "Seeded database" }
           when "migrate"
             migrate
           when "rollback"

--- a/src/amber/cli/commands/database.cr
+++ b/src/amber/cli/commands/database.cr
@@ -55,12 +55,12 @@ module Amber::CLI
           Micrate::DB.connection_url = database_url
           case command
           when "drop"
-            Micrate.logger.info { drop_database }
+            drop_database
           when "create"
-            Micrate.logger.info { create_database }
+            create_database
           when "seed"
             Helpers.run("crystal db/seeds.cr", wait: true, shell: true)
-            Micrate.logger.info { "Seeded database" }
+            CLI.logger.info "Seeded database"
           when "migrate"
             migrate
           when "rollback"
@@ -90,26 +90,26 @@ module Amber::CLI
         if url.starts_with? "sqlite3:"
           path = url.gsub("sqlite3:", "")
           File.delete(path)
-          "Deleted file #{path}"
+          CLI.logger.info "Deleted file #{path}"
         else
           name = set_database_to_schema url
           Micrate::DB.connect do |db|
             db.exec "DROP DATABASE IF EXISTS #{name};"
           end
-          "Dropped database #{name}"
+          CLI.logger.info "Dropped database #{name}"
         end
       end
 
       private def create_database
         url = Micrate::DB.connection_url.to_s
         if url.starts_with? "sqlite3:"
-          CREATE_SQLITE_MESSAGE
+          CLI.logger.info CREATE_SQLITE_MESSAGE
         else
           name = set_database_to_schema url
           Micrate::DB.connect do |db|
             db.exec "CREATE DATABASE #{name};"
           end
-          "Created database #{name}"
+          CLI.logger.info "Created database #{name}"
         end
       end
 

--- a/src/amber/cli/commands/pipelines.cr
+++ b/src/amber/cli/commands/pipelines.cr
@@ -52,6 +52,7 @@ module Amber::CLI
         /x
 
       FAILED_TO_PARSE_ERROR = "Could not parse pipeline/plugs in #{ROUTES_PATH}"
+      UNRECOGNIZED_OPTION   = "Unrecognized option"
 
       command_name "pipelines"
 
@@ -78,6 +79,7 @@ module Amber::CLI
           when .starts_with?("pipeline") then set_pipe(line)
           when .starts_with?("plug")     then set_plug(line)
           else
+            raise BadRoutesException.new(UNRECOGNIZED_OPTION)
           end
         end
       end

--- a/src/amber/cli/commands/pipelines.cr
+++ b/src/amber/cli/commands/pipelines.cr
@@ -77,6 +77,7 @@ module Amber::CLI
           case line
           when .starts_with?("pipeline") then set_pipe(line)
           when .starts_with?("plug")     then set_plug(line)
+          else
           end
         end
       end

--- a/src/amber/cli/commands/pipelines.cr
+++ b/src/amber/cli/commands/pipelines.cr
@@ -79,7 +79,7 @@ module Amber::CLI
           when .starts_with?("pipeline") then set_pipe(line)
           when .starts_with?("plug")     then set_plug(line)
           else
-            raise BadRoutesException.new(UNRECOGNIZED_OPTION)
+            # skip line
           end
         end
       end

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -82,6 +82,7 @@ module Amber::CLI
                 next unless filter_actions.includes?(action)
               when "except"
                 next if filter_actions.includes?(action)
+              else
               end
               build_route(
                 verb: verb, controller: route_match[3]?, action: action,

--- a/src/amber/cli/commands/routes.cr
+++ b/src/amber/cli/commands/routes.cr
@@ -16,6 +16,7 @@ module Amber::CLI
         "post" => ["create"], "patch" => ["update"],
         "put" => ["update"], "delete" => ["destroy"],
       }
+      FILTER_NOT_RECOGNIZED = "Filter not recognized"
 
       command_name "routes"
       getter routes = Array(Hash(String, String)).new
@@ -83,6 +84,7 @@ module Amber::CLI
               when "except"
                 next if filter_actions.includes?(action)
               else
+                raise Exception.new(FILTER_NOT_RECOGNIZED)
               end
               build_route(
                 verb: verb, controller: route_match[3]?, action: action,

--- a/src/amber/cli/templates/app/config/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/database.cr.ecr
@@ -1,3 +1,3 @@
 require "granite/adapter/<%= @database %>"
 
-Granite::Connections << Granite::Adapter::<%= @database.capitalize %>.new(name: "<%= @database %>", url: Amber.settings.database_url)
+Granite::Connections << Granite::Adapter::<%= @database.capitalize %>.new(name: "<%= @database %>", url: ENV["DATABASE_URL"]? || Amber.settings.database_url)

--- a/src/amber/cli/templates/app/config/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/database.cr.ecr
@@ -1,5 +1,3 @@
 require "granite/adapter/<%= @database %>"
 
 Granite::Connections << Granite::Adapter::<%= @database.capitalize %>.new(name: "<%= @database %>", url: Amber.settings.database_url)
-Granite.settings.logger = Amber.settings.logger.dup
-Granite.settings.logger.not_nil!.progname = "Granite"

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -28,8 +28,8 @@ database_url: mysql://root@localhost:3306/<%= database_name %>_development
 database_url: postgres://postgres:password@localhost:5432/<%= database_name %>_development
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>_development.db
-<% else -%>
-<% end -%>
+<% else
+end -%>
 auto_reload: true
 
 session:

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -25,7 +25,7 @@ redis_url: "redis://localhost:6379"
 when "mysql" -%>
 database_url: mysql://root@localhost:3306/<%= database_name %>_development
 <% when "pg" -%>
-database_url: postgres://postgres:@localhost:5432/<%= database_name %>_development
+database_url: postgres://postgres:password@localhost:5432/<%= database_name %>_development
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>_development.db
 <% else -%>

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -28,6 +28,7 @@ database_url: mysql://root@localhost:3306/<%= database_name %>_development
 database_url: postgres://postgres:@localhost:5432/<%= database_name %>_development
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>_development.db
+<% else -%>
 <% end -%>
 auto_reload: true
 

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -28,6 +28,7 @@ database_url: mysql://root@localhost:3306/<%= database_name %>
 database_url: postgres://postgres:@localhost:5432/<%= database_name %>
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>.db
+<% else -%>
 <% end -%>
 auto_reload: false
 

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -25,7 +25,7 @@ redis_url: "redis://localhost:6379"
 when "mysql" -%>
 database_url: mysql://root@localhost:3306/<%= database_name %>
 <% when "pg" -%>
-database_url: postgres://postgres:@localhost:5432/<%= database_name %>
+database_url: postgres://postgres:password@localhost:5432/<%= database_name %>
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>.db
 <% else -%>

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -28,8 +28,8 @@ database_url: mysql://root@localhost:3306/<%= database_name %>
 database_url: postgres://postgres:password@localhost:5432/<%= database_name %>
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>.db
-<% else -%>
-<% end -%>
+<% else
+end -%>
 auto_reload: false
 
 session:

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -25,7 +25,7 @@ redis_url: "redis://localhost:6379"
 when "mysql" -%>
 database_url: mysql://root@localhost:3306/<%= database_name %>_test
 <% when "pg" -%>
-database_url: postgres://postgres:@localhost:5432/<%= database_name %>_test
+database_url: postgres://postgres:password@localhost:5432/<%= database_name %>_test
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>_test.db
 <% else -%>

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -28,6 +28,7 @@ database_url: mysql://root@localhost:3306/<%= database_name %>_test
 database_url: postgres://postgres:@localhost:5432/<%= database_name %>_test
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>_test.db
+<% else -%>
 <% end -%>
 auto_reload: false
 

--- a/src/amber/cli/templates/app/config/environments/test.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/test.yml.ecr
@@ -28,8 +28,8 @@ database_url: mysql://root@localhost:3306/<%= database_name %>_test
 database_url: postgres://postgres:password@localhost:5432/<%= database_name %>_test
 <% when "sqlite" -%>
 database_url: sqlite3:./db/<%= database_name %>_test.db
-<% else -%>
-<% end -%>
+<% else
+end -%>
 auto_reload: false
 
 session:

--- a/src/amber/cli/templates/app/config/initializers/mailer.cr
+++ b/src/amber/cli/templates/app/config/initializers/mailer.cr
@@ -10,9 +10,6 @@ Quartz.config do |c|
 
   c.use_tls = !c.password.blank?
   c.use_authentication = !c.password.blank?
-
-  c.logger = Amber.settings.logger.dup
-  c.logger.progname = "Email"
 end
 
 require "../../src/mailers/application_mailer"

--- a/src/amber/cli/templates/app/config/settings.cr.ecr
+++ b/src/amber/cli/templates/app/config/settings.cr.ecr
@@ -21,8 +21,8 @@ Amber::Server.configure do |settings|
   # Defaults to true.
   #
   # Log Level defines the verbosity of the Amber logger. This option defaults to
-  # debug for all environments. The available log levels are: debug, info, warn,
-  # error, fatal, and unknown.
+  # debug for all environments. The available log levels are: debug, verbose, info, warning,
+  # error, and fatal.
   #
   # settings.logging.colorize = true
   # settings.logging.severity = "debug"

--- a/src/amber/cli/templates/app/config/webpack/common.js
+++ b/src/amber/cli/templates/app/config/webpack/common.js
@@ -9,7 +9,7 @@ let config = {
     main: path.resolve(__dirname, 'entry.js')
   },
   output: {
-    filename: '[name].[contenthash].js',
+    filename: '[name].bundle.js',
     path: path.resolve(__dirname, '../../public/dist'),
     publicPath: '/dist'
   },
@@ -57,7 +57,7 @@ let config = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash].css'
+      filename: '[name].bundle.css'
     }),
     new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({

--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -1,5 +1,5 @@
 <% if @database == "pg"
-     @db_url = "postgres://admin:password@db:5432/#{database_name}_development"
+     @db_url = "postgres://postgres:password@db:5432/#{database_name}_development"
      @wait_for = "while ! nc -q 1 db 5432 </dev/null; do sleep 1; done && "
    elsif @database == "mysql"
      @db_url = "mysql://admin:password@db:3306/#{database_name}_development"
@@ -42,7 +42,7 @@ services:
   db:
     image: postgres
     environment:
-      POSTGRES_USER: admin
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
       POSTGRES_DB: <%= "#{database_name}_development" %>
     volumes:

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -18,16 +18,18 @@ targets:
 dependencies:
   amber:
     github: amberframework/amber
-    branch: master
+    branch: replace-logger-with-log
     #version: <%= Amber::VERSION %>
 
   granite:
     github: amberframework/granite
-    version: ~> 0.20.0
+    branch: master
+    #version: ~> 0.20.0
 
   quartz_mailer:
     github: amberframework/quartz-mailer
-    version: ~> 0.6.0
+    branch: replace-logger-with-log
+    #version: ~> 0.6.0
 
   jasper_helpers:
     github: amberframework/jasper-helpers

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -45,6 +45,7 @@ dependencies:
   sqlite3:
     github: crystal-lang/crystal-sqlite3
     version: ~> 0.16.0
+<% else -%>
 <% end -%>
 
   citrine-i18n:

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -18,7 +18,7 @@ targets:
 dependencies:
   amber:
     github: amberframework/amber
-    branch: replace-logger-with-log
+    branch: master
     #version: <%= Amber::VERSION %>
 
   granite:

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -23,13 +23,11 @@ dependencies:
 
   granite:
     github: amberframework/granite
-    branch: master
-    #version: ~> 0.20.0
+    version: ~> 0.21.0
 
   quartz_mailer:
     github: amberframework/quartz-mailer
-    branch: replace-logger-with-log
-    #version: ~> 0.6.0
+    version: ~> 0.7.0
 
   jasper_helpers:
     github: amberframework/jasper-helpers

--- a/src/amber/cli/templates/app/spec/spec_helper.cr.ecr
+++ b/src/amber/cli/templates/app/spec/spec_helper.cr.ecr
@@ -6,7 +6,7 @@ require "garnet_spec"
 
 require "../config/application"
 
-Micrate::DB.connection_url = ENV["DATABASE_URL"]? || Amber.settings.database_url
+# Micrate::DB.connection_url = ENV["DATABASE_URL"]? || Amber.settings.database_url
 
 # Automatically run migrations on the test database
-Micrate::Cli.run_up
+# Micrate::Cli.run_up

--- a/src/amber/cli/templates/app/spec/spec_helper.cr.ecr
+++ b/src/amber/cli/templates/app/spec/spec_helper.cr.ecr
@@ -6,7 +6,7 @@ require "garnet_spec"
 
 require "../config/application"
 
-Micrate::DB.connection_url = Amber.settings.database_url
+Micrate::DB.connection_url = ENV["DATABASE_URL"]? || Amber.settings.database_url
 
 # Automatically run migrations on the test database
 Micrate::Cli.run_up

--- a/src/amber/cli/templates/app/spec/spec_helper.cr.ecr
+++ b/src/amber/cli/templates/app/spec/spec_helper.cr.ecr
@@ -10,7 +10,3 @@ Micrate::DB.connection_url = Amber.settings.database_url
 
 # Automatically run migrations on the test database
 Micrate::Cli.run_up
-<%- if @model == "granite" -%>
-# Disable Granite logs in tests
-Granite.settings.logger = Amber.settings.logger.dup
-<%- end -%>

--- a/src/amber/environment/logger.cr
+++ b/src/amber/environment/logger.cr
@@ -1,19 +1,44 @@
-require "logger"
+require "log"
 require "colorize"
 
 module Amber::Environment
-  class Logger < ::Logger
+  class Logger
     property color : Symbol = :light_cyan
+    property level : (Log::Severity | String)
+    property progname : String
+    property formatter : Log::Formatter? = nil
 
-    {% for name in Severity.constants %}
+    def initialize(@io : IO?,
+                   @level = ENV.fetch("CRYSTAL_LOG_LEVEL", "INFO"),
+                   @progname = ENV.fetch("CRYSTAL_LOG_SOURCES", ""),
+                   @formatter = nil)
+      builder : Log::Builder = Log.builder
+      backend = Log::IOBackend.new(@io || STDOUT)
+      backend.formatter = @formatter || default_format
+
+      builder.clear
+      level = Log::Severity.parse(@level.to_s)
+      progname.split(',', remove_empty: false) do |source|
+        source = source.strip
+        builder.bind(source, level, backend)
+      end
+    end
+
+    def default_format
+      Log::Formatter.new do |entry, io|
+        io << entry.timestamp.to_s("%I:%M:%S")
+        io << " "
+        io << entry.source
+        io << " (#{entry.severity})" if entry.severity > Log::Severity::Debug
+        io << " "
+        io << entry.message
+      end
+    end
+
+    {% for name in ["debug", "verbose", "info", "warn", "error", "fatal"] %}
       def {{name.id.downcase}}(message, progname = progname, color = @color)
-        log(Severity::{{name.id}}, message, progname.ljust(10), color)
+        Log.{{name.id.downcase}} { "#{(progname || @progname).colorize(color).to_s} | #{message}"  }
       end
     {% end %}
-
-    def log(severity, message, progname = nil, color = @color)
-      return if severity < level || !@io
-      write(severity, Time.utc, "#{progname || @progname} |".colorize(color).to_s, message)
-    end
   end
 end

--- a/src/amber/environment/logger_builder.cr
+++ b/src/amber/environment/logger_builder.cr
@@ -12,14 +12,6 @@ module Amber::Environment
       @logger.level = logging.severity
       @logger.progname = "Server"
       @logger.color = logging.color
-      @logger.formatter = Logger::Formatter.new do |severity, datetime, progname, message, io|
-        io << datetime.to_s("%I:%M:%S")
-        io << " "
-        io << progname
-        io << " (#{severity})" if severity > Logger::DEBUG
-        io << " "
-        io << message
-      end
     end
   end
 end

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -6,7 +6,7 @@ module Amber::Environment
       "debug":   Log::Severity::Debug,
       "verbose": Log::Severity::Verbose,
       "info":    Log::Severity::Info,
-      "warn":    Log::Severity::Warning,
+      "warning": Log::Severity::Warning,
       "error":   Log::Severity::Error,
       "fatal":   Log::Severity::Fatal,
     }

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -2,15 +2,6 @@ module Amber::Environment
   class Logging
     alias OptionsType = Hash(String, String | Bool | Array(String))
 
-    SEVERITY_MAP = {
-      "debug":   Log::Severity::Debug,
-      "verbose": Log::Severity::Verbose,
-      "info":    Log::Severity::Info,
-      "warning": Log::Severity::Warning,
-      "error":   Log::Severity::Error,
-      "fatal":   Log::Severity::Fatal,
-    }
-
     COLOR_MAP = {
       "black":         :black,
       "red":           :red,
@@ -58,7 +49,7 @@ module Amber::Environment
     end
 
     def severity : Log::Severity
-      SEVERITY_MAP[@severity]
+      Log::Severity.parse @severity
     end
 
     def color : Symbol

--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -3,12 +3,12 @@ module Amber::Environment
     alias OptionsType = Hash(String, String | Bool | Array(String))
 
     SEVERITY_MAP = {
-      "debug":   Logger::DEBUG,
-      "info":    Logger::INFO,
-      "warn":    Logger::WARN,
-      "error":   Logger::ERROR,
-      "fatal":   Logger::FATAL,
-      "unknown": Logger::UNKNOWN,
+      "debug":   Log::Severity::Debug,
+      "verbose": Log::Severity::Verbose,
+      "info":    Log::Severity::Info,
+      "warn":    Log::Severity::Warning,
+      "error":   Log::Severity::Error,
+      "fatal":   Log::Severity::Fatal,
     }
 
     COLOR_MAP = {
@@ -57,7 +57,7 @@ module Amber::Environment
       @context = logging["context"].as(Array(String))
     end
 
-    def severity : Logger::Severity
+    def severity : Log::Severity
       SEVERITY_MAP[@severity]
     end
 


### PR DESCRIPTION
### Description of the Change

Replace Logger with Log to remove deprecated warning

To eliminate all deprecation warnings, Granite and Quartz Mailer will need to be released and shards template updated.

### Benefits

Removes the deprecated warning.
