### PR TITLE
1221 configurable static response headers

### DIFF
--- a/spec/amber/environment/settings_spec.cr
+++ b/spec/amber/environment/settings_spec.cr
@@ -35,7 +35,7 @@ module Amber::Environment
 
     describe "#static_file_server" do
       it "sets default headers value as empty map" do
-        test_yaml = File.read(File.expand_path("./spec/support/config/test.yml"))
+        test_yaml = File.read(File.expand_path("./spec/support/config/development.yml"))
         settings = Amber::Settings.from_yaml(test_yaml)
         settings.pipes.dig?("static", "headers").should eq({} of String => Amber::Settings::SettingValue)
       end

--- a/spec/amber/environment/settings_spec.cr
+++ b/spec/amber/environment/settings_spec.cr
@@ -32,5 +32,19 @@ module Amber::Environment
       settings = Amber::Settings.from_yaml(color_yaml)
       settings.logging.color.should eq :red
     end
+
+    describe "#static_file_server" do
+      it "sets default headers value as empty map" do
+        test_yaml = File.read(File.expand_path("./spec/support/config/test.yml"))
+        settings = Amber::Settings.from_yaml(test_yaml)
+        settings.public_file_server["headers"].should eq({} of String => String)
+      end
+
+      it "sets header file settings from environment yaml file" do
+        test_yaml = File.read(File.expand_path("./spec/support/config/with_public_file_server.yml"))
+        settings = Amber::Settings.from_yaml(test_yaml)
+        settings.public_file_server["headers"].should eq({"Cache-Control" => "private, max-age=7200"})
+      end
+    end
   end
 end

--- a/spec/amber/environment/settings_spec.cr
+++ b/spec/amber/environment/settings_spec.cr
@@ -37,13 +37,13 @@ module Amber::Environment
       it "sets default headers value as empty map" do
         test_yaml = File.read(File.expand_path("./spec/support/config/test.yml"))
         settings = Amber::Settings.from_yaml(test_yaml)
-        settings.public_file_server["headers"].should eq({} of String => String)
+        settings.pipes.dig?("static", "headers").should eq({} of String => Amber::Settings::SettingValue)
       end
 
       it "sets header file settings from environment yaml file" do
-        test_yaml = File.read(File.expand_path("./spec/support/config/with_public_file_server.yml"))
+        test_yaml = File.read(File.expand_path("./spec/support/config/with_static_pipe_settings.yml"))
         settings = Amber::Settings.from_yaml(test_yaml)
-        settings.public_file_server["headers"].should eq({"Cache-Control" => "private, max-age=7200"})
+        settings.pipes.dig?("static", "headers").should eq({"Cache-Control" => "private, max-age=7200"})
       end
     end
   end

--- a/spec/amber/pipes/static_spec.cr
+++ b/spec/amber/pipes/static_spec.cr
@@ -57,6 +57,17 @@ module Amber
         response_true.body.should match(/index/)
         response_false.status_code.should eq 404
       end
+
+      it "sets default response headers" do
+        request = HTTP::Request.new("GET", "/index.html")
+        static = Static.new PUBLIC_PATH
+
+        response = create_request_and_return_io(static, request)
+
+        response.headers["Cache-Control"].should eq "private, max-age=3600"
+        response.headers["Accept-Ranges"].should eq "bytes"
+        response.headers["X-Content-Type-Options"].should eq "nosniff"
+      end
     end
   end
 end

--- a/spec/amber/pipes/static_spec.cr
+++ b/spec/amber/pipes/static_spec.cr
@@ -64,9 +64,9 @@ module Amber
 
         response = create_request_and_return_io(static, request)
 
-        response.headers["Cache-Control"].should eq "private, max-age=3600"
         response.headers["Accept-Ranges"].should eq "bytes"
         response.headers["X-Content-Type-Options"].should eq "nosniff"
+        response.headers["Cache-Control"].should eq "no-store"
       end
     end
   end

--- a/spec/support/config/test.yml
+++ b/spec/support/config/test.yml
@@ -22,6 +22,10 @@ session:
   store: "signed_cookie"
   expires: 0
 
