### PR TITLE
revert default logging severity

### DIFF
--- a/src/amber/environment/logging.cr
+++ b/src/amber/environment/logging.cr
@@ -22,6 +22,7 @@ module Amber::Environment
     }
 
     DEFAULTS = {
+      "severity" => "debug",
       "colorize" => true,
       "color"    => "light_cyan",
       "filter"   => ["password", "confirm_password"],


### PR DESCRIPTION
### Description of the Change

This PR reverts the default logging severity which was removed in #1208.

### Alternate Designs

No

### Benefits

The server can run without the configuration file.
Without this line and the configuration file, it fails with `Unhandled exception: Missing hash key: "severity" (KeyError)`.
And this is annoying when testing my shards that depend on Amber.

### Possible Drawbacks

No