### PR TITLE
Changed node version check to look for v14 only

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: amber
 
-version: 1.3.0
+version: 1.3.1
 
 authors:
   - Amber Team and Contributors <amberframework.org>

--- a/src/amber/cli/templates/app/package.json.ecr
+++ b/src/amber/cli/templates/app/package.json.ecr
@@ -20,7 +20,7 @@
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.1",
     "mini-css-extract-plugin": "^1.6.0",
-  <% if `node -v`.matches?(/v14|v16/) -%>
+  <% if `node -v`.matches?(/v14/) -%>
     "node-sass": "^5.0.0",
     "sass-loader": "^11.0.1",
   <% else -%>

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -18,8 +18,7 @@ targets:
 dependencies:
   amber:
     github: amberframework/amber
-    #version: <%= Amber::VERSION %>
-    branch: master
+    version: <%= Amber::VERSION %>
 
   granite:
     github: amberframework/granite

--- a/src/amber/version.cr
+++ b/src/amber/version.cr
@@ -1,3 +1,3 @@
 module Amber
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
Change to how the node version sets the dependency values to fix node-sass version not working on the Node 16 and changing the app template to default to the latest Amber release version instead of the master branch