### PR TITLE
Updated the remaining two templates that used the old GarnetSpec parent class

### DIFF
--- a/src/amber/cli/templates/api/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/api/controller/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -25,7 +25,7 @@ def <%= create_model_method %>
   model
 end
 
-class <%= class_name %>ControllerTest < GarnetSpec::Controller::Test
+class <%= class_name %>ControllerTest < GarnetSpec::SystemTest
   getter handler : Amber::Pipe::Pipeline
 
   def initialize

--- a/src/amber/cli/templates/error/spec/controllers/{{name}}_controller_spec.cr.ecr
+++ b/src/amber/cli/templates/error/spec/controllers/{{name}}_controller_spec.cr.ecr
@@ -28,7 +28,7 @@ describe <%= class_name %>Controller do
 end
 
 # Controller Integration Test
-class <%= class_name %>ControllerTest < GarnetSpec::Controller::Test
+class <%= class_name %>ControllerTest < GarnetSpec::SystemTest
   getter handler : Amber::Pipe::Pipeline
 
   def initialize


### PR DESCRIPTION
This changes the remaining 2 templates that used an old parent class for templating GarnetSpecs after #1296 was merged