### PR TITLE
Bump ameba dependency to ~> 0.13.4

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -84,4 +84,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: ~> 0.12.1
+    version: ~> 0.13.4


### PR DESCRIPTION
That should fix building with the newest (0.36) crystal version.
Possibly fixes #1247