### PR TITLE
Increase reliability of "amber exec" output

### DIFF
--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -52,6 +52,7 @@ module Amber::CLI
         file = File.open(@filelogs, "w")
         spawn show
         process = Process.run(code, shell: true, output: file, error: file)
+        sleep 1.millisecond
         process.exit_status
       end
 


### PR DESCRIPTION
### Description of the Change

When the code passed to "amber exec" outputs right before exiting, the
output may not be written completely sometimes. This is due to the 1
millisecond delay in the loop when reading the output.

To fix this we just add a millisecond delay after the code exited, so
that the output loop can finish.

### Alternate Designs

I thought about printing the output on exit, however for a longer program this does not make sense. Moreover, it might be possible to store the handle to the opened file and read everything that was not read yet on program exit. However this seemed like a more complex change that I did not want to approach.

### Benefits

Especially when the code passed to "amber exec" includes a compile-time error, the error was often not showed (at least on my machine). Having all errors (or other output) is the clear benefit of this PR.

### Possible Drawbacks

The execution time is one millisecond longer than normal.
