### PR TITLE
Update dependencies

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -16,11 +16,11 @@ targets:
 dependencies:
   amber_router:
     github: amberframework/amber-router
-    version: ~> 0.3.0
+    version: ~> 0.4.4
 
   cli:
     github: amberframework/cli
-    version: ~> 0.9.1
+    version: ~> 0.9.3
 
   compiled_license:
     github: elorest/compiled_license
@@ -32,7 +32,7 @@ dependencies:
 
   liquid:
     github: TechMagister/liquid.cr
-    version: ~> 0.3.3
+    version: ~> 0.3.4
 
   micrate:
     github: amberframework/micrate
@@ -83,5 +83,5 @@ dependencies:
 
 development_dependencies:
   ameba:
-    github: veelenga/ameba
-    version: ~> 0.12.1
+    github: crystal-ameba/ameba
+    version: ~> 0.13.4

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -57,5 +57,5 @@ development_dependencies:
     github: amberframework/garnet-spec
     version: 0.2.0
   ameba:
-    github: veelenga/ameba
-    version: ~> 0.12.1
+    github: crystal-ameba/ameba
+    version: ~> 0.13.4


### PR DESCRIPTION
Fixes amberframework/homebrew-amber/issues/7

Updating dependencies so that Amber works with Crystal 0.36.1.
