### PR TITLE
Fix the correct documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Our Philosophy? [Read Amber Philosophy H.R.T.](.github/AMBER_PHILOSOPHY.md)
 
 ## Documentation
 
-Read Amber documentation on https://docs.amberframework.org
+Read Amber documentation on https://docs.amberframework.org/amber
 
 ## Benchmarks
 


### PR DESCRIPTION
### Description of the Change

I fix the correct url for the amber documentation

### Benefits

By default documentation url without `/amber` give Granite documentation