### PR TITLE
Exposes default database ports on generated docker-compose.yml

### DIFF
--- a/src/amber/cli/templates/app/docker-compose.yml.ecr
+++ b/src/amber/cli/templates/app/docker-compose.yml.ecr
@@ -41,6 +41,8 @@ services:
 <% if @database == "pg" -%>
   db:
     image: postgres
+    ports:
+      - 5432:5432
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
@@ -50,6 +52,8 @@ services:
 <% elsif @database == "mysql" -%>
   db:
     image: mysql:5.6
+    ports:
+      - 3306:3306
     environment:
       MYSQL_USER: admin
       MYSQL_PASSWORD: password


### PR DESCRIPTION
### Description of the Change
When generating an application via `amber new [project name]` the generator creates a helpful `docker-compse.yml` file. This makes running or deploying an application in a modern containerized environment fairly trivial. However, the `docker-compose.yml` is not set up by default to support a containerized _local_ development scheme. This means that developers will have to manually install `postgresql`, `mysql`, _etc_ or run their own local database container if they wish develop against it locally. This change set adds the default port exposure on the host machine for `postgres` (`port 5432`) and `mysql` (`port 3306`), such that a developer can run a host machine `amber` process, but, a containerized database. 

e.g.
```bash
 $ docker-compose up db

 $ amber watch
```

At the moment, since the ports are **not** exposed, a local amber process will not be able to talk to a separate database container without this change. 

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Alternate Designs
By default it seems as though amber is nudging users towards use of Docker a bit. This is _slightly_ different in philosophy from Rails (which does not assume anything about deployment or development scheme: e.g. no `Procfile` or `Dockerfile` generated by default). The only other alternative design I could think of was dropping the `docker-compose.yml` generated by default _entirely_ such that Amber equally makes no assumptions about how end developers will develop or deploy their applications. I personally think generated the `docker-compose.yml` is awesome given I prefer container style local development and deployment. Since Amber already generates the compose file, I don't think it's too much more to lean into exposing the ports for local container development.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the code change? -->
* Local containerized development from `amber new` 

### Possible Drawbacks
* Continued assumption by framework of _how_ a developer will deploy and develop and application
