### PR TITLE
Added rails-like locals functionality for partials

### DIFF
--- a/spec/amber/controller/render_spec.cr
+++ b/spec/amber/controller/render_spec.cr
@@ -17,6 +17,10 @@ module Amber::Controller
         RenderController.new(context).render_partial.should eq partial_only
       end
 
+      it "renders partial with locals" do
+        RenderController.new(context).render_partial_with_locals.should eq partial_only
+      end
+
       it "renders flash message" do
         RenderController.new(context).render_with_flash
       end

--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -93,6 +93,10 @@ class RenderController < Amber::Controller::Base
     render(path: "spec/support/sample/views", partial: "test/_test.slang")
   end
 
+  def render_partial_with_locals
+    render(path: "spec/support/sample/views", partial: "test/_test_with_locals.slang", locals: {message: "Hello World"})
+  end
+
   def render_with_layout
     render("test/test.slang", layout: "layout.slang", path: "spec/support/sample/views", folder: "./")
   end

--- a/spec/support/sample/views/test/_test_with_locals.slang
+++ b/spec/support/sample/views/test/_test_with_locals.slang
@@ -1,0 +1,2 @@
+h1 = message
+p I am glad you came

--- a/src/amber/controller/helpers/render.cr
+++ b/src/amber/controller/helpers/render.cr
@@ -7,12 +7,10 @@ module Amber::Controller::Helpers
         raise "Template or partial required!"
       {% end %}
 
-      {{ obj = locals }}
-
       # Convert locals key/values into variables
-      {% if obj %}
-        {% for i in obj %}
-          {{i}} = {{ obj[i] }}
+      {% if locals %}
+        {% for i in locals %}
+          {{i}} = {{ locals[i] }}
         {% end %}
       {% end %}
 

--- a/src/amber/controller/helpers/render.cr
+++ b/src/amber/controller/helpers/render.cr
@@ -2,9 +2,18 @@ module Amber::Controller::Helpers
   module Render
     LAYOUT = "application.slang"
 
-    macro render(template = nil, layout = true, partial = nil, path = "src/views", folder = __FILE__)
+    macro render(template = nil, layout = true, partial = nil, path = "src/views", folder = __FILE__, locals = nil)
       {% if !(template || partial) %}
         raise "Template or partial required!"
+      {% end %}
+
+      {{ obj = locals }}
+
+      # Convert locals key/values into variables
+      {% if obj %}
+        {% for i in obj %}
+          {{i}} = {{ obj[i] }}
+        {% end %}
       {% end %}
 
       {{ filename = template || partial }}


### PR DESCRIPTION
### Description of the Change

Added a simple way to pass locals to partials. I know all variables are accessible in partials. Sometimes you want to rename those variables so the context makes more sense in said partial.

Usage in a view would be:
```crystal
render(partial: "people.ecr", locals: {name: user.name, email: user.email, age: user.age})

# In people.ecr
<h1>Hello, <%= name %><h1/>
```

### Alternate Designs

Currently the alternative is using the variables by the name they were assigned in the controller. 

### Benefits

Allows users to rename variables without actually having to initialize them in a controller before rendering a partial. 

### Possible Drawbacks

None that i am aware of. I didn't write any specs for it though. I could do so if requested!
