### PR TITLE
Remove crystalshards.xyz link on template view

### DIFF
--- a/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.ecr.ecr
@@ -5,7 +5,6 @@
     <div class="list-group">
       <a class="list-group-item list-group-item-action" target="_blank" href="https://docs.amberframework.org">Getting Started with Amber Framework</a>
       <a class="list-group-item list-group-item-action" target="_blank" href="https://github.com/veelenga/awesome-crystal">List of Awesome Crystal projects and shards</a>
-      <a class="list-group-item list-group-item-action" target="_blank" href="https://crystalshards.xyz">What's hot in Crystal right now</a>
     </div>
   </div>
 </div>

--- a/src/amber/cli/templates/app/src/views/home/index.slang.ecr
+++ b/src/amber/cli/templates/app/src/views/home/index.slang.ecr
@@ -5,4 +5,3 @@
     .list-group
       a.list-group-item.list-group-item-action target="_blank" href="https://docs.amberframework.org" Getting Started with Amber Framework
       a.list-group-item.list-group-item-action target="_blank" href="https://github.com/veelenga/awesome-crystal" List of Awesome Crystal projects and shards
-      a.list-group-item.list-group-item-action target="_blank" href="https://crystalshards.xyz" What's hot in Crystal right now


### PR DESCRIPTION
### Description of the Change

Removes the crystalshards.xyz link. Perhaps it should be https://crystalshards.org (idk where the best spot is rn, I'm super ignorant) but the domain is compromised for the other link and it seems bad.

### Alternate Designs

N/A

### Benefits

The template page looks more professional.

### Possible Drawbacks

N/A
