### PR TITLE
Support granite migrations

### DIFF
--- a/src/amber/cli/templates/app/config/database.cr.ecr
+++ b/src/amber/cli/templates/app/config/database.cr.ecr
@@ -1,3 +1,4 @@
+require "amber"
 require "granite/adapter/<%= @database %>"
 
-Granite::Connections << Granite::Adapter::<%= @database.capitalize %>.new(name: "<%= @database %>", url: ENV["DATABASE_URL"]? || Amber.settings.database_url)
+Granite::Connections << Granite::Adapter::<%= @database.capitalize %>.new(name: "<%= @database %>", url: Amber.settings.database_url)

--- a/src/amber/cli/templates/app/config/settings.cr.ecr
+++ b/src/amber/cli/templates/app/config/settings.cr.ecr
@@ -40,7 +40,7 @@ Amber::Server.configure do |settings|
   # deploying Amber to a PAAS and likely the assigned server IP is either
   # known or unknown. Defaults to an environment variable HOST
   #
-  # settings.host = ENV["HOST"] if ENV["HOST"]?
+  settings.host = ENV["HOST"] if ENV["HOST"]?
   #
   #
   # Port Reuse: Amber supports clustering mode which allows to spin
@@ -68,7 +68,7 @@ Amber::Server.configure do |settings|
   # Redis URL: Redis is an in memory key value storage. Amber utilizes redis as
   # a storing option for session information.
   #
-  # settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?
+  settings.redis_url = ENV["REDIS_URL"] if ENV["REDIS_URL"]?
   #
   #
   # Database URL: This is the database connection string or data file url.
@@ -76,7 +76,7 @@ Amber::Server.configure do |settings|
   # database or the data file. Defaults to the database provider you chose at
   # at app generation.
   #
-  # settings.database_url = ENV["DATABASE_URL"] if ENV["DATABASE_URL"]?
+  settings.database_url = ENV["DATABASE_URL"] if ENV["DATABASE_URL"]?
   #
   #
   # SSL Key File: The private key is a text file used initially to generate a

--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -17,8 +17,8 @@ services:
     image: <%= @name %>
     command: amber watch
     environment:
-    DATABASE_URL: <%= @db_url %>
-    REDIS_URL: redis://cache:6379
+      DATABASE_URL: <%= @db_url %>
+      REDIS_URL: redis://cache:6379
     ports:
       - 3000:3000
     links:

--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -17,11 +17,13 @@ services:
     image: <%= @name %>
     command: amber watch
     environment:
-      DATABASE_URL: <%= @db_url %>
+    DATABASE_URL: <%= @db_url %>
+    REDIS_URL: redis://cache:6379
     ports:
       - 3000:3000
     links:
       - db
+      - cache
     volumes:
     - .:/app
     - nodes:/app/node_modules
@@ -65,7 +67,14 @@ services:
     - db:/app/local/db
 <% end -%>
 
+  cache:
+    image: redis:5.0-alpine
+    command: redis-server
+    volumes:
+      - cache:/var/lib/redis/data
+
 volumes:
-  db:
   nodes:
   shards:
+  db:
+  cache:

--- a/src/amber/cli/templates/auth/db/+seeds.cr.ecr
+++ b/src/amber/cli/templates/auth/db/+seeds.cr.ecr
@@ -1,3 +1,3 @@
 # Test user for auth
 
-<%= class_name %>.create(email: "admin@example.com", password: "password")
+# <%= class_name %>.create(email: "admin@example.com", password: "password")

--- a/src/amber/cli/templates/auth/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
@@ -1,3 +1,5 @@
+require "granite/migration"
+
 class Create<%= class_name %> < Granite::Migration
   connection :<%= config.database %>
 

--- a/src/amber/cli/templates/auth/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
@@ -1,0 +1,23 @@
+class Create<%= class_name %> < Granite::Migration
+  connection :<%= config.database %>
+
+  def up
+    create_table :<%= table_name %> do |t|
+      t.primary :id
+<% @fields.reject{|f| f.hidden }.each do |field| -%>
+      t.<%= field.type %> :<%= "#{field.name}#{field.reference? ? "_id" : ""}" %>
+<% end -%>
+<% if config.database != "sqlite" -%>
+      t.timestamps
+<% end -%>
+    end
+
+<% @fields.select{|f| f.reference? }.each do |field| -%>
+    create_index :<%= table_name %>, :<%= "#{field.name}_id" %>
+<% end -%>
+  end
+
+  def down
+    drop_table :<%= table_name %>
+  end
+end

--- a/src/amber/cli/templates/auth/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
+++ b/src/amber/cli/templates/auth/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
@@ -1,6 +1,0 @@
--- +micrate Up
-<%= create_table_sql %>
-<%= create_index_for_reference_fields_sql %>
-
--- +micrate Down
-<%= drop_table_sql %>

