### PR TITLE
[CORS]  Process Requests As Normal for Non CORS

### DIFF
--- a/spec/amber/pipes/cors_spec.cr
+++ b/spec/amber/pipes/cors_spec.cr
@@ -8,10 +8,10 @@ module Amber::Pipe
       assert_cors_success(context)
     end
 
-    it "does not return CORS headers if Origin header not present" do
+    it "process requests as normal for non CORS requests" do
       context = cors_context("GET")
       cors_add_next(CORS.new).call(context)
-      assert_cors_failure context
+      assert_non_cors_request context
     end
 
     it "supports OPTIONS request" do

--- a/spec/support/helpers/router_helper.cr
+++ b/spec/support/helpers/router_helper.cr
@@ -60,6 +60,12 @@ module RouterHelper
     origin_header.should_not be_nil
   end
 
+  def assert_non_cors_request(context)
+    origin_header = context.response.headers["Access-Control-Allow-Origin"]?
+    context.response.status_code.should eq 200
+    origin_header.should be_nil
+  end
+
   def assert_cors_failure(context)
     origin_header = context.response.headers["Access-Control-Allow-Origin"]?
     context.response.status_code.should eq 403

--- a/src/amber/pipes/cors.cr
+++ b/src/amber/pipes/cors.cr
@@ -136,7 +136,7 @@ module Amber
         @origins.includes? "*"
       end
 
-      def origin_header?(request)
+      protected def origin_header?(request)
         @request_origin = request.headers[Headers::ORIGIN]? || request.headers[Headers::X_ORIGIN]?
       end
     end

--- a/src/amber/pipes/cors.cr
+++ b/src/amber/pipes/cors.cr
@@ -38,6 +38,8 @@ module Amber
       end
 
       def call(context : HTTP::Server::Context)
+        return call_next(context) unless @origin.origin_header?(context.request)
+
         if @origin.match?(context.request)
           is_preflight_request = preflight?(context)
           put_expose_header(context.response)
@@ -134,7 +136,7 @@ module Amber
         @origins.includes? "*"
       end
 
-      private def origin_header?(request)
+      def origin_header?(request)
         @request_origin = request.headers[Headers::ORIGIN]? || request.headers[Headers::X_ORIGIN]?
       end
     end


### PR DESCRIPTION
**Issue:** https://github.com/amberframework/amber/issues/1224

### Description of the Change

When using CORS pipe all requests are being validated as CORS.

If validation fails 403 forbidden is thrown

### Changes

- If origin header is not present process the request as a normal one

### Side Effects

- Non CORS  requests are processed requests as normal when CORS handler is present
