### PR TITLE
Updated docker file to use latest crystal image and updated straggling Amber version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.0.0
+FROM crystallang/crystal:latest
 
 # Install Dependencies
 ARG DEBIAN_FRONTEND=noninteractive

--- a/src/amber/version.cr
+++ b/src/amber/version.cr
@@ -1,3 +1,3 @@
 module Amber
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
- Docker now uses the `latest` crystal image available
- Missed Amber VERSION constant updated