### PR TITLE
Plugin: Additional Features

### DIFF
--- a/spec/amber/cli/plugins/installer_spec.cr
+++ b/spec/amber/cli/plugins/installer_spec.cr
@@ -29,5 +29,11 @@ module Amber::Plugins
       installer.args["name"]?.should_not be_nil
       installer.args["name"].should eq "Amber"
     end
+
+    it "should clean up config.yml after rendering" do
+      scaffold_app_with_plugin
+      Installer.new("test", [] of String).render("#{Dir.current}/src/plugins", list: true, color: true)
+      File.exists?("#{Dir.current}/src/plugins/config.yml").should be_false
+    end
   end
 end

--- a/spec/amber/cli/plugins/installer_spec.cr
+++ b/spec/amber/cli/plugins/installer_spec.cr
@@ -10,15 +10,23 @@ module Amber::Plugins
     end
 
     it "should add routes when installing plugin" do
-      scaffold_app(TESTING_APP)
-      Dir.mkdir_p("#{Dir.current}/lib/test/plugin")
-      File.write("#{Dir.current}/lib/test/plugin/config.yml", yml_config_contents)
+      scaffold_app_with_plugin
 
-      Installer.new("test").render("#{Dir.current}/src/plugins", list: true, color: true)
+      Installer.new("test", [] of String).render("#{Dir.current}/src/plugins", list: true, color: true)
 
       routes = File.read("#{Dir.current}/config/routes.cr")
       routes.empty?.should be_false
       routes.should contain "post \"/plugin\", PluginController, :create"
+    end
+
+    it "should pass args to liquid context" do
+      scaffold_app_with_plugin
+      installer = Installer.new("test", ["Amber"])
+      installer.render("#{Dir.current}/src/plugins", list: true, color: true)
+
+      installer.settings.should_not be_nil
+      installer.args["name"]?.should_not be_nil
+      installer.args["name"].should eq "Amber"
     end
   end
 end

--- a/spec/amber/cli/plugins/installer_spec.cr
+++ b/spec/amber/cli/plugins/installer_spec.cr
@@ -17,6 +17,7 @@ module Amber::Plugins
       routes = File.read("#{Dir.current}/config/routes.cr")
       routes.empty?.should be_false
       routes.should contain "post \"/plugin\", PluginController, :create"
+      routes.should contain "plug Authenticate.new"
     end
 
     it "should pass args to liquid context" do

--- a/spec/support/helpers/plugin_helper.cr
+++ b/spec/support/helpers/plugin_helper.cr
@@ -5,6 +5,14 @@ module PluginHelper
         pipelines:
           web:
             - post "/plugin", PluginController, :create
+      args:
+        - name
     FILE
+  end
+
+  def scaffold_app_with_plugin
+    scaffold_app(TESTING_APP)
+    Dir.mkdir_p("#{Dir.current}/lib/test/plugin")
+    File.write("#{Dir.current}/lib/test/plugin/config.yml", yml_config_contents)
   end
 end

--- a/spec/support/helpers/plugin_helper.cr
+++ b/spec/support/helpers/plugin_helper.cr
@@ -2,6 +2,9 @@ module PluginHelper
   def yml_config_contents
     <<-FILE
       routes:
+        plugs:
+          web:
+            - plug Authenticate.new
         pipelines:
           web:
             - post "/plugin", PluginController, :create

--- a/src/amber/cli/commands/plugin.cr
+++ b/src/amber/cli/commands/plugin.cr
@@ -10,6 +10,7 @@ module Amber::CLI
       class Options
         bool ["-u", "--uninstall"], desc: "uninstall plugin", default: false
         arg "name", desc: "name of the shard", required: true
+        arg_array "args", desc: "args available during template rendering"
         help
       end
 
@@ -23,7 +24,7 @@ module Amber::CLI
         ensure_name_argument!
 
         if Amber::Plugins::Plugin.can_generate?(args.name)
-          template = Amber::Plugins::Plugin.new(args.name, "./src/plugins")
+          template = Amber::Plugins::Plugin.new(args.name, "./src/plugins", options.args)
           template.generate (options.uninstall? ? "uninstall" : "install")
         end
       end

--- a/src/amber/cli/plugins/installer.cr
+++ b/src/amber/cli/plugins/installer.cr
@@ -25,10 +25,15 @@ module Amber::Plugins
     def render(directory, **args)
       pre_render(directory, **args)
       super(directory, **args)
+      post_render(directory, **args)
     end
 
     def pre_render(directory, **args)
       add_routes
+    end
+
+    def post_render(directory, **args)
+      cleanup(directory)
     end
 
     # setup the Liquid context
@@ -52,6 +57,12 @@ module Amber::Plugins
       config.routes["plugs"].each do |pipe, plugs|
         add_plugs pipe, plugs.join("\n    ")
       end
+    end
+
+    private def cleanup(directory)
+      return unless File.exists?("#{directory}/config.yml")
+
+      File.delete("#{directory}/config.yml")
     end
   end
 end

--- a/src/amber/cli/plugins/installer.cr
+++ b/src/amber/cli/plugins/installer.cr
@@ -8,10 +8,13 @@ module Amber::Plugins
     property name : String
     getter language : String = CLI.config.language
     property timestamp : String
+    property args : Hash(String, String)
 
-    def initialize(@name)
+    def initialize(@name, args)
       @template = Fetcher.new(name).fetch
       @timestamp = Time.utc.to_s("%Y%m%d%H%M%S%L")
+      @args = Hash(String, String).new
+      args.each_with_index { |arg, idx| @args[("a".."z").to_a[idx]] = arg }
     end
 
     # setup the Liquid context