+pipes:
+  static:
+    headers:
+      "Cache-Control": "no-store"
+
 secrets:
   description: "Store your test secrets credentials and settings here."
-

--- a/spec/support/config/with_public_file_server.yml
+++ b/spec/support/config/with_public_file_server.yml
@@ -1,0 +1,17 @@
+port: 3000
+port_reuse: true
+process_count: 1
+redis_url: "redis://localhost:6379"
+database_url: "mysql://root@localhost:3306/development_settings_test"
+
+session:
+  key: "myapp.session"
+  store: "encrypted_cookie"
+  expires: 10
+
+secrets:
+  description: "Store your test secrets credentials and settings here."
+
+public_file_server:
+  headers:
+    "Cache-Control": "private, max-age=7200"

--- a/spec/support/config/with_static_pipe_settings.yml
+++ b/spec/support/config/with_static_pipe_settings.yml
@@ -9,9 +9,10 @@ session:
   store: "encrypted_cookie"
   expires: 10
 
+pipes:
+  static:
+    headers:
+      "Cache-Control": "private, max-age=7200"
+
 secrets:
   description: "Store your test secrets credentials and settings here."
-
-public_file_server:
-  headers:
-    "Cache-Control": "private, max-age=7200"

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -36,3 +36,7 @@ smtp:
 
 secrets:
   description: Store your development secrets credentials and settings here.
+
+public_file_server:
+  headers:
+    "Cache-Control": "no-store"

--- a/src/amber/cli/templates/app/config/environments/development.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/development.yml.ecr
@@ -34,9 +34,10 @@ session:
 smtp:
   enabled: false
 
+pipes:
+  static:
+    headers:
+      "Cache-Control": "no-store"
+
 secrets:
   description: Store your development secrets credentials and settings here.
-
-public_file_server:
-  headers:
-    "Cache-Control": "no-store"

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -38,9 +38,10 @@ smtp:
   username: api_key
   enabled: false
 
+pipes:
+  static:
+    headers:
+      "Cache-Control": "private, max-age=3600"
+
 secrets:
   description: Store your production secrets credentials and settings here.
-
-public_file_server:
-  headers:
-    "Cache-Control": "private, max-age=3600"

--- a/src/amber/cli/templates/app/config/environments/production.yml.ecr
+++ b/src/amber/cli/templates/app/config/environments/production.yml.ecr
@@ -40,3 +40,7 @@ smtp:
 
 secrets:
   description: Store your production secrets credentials and settings here.
+
+public_file_server:
+  headers:
+    "Cache-Control": "private, max-age=3600"

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -74,11 +74,13 @@ module Amber::Environment
         },
       },
       auto_reload: {type: Bool, default: false},
-      public_file_server: {
-        type:    Hash(String, Hash(String, String)),
+      pipes: {
+        type: Hash(String, Hash(String, Hash(String, SettingValue))),
         default: {
-          "headers" => {} of String => String,
-        },
+          "static" => {
+            "headers" => {} of String => SettingValue
+          }
+        }
       }
     )
 

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -75,12 +75,12 @@ module Amber::Environment
       },
       auto_reload: {type: Bool, default: false},
       pipes: {
-        type: Hash(String, Hash(String, Hash(String, SettingValue))),
+        type:    Hash(String, Hash(String, Hash(String, SettingValue))),
         default: {
           "static" => {
-            "headers" => {} of String => SettingValue
-          }
-        }
+            "headers" => {} of String => SettingValue,
+          },
+        },
       }
     )
 

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -73,7 +73,13 @@ module Amber::Environment
           "enabled" => false,
         },
       },
-      auto_reload: {type: Bool, default: false}
+      auto_reload: {type: Bool, default: false},
+      public_file_server: {
+        type: Hash(String, Hash(String, String)),
+        default: {
+          "headers" => {} of String => String
+        }
+      }
     )
 
     def session

--- a/src/amber/environment/settings.cr
+++ b/src/amber/environment/settings.cr
@@ -75,10 +75,10 @@ module Amber::Environment
       },
       auto_reload: {type: Bool, default: false},
       public_file_server: {
-        type: Hash(String, Hash(String, String)),
+        type:    Hash(String, Hash(String, String)),
         default: {
-          "headers" => {} of String => String
-        }
+          "headers" => {} of String => String,
+        },
       }
     )
 

