### PR TITLE
Unify AbstractStore#update API

### DIFF
--- a/src/amber/router/session/abstract_store.cr
+++ b/src/amber/router/session/abstract_store.cr
@@ -3,7 +3,7 @@ module Amber::Router::Session
   abstract class AbstractStore
     abstract def id
     abstract def destroy
-    abstract def update(other_hash)
+    abstract def update(other_hash : Hash(String | Symbol, String))
     abstract def set_session
     abstract def current_session
   end

--- a/src/amber/router/session/redis_store.cr
+++ b/src/amber/router/session/redis_store.cr
@@ -59,7 +59,7 @@ module Amber::Router::Session
       store.hgetall(session_id).each_slice(2).to_h
     end
 
-    def update(hash : Hash(String, String))
+    def update(hash : Hash(String | Symbol, String))
       store.hmset(session_id, hash)
     end
 


### PR DESCRIPTION
Fix #1239

`Redis#hmset` already uses `key.to_s` to convert keys to strings.