--- a/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/auth/src/models/{{name}}.cr.ecr
@@ -2,13 +2,14 @@ require "crypto/bcrypt/password"
 
 class <%= class_name %> < Granite::Base
   include Crypto
-  connection <%= config.database %>
-  <%= "table #{table_name}" %>
+  connection :<%= config.database %>
+  table :<%= table_name %>
 
   column id : Int64, primary: true
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
   column <%= field.name %> : <%= field.cr_type %>?
 <% end -%>
+
 <% if config.database != "sqlite" -%>
   timestamps
 <% end -%>

--- a/src/amber/cli/templates/migration/empty/db/migrations/{{timestamp}}_{{name}}.cr.ecr
+++ b/src/amber/cli/templates/migration/empty/db/migrations/{{timestamp}}_{{name}}.cr.ecr
@@ -1,3 +1,5 @@
+require "granite/migration"
+
 class <%= class_name %> < Granite::Migration
   connection :<%= config.database %>
 

--- a/src/amber/cli/templates/migration/empty/db/migrations/{{timestamp}}_{{name}}.cr.ecr
+++ b/src/amber/cli/templates/migration/empty/db/migrations/{{timestamp}}_{{name}}.cr.ecr
@@ -1,0 +1,9 @@
+class <%= class_name %> < Granite::Migration
+  connection :<%= config.database %>
+
+  def up
+  end
+
+  def down
+  end
+end

--- a/src/amber/cli/templates/migration/empty/db/migrations/{{timestamp}}_{{name}}.sql.ecr
+++ b/src/amber/cli/templates/migration/empty/db/migrations/{{timestamp}}_{{name}}.sql.ecr
@@ -1,5 +1,0 @@
--- +micrate Up
--- SQL in section 'Up' is executed when this migration is applied
-
--- +micrate Down
--- SQL section 'Down' is executed when this migration is rolled back

--- a/src/amber/cli/templates/migration/full/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
+++ b/src/amber/cli/templates/migration/full/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
@@ -1,3 +1,5 @@
+require "granite/migration"
+
 class Create<%= class_name %> < Granite::Migration
   connection :<%= config.database %>
 

--- a/src/amber/cli/templates/migration/full/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
+++ b/src/amber/cli/templates/migration/full/db/migrations/{{timestamp}}_create_{{name}}.cr.ecr
@@ -1,0 +1,23 @@
+class Create<%= class_name %> < Granite::Migration
+  connection :<%= config.database %>
+
+  def up
+    create_table :<%= table_name %> do |t|
+      t.primary :id
+<% @fields.reject{|f| f.hidden }.each do |field| -%>
+      t.<%= field.type %> :<%= "#{field.name}#{field.reference? ? "_id" : ""}" %>
+<% end -%>
+<% if config.database != "sqlite" -%>
+      t.timestamps
+<% end -%>
+    end
+
+<% @fields.select{|f| f.reference? }.each do |field| -%>
+    create_index :<%= table_name %>, :<%= "#{field.name}_id" %>
+<% end -%>
+  end
+
+  def down
+    drop_table :<%= table_name %>
+  end
+end

--- a/src/amber/cli/templates/migration/full/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
+++ b/src/amber/cli/templates/migration/full/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
@@ -1,6 +1,0 @@
--- +micrate Up
-<%= create_table_sql %>
-<%= create_index_for_reference_fields_sql %>
-
--- +micrate Down
-<%= drop_table_sql %>

--- a/src/amber/cli/templates/model/src/models/{{name}}.cr.ecr
+++ b/src/amber/cli/templates/model/src/models/{{name}}.cr.ecr
@@ -1,7 +1,8 @@
 class <%= class_name %> < Granite::Base
-  connection <%= config.database %>
-  <%= "table #{table_name}" %>
-<% @fields.select{|f| f.reference? }.each do |field| %>
+  connection :<%= config.database %>
+  table :<%= table_name %>
+
+<% @fields.select{|f| f.reference? }.each do |field| -%>
   belongs_to :<%= field.name %>
 <% end -%>
 
@@ -9,6 +10,7 @@ class <%= class_name %> < Granite::Base
 <% @fields.reject{|f| f.hidden || f.reference? }.each do |field| -%>
   column <%= field.name %> : <%= field.cr_type %>?
 <% end -%>
+
 <% if config.database != "sqlite" -%>
   timestamps
 <% end -%>


### PR DESCRIPTION
### Description of the Change

This change adds support for the new granite migrations DSL that is similar to Rails.  This replaces the template generators to use the new syntax.

### Alternate Designs

Keep the existing SQL generators

### Benefits

One of the most requested features is support for a clean DSL for migrations.  This will make Rails developers feel right at home using Amber.

### Possible Drawbacks

The current implementation does not have all the field options yet.  A work around is to use `t.custom` and use SQL syntax for the field for now.