--- a/src/amber/pipes/static.cr
+++ b/src/amber/pipes/static.cr
@@ -133,9 +133,9 @@ module Amber
 
       private def add_response_headers(env : HTTP::Server::Context)
         {
-          "Accept-Ranges" => "bytes",
+          "Accept-Ranges"          => "bytes",
           "X-Content-Type-Options" => "nosniff",
-          "Cache-Control" => "private, max-age=3600",
+          "Cache-Control"          => "private, max-age=3600",
         }.merge(
           Amber.settings.public_file_server["headers"]
         ).each do |key, value|

--- a/src/amber/pipes/static.cr
+++ b/src/amber/pipes/static.cr
@@ -132,14 +132,20 @@ module Amber
       end
 
       private def add_response_headers(env : HTTP::Server::Context)
-        {
+        pipes = Amber.settings.pipes
+        default_headers = {
           "Accept-Ranges"          => "bytes",
           "X-Content-Type-Options" => "nosniff",
           "Cache-Control"          => "private, max-age=3600",
-        }.merge(
-          Amber.settings.public_file_server["headers"]
-        ).each do |key, value|
-          env.response.headers[key] = value
+        } of String => Amber::Settings::SettingValue
+
+        headers = if pipes.has_key?("static") && pipes["static"].has_key?("headers")
+                    default_headers.merge(pipes["static"]["headers"])
+                  else
+                    default_headers
+                  end
+        headers.each do |key, value|
+           env.response.headers[key] = value.as(String)
         end
       end
 

--- a/src/amber/pipes/static.cr
+++ b/src/amber/pipes/static.cr
@@ -109,12 +109,13 @@ module Amber
         file_path = File.expand_path(path, Dir.current)
         mime_type ||= mime_type(file_path)
         env.response.content_type = mime_type
-        env.response.headers["Accept-Ranges"] = "bytes"
-        env.response.headers["X-Content-Type-Options"] = "nosniff"
-        add_cache_header(env)
+
+        add_response_headers(env)
+
         minsize = 860 # http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits ??
         request_headers = env.request.headers
         filesize = File.size(file_path)
+
         File.open(file_path) do |file|
           next multipart(file, env) if next_multipart?(env)
 
@@ -130,8 +131,16 @@ module Amber
         return
       end
 
-      private def add_cache_header(env : HTTP::Server::Context)
-        env.response.headers["Cache-Control"] = "private, max-age=3600"
+      private def add_response_headers(env : HTTP::Server::Context)
+        {
+          "Accept-Ranges" => "bytes",
+          "X-Content-Type-Options" => "nosniff",
+          "Cache-Control" => "private, max-age=3600",
+        }.merge(
+          Amber.settings.public_file_server["headers"]
+        ).each do |key, value|
+          env.response.headers[key] = value
+        end
       end
 
       private def next_multipart?(env)

--- a/src/amber/pipes/static.cr
+++ b/src/amber/pipes/static.cr
@@ -145,7 +145,7 @@ module Amber
                     default_headers
                   end
         headers.each do |key, value|
-           env.response.headers[key] = value.as(String)
+          env.response.headers[key] = value.as(String)
         end
       end
 


### PR DESCRIPTION
Ability to configure response headers from <environment>.yml file
with the following configuration,

```yaml
public_file_server:
  headers:
    "Cache-Control": "private, max-age=7200"
```
### Description of the Change

When files are served by the static file server, via [pipes/static.cr](https://github.com/amberframework/amber/blob/master/src/amber/pipes/static.cr), and does not expose a way to modify the [hard coded Cache-Control headers](https://github.com/amberframework/amber/blob/master/src/amber/pipes/static.cr#L134)

### Alternate Designs

This enhancement is similar to the static file middle-ware headers configuration of Rails. [Original PR](https://github.com/rails/rails/pull/19135/files)

### Benefits

Ability to modify response headers for files served by static pipe. 

### Possible Drawbacks

Since this PR is an enhancement to the existing functionality, no changes are introduced to the behavior of the framework. 