### PR TITLE
fix to cli scaffold controller spec deprecated garnetspec module

### DIFF
--- a/src/amber/cli/templates/scaffold/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/scaffold/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -25,7 +25,7 @@ def <%= create_model_method %>
   model
 end
 
-class <%= class_name %>ControllerTest < GarnetSpec::Controller::Test
+class <%= class_name %>ControllerTest < GarnetSpec::SystemTest
   getter handler : Amber::Pipe::Pipeline
 
   def initialize


### PR DESCRIPTION
### Description of the Change

At some point in the history of the GarnetSpec shard, the `GarnetSpec::Controller::Test` module was deprecated, instead the `GarnetSpec::SystemTest` module is to be used.

### Benefits

Fixes an error when running cli scaffold controller spec files in more current versions of the GarnetSpec shard.

### Possible Drawbacks

Will not work in older versions of GarnetSpec shard.