@@ -21,6 +24,7 @@ module Amber::Plugins
       ctx.set "name", name
       ctx.set "language", language
       ctx.set "timestamp", timestamp
+      ctx.set "args", args
     end
   end
 end

--- a/src/amber/cli/plugins/installer.cr
+++ b/src/amber/cli/plugins/installer.cr
@@ -48,6 +48,10 @@ module Amber::Plugins
       config.routes["pipelines"].each do |pipe, routes|
         add_routes pipe, routes.join("\n    ")
       end
+
+      config.routes["plugs"].each do |pipe, plugs|
+        add_plugs pipe, plugs.join("\n    ")
+      end
     end
   end
 end

--- a/src/amber/cli/plugins/plugin.cr
+++ b/src/amber/cli/plugins/plugin.cr
@@ -14,13 +14,14 @@ module Amber::Plugins
     Log = ::Log.for(self)
     getter name : String
     getter directory : String
+    getter args : Array(String)
 
     def self.can_generate?(name : String)
       template = Fetcher.new(name).fetch
       !(template.nil?)
     end
 
-    def initialize(name : String, directory : String)
+    def initialize(name : String, directory : String, @args : Array(String))
       @name = name
 
       @directory = File.join(directory)
@@ -33,7 +34,7 @@ module Amber::Plugins
       case action
       when "install"
         log_message "Adding plugin #{name}"
-        Installer.new(name).render(directory, list: true, color: true)
+        Installer.new(name, args).render(directory, list: true, color: true)
       else
         Log.error { "Invalid plugin command".colorize(:light_red) }
       end

--- a/src/amber/cli/plugins/settings.cr
+++ b/src/amber/cli/plugins/settings.cr
@@ -9,6 +9,10 @@ module Amber::Plugins
       routes: {
         type:    RouteType,
         default: {"pipelines" => Hash(String, Array(String)).new},
+      },
+      args: {
+        type: Array(String),
+        default: [] of String
       }
     )
   end

--- a/src/amber/cli/plugins/settings.cr
+++ b/src/amber/cli/plugins/settings.cr
@@ -8,11 +8,14 @@ module Amber::Plugins
     YAML.mapping(
       routes: {
         type:    RouteType,
-        default: {"pipelines" => Hash(String, Array(String)).new},
+        default: {
+          "pipelines" => Hash(String, Array(String)).new,
+          "plugs"     => Hash(String, Array(String)).new,
+        },
       },
       args: {
-        type: Array(String),
-        default: [] of String
+        type:    Array(String),
+        default: [] of String,
       }
     )
   end


### PR DESCRIPTION
### Description of the Change

Small changes to expand the functionality of plugins. 

One feature allow passing arguments to liquid template files. The syntax is:
```sh
amber plugin mochi granite
```

With `granite` being the single argument. 

I added support for auto-generating plugs. The final commit ensures the `config.yml` file is deleted after rendering. This should of made it into the previous PR.

A spec has been added for all additional features.

### Benefits

Plugin templates can be more dynamic. For example, my shard Mochi supports both Granite and Jennifer ORM's. Rather than having shards "mochi-granite-plugin" and "mochi-jennifer-plugin" that would be almost duplicates of each other, I can use simple `if` statements in my plugin templates.

`if args.orm == "granite"`

### Possible Drawbacks

It's possible users don't pass in the proper arguments and the template doesn't come out right. 

### Example Config File

I have a branch open on my authentication shard waiting for this final PR. In case anyone else wanted to take a look, here is what the config file currently supports.

```yml
args: 
  - orm
  - extension
routes:
  plugs:
    web:
      - "# Mochi Authenticable"
      - plug CurrentUser.new
    auth:
      - "# Mochi Authenticable"
      - plug Authenticate.new
  pipelines:
    web:
      - "# Mochi Authenticable"
      - get "/signin", SessionController, :new
      - post "/session", SessionController, :create
      - get "/signup", UserController, :new
      - post "/signup", UserController, :create
      - ""
      - "# Mochi Confirmable"
      - "# get \"/registration/update\", RegistrationController, :update"
      - ""
      - "# Mochi Invitable"
      - "# get \"/invite/new\", InvitableController, :new"
      - "# get \"/invite/edit\", InvitableController, :edit"
      - "# post \"/invite\", InvitableController, :create"
      - "# patch \"/invite\", InvitableController, :update"
      - ""
      - "# Mochi Lockable"
      - "# get \"/unlock\", UnlockableController, :update"
      - ""
      - "# Mochi Omniauthable"
      - "# get \"/omniauth/user/:provider\", Omniauthable::UserController, :create"
      - "# get \"/omniauth/user/:provider/callback\", Omniauthable::UserController, :callback"
      - "# get \"/omniauth/:provider\", Omniauthable::SessionController, :create"
      - "# get \"/omniauth/:provider/callback\", Omniauthable::SessionController, :callback"
      - ""
      - "# Mochi Recoverable"
      - "# get \"/reset/password\", RecoverableController, :new"
      - "# get \"/reset/password/edit\", RecoverableController, :edit"
      - "# post \"/reset/password\", RecoverableController, :create"
      - "# patch \"/reset/password/:id\", RecoverableController, :update"
    auth:
      - "# Mochi Authenticable"
      - get "/profile", UserController, :show
      - get "/profile/edit", UserController, :edit
      - patch "/profile", UserController, :update
      - get "/signout", SessionController, :destroy
```

We decided not to go with submodules since the crystal binary doesn't include unused code. Because of that, I wanted only my "first" module (basic authentication) to have routes and the rest are commented out. Users can uncomment what they need and delete the rest.

Routes & plugs get auto-generated and in my liquid templates, i can reference `args.orm` and `args.extension`.