### PR TITLE
Uses docker in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: xenial
 sudo: required
-language: crystal
 
 services:
   - postgresql
   - redis-server
+  - docker
 
 cache:
   directories:
@@ -20,9 +20,10 @@ before-install:
   - psql -U postgres -c "ALTER USER postgres WITH PASSWORD 'password';"
 
 script:
-  - bin/ameba
-  - crystal tool format --check
-  - crystal spec $TEST_SUITE
+  - docker build -t amber-test .
+  - docker run --rm amber-test /opt/amber/bin/ameba
+  - docker run --rm amber-test crystal tool format --check
+  - docker run --rm --network=host amber-test crystal spec $TEST_SUITE
 
 notifications:
   webhooks:


### PR DESCRIPTION
### Description of the Change

This change runs CI in Travis using docker. Unfortunately, there is a limitation in Travis that does not allow the pinning of a crystal version (it defaults to latest). This causes a mismatch in the version of crystal being run in CI vs the version of crystal that amber is expecting.

### Alternate Designs

An alternate design was to use docker-compose instead of building the image and using a bunch of `docker run` commands. I opted not to use docker-compose, as some of the configurations in `spec/support/config` seemed like they were hardcoding the redis_url, and passing `REDIS_URL` within the docker-compose file did not seem to overwrite it. This caused tests to not be able to connect to Redis.

### Benefits

Running the same version of crystal in CI that amber expects helps build more confidence in the test suite.

### Possible Drawbacks

A slight increase in build time.
