### PR TITLE
Improve default log formatting & output

### DIFF
--- a/src/amber/cli/templates/app/config/logger.cr.ecr
+++ b/src/amber/cli/templates/app/config/logger.cr.ecr
@@ -6,6 +6,7 @@ require "log"
 # You can read details here: https://crystal-lang.org/api/0.35.0/Log.html
 
 # Using environment settings:
+Colorize.enabled = Amber.settings.logging.colorize
 backend = Log::IOBackend.new(STDOUT)
 
 # Custom formatter
@@ -21,11 +22,13 @@ backend.formatter = Log::Formatter.new do |entry, io|
   # io << entry.timestamp.in(time_zone).to_s("%I:%M:%S")
   io << " "
   io << entry.source
+  io << " |"
   io << " (#{entry.severity})" if entry.severity > Log::Severity::Debug
   io << " "
   io << entry.message
 end
 
+Log.builder.clear
 Log.builder.bind "*", Amber.settings.logging.severity, backend
 
 # Using crystal's standard environment variables:

--- a/src/amber/pipes/logger.cr
+++ b/src/amber/pipes/logger.cr
@@ -64,7 +64,7 @@ module Amber
       end
 
       private def log(msg, prog, color = :white)
-        Log.for(prog).debug { "#{prog.colorize(color)} | #{msg}" }
+        Log.for(prog.colorize(color).to_s).debug { msg }
       end
 
       private def log_config


### PR DESCRIPTION
### Description of the Change

With the new changes to logging, a default Amber installation produces slightly wonky log output.  See below:

<img width="1249" alt="Screen Shot 2020-11-10 at 8 58 32 PM" src="https://user-images.githubusercontent.com/113276/98770931-25233e80-2398-11eb-8b9c-f5ef83ec0a7c.png">

There are two issues here:

1. Standard log messages are repeated.
2. Log messages from pipelines have a redundant `prog` parameter.  This is because the new Log implementation now supports sources natively, but the relevant amber code still includes the `prog` parameter twice.

This PR makes a few small changes to improve things:

1. The `prog` parameter is only written once, colorized if necessary
2. The default formatting of pipeline log lines (with a | character separating the source from the msg) is moved from source code up to the configuration file.  This gives the user additional flexibility in customizing how log lines are displayed without mucking around in amber source\
3. `Log.builder.clear` is added to the default config/logger.cr in order to resolve the double log lines.  There is still a brief double log when amber first fires up before the config file is loaded -- there may be a better way to fix this. 

### Benefits

Cleaner logs!  See below for default output with these changes applied:

<img width="1186" alt="Screen Shot 2020-11-10 at 9 13 11 PM" src="https://user-images.githubusercontent.com/113276/98771560-91527200-2399-11eb-99dd-8a3208f7812e.png">

### Possible Drawbacks

Slightly more complex & longer configuration for logging (config/logger.cr)
