### PR TITLE
Updated the version number in Amber to reflect the actual release number

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Amber borrows concepts that have already been battle tested and successful, and 
 
 ## Community
 
-Questions? Join our IRC channel [#amber](https://webchat.freenode.net/?channels=#amber) or [Gitter room](https://gitter.im/amberframework/amber) or ask on Stack Overflow under the [amber-framework](https://stackoverflow.com/questions/tagged/amber-framework) tag.
+Questions? Join our [Discord](https://discord.gg/7hcPbC9t8Y).
 
 Guidelines? We have adopted the Contributor Covenant to be our [CODE OF CONDUCT](.github/CODE_OF_CONDUCT.md) for Amber.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Amber borrows concepts that have already been battle tested and successful, and 
 
 ## Community
 
-Questions? Join our [Discord](https://discord.gg/7hcPbC9t8Y).
+Questions? Join our [Discord](https://discord.gg/vwvP5zakSn).
 
 Guidelines? We have adopted the Contributor Covenant to be our [CODE OF CONDUCT](.github/CODE_OF_CONDUCT.md) for Amber.
 

--- a/src/amber/version.cr
+++ b/src/amber/version.cr
@@ -1,3 +1,3 @@
 module Amber
-  VERSION = "1.0.0rc2"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
Looks like the version within the app was not incremented when the release was made. So running `amber -v` appears to have installed  1.0.0rc2 instead of the latest 1.2.1, giving the impression that the wrong version was installed.