### PR TITLE
1227 fix layout equals false

### DIFF
--- a/spec/amber/controller/render_spec.cr
+++ b/spec/amber/controller/render_spec.cr
@@ -29,6 +29,10 @@ module Amber::Controller
         RenderController.new(context).render_with_layout.should eq layout_with_template
       end
 
+      it "renders with layout equal to false" do
+        RenderLayoutFalseController.new(context).render_with_layout.should eq partial_only
+      end
+
       # it "renders a form with a csrf tag" do
       #   result = RenderController.new(context).render_with_csrf
       #   result.should contain "<form"

--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -111,6 +111,14 @@ class RenderController < Amber::Controller::Base
   end
 end
 
+class RenderLayoutFalseController < Amber::Controller::Base
+  LAYOUT = false
+
+  def render_with_layout
+    render("test/test.slang", layout: "layout.slang", path: "spec/support/sample/views", folder: "./")
+  end
+end
+
 class ResponsesController < Amber::Controller::Base
   def index
     respond_with do

--- a/src/amber/controller/helpers/render.cr
+++ b/src/amber/controller/helpers/render.cr
@@ -22,7 +22,7 @@ module Amber::Controller::Helpers
       {% end %}
 
       # Render Layout
-      {% if layout && LAYOUT != "false" && !partial %}
+      {% if layout && LAYOUT != "false" && LAYOUT && !partial %}
         content = %content
         render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
       {% else %}

--- a/src/amber/controller/helpers/render.cr
+++ b/src/amber/controller/helpers/render.cr
@@ -22,7 +22,7 @@ module Amber::Controller::Helpers
       {% end %}
 
       # Render Layout
-      {% if layout && !partial %}
+      {% if layout && LAYOUT != "false" && !partial %}
         content = %content
         render_template("layouts/#{{{layout.class_name == "StringLiteral" ? layout : LAYOUT}}}", {{path}})
       {% else %}


### PR DESCRIPTION
### Description of the Change

This PR fixes issue #1227 .  This adds a check to see if LAYOUT is false or "false" and disables the layout for all of the render calls in the controller.

### Alternate Designs

Passing `layout=false` to all render calls in the controller

### Benefits

Reduces the code needed to disable the layout.

### Possible Drawbacks

It's not clear that LAYOUT can be set to false.  Its a bit awkward to have a (String | Boolean) union type for this field.
