### PR TITLE
Plugin: Add support for a config file

### DIFF
--- a/spec/amber/cli/plugins/installer_spec.cr
+++ b/spec/amber/cli/plugins/installer_spec.cr
@@ -1,0 +1,24 @@
+require "../../../spec_helper"
+require "../../../support/helpers/cli_helper"
+
+include CLIHelper
+
+module Amber::Plugins
+  describe Installer do
+    Spec.after_each do
+      cleanup
+    end
+
+    it "should add routes when installing plugin" do
+      scaffold_app(TESTING_APP)
+      Dir.mkdir_p("#{Dir.current}/lib/test/plugin")
+      File.write("#{Dir.current}/lib/test/plugin/config.yml", yml_config_contents)
+
+      Installer.new("test").render("#{Dir.current}/src/plugins", list: true, color: true)
+
+      routes = File.read("#{Dir.current}/config/routes.cr")
+      routes.empty?.should be_false
+      routes.should contain "post \"/plugin\", PluginController, :create"
+    end
+  end
+end

--- a/spec/support/helpers.cr
+++ b/spec/support/helpers.cr
@@ -1,5 +1,6 @@
 require "./helpers/controller_helper"
 require "./helpers/cookie_helper"
+require "./helpers/plugin_helper"
 require "./helpers/session_helper"
 require "./helpers/router_helper"
 require "./helpers/websockets_helper"
@@ -8,6 +9,7 @@ require "./helpers/validations_helper"
 module Helpers
   include ControllerHelper
   include CookieHelper
+  include PluginHelper
   include RouterHelper
   include WebsocketsHelper
   include ValidationsHelper

--- a/spec/support/helpers/plugin_helper.cr
+++ b/spec/support/helpers/plugin_helper.cr
@@ -1,0 +1,10 @@
+module PluginHelper
+  def yml_config_contents
+    <<-FILE
+      routes:
+        pipelines:
+          web:
+            - post "/plugin", PluginController, :create
+    FILE
+  end
+end

--- a/src/amber/cli/plugins/plugin.cr
+++ b/src/amber/cli/plugins/plugin.cr
@@ -8,6 +8,7 @@ require "../helpers/helpers"
 require "../recipes/file_entries"
 require "./fetcher"
 require "./installer"
+require "./settings"
 
 module Amber::Plugins
   class Plugin

--- a/src/amber/cli/plugins/settings.cr
+++ b/src/amber/cli/plugins/settings.cr
@@ -1,0 +1,15 @@
+require "yaml"
+require "yaml_mapping"
+
+module Amber::Plugins
+  class Settings
+    alias RouteType = Hash(String, Hash(String, Array(String)))
+
+    YAML.mapping(
+      routes: {
+        type:    RouteType,
+        default: {"pipelines" => Hash(String, Array(String)).new},
+      }
+    )
+  end
+end


### PR DESCRIPTION
### Description of the Change

This adds the ability for plugin authors to create a `config.yml` file. The file is should be located in the plugin folder. Currently, I have only added the ability to inject routes into the users `route.cr` file but I have no problem adding extra functionality if people bring up ideas.

The code expects the YAML file to be in the following format:

```yml
routes:
  pipelines:
    web:
      - get "/", HomeController, :index
      - post "/", HomeController, :index
```

### Benefits

Right now, the benefit is routes can be auto-generated. 

### Possible Drawbacks

More code. 

A current limitation is it breaks if you don't have the full information. The cli will not read the file if the file doesn't exist. It doesn't break if the file is empty. It does break when the file is just:

```yml
routes:
  pipelines:
```

or

```yml
routes:
  pipelines:
    web:
```

But plugin authors shouldn't be doing that anyways. 