### PR TITLE
Bump ameba version to ~> 1.3.0

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,3 +1,7 @@
 Excluded:
   - tmp/
   - myapp/
+
+Lint/NotNil:
+  Enabled: false
+

--- a/shard.yml
+++ b/shard.yml
@@ -85,4 +85,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.0.0
+    version: ~> 1.3.0

--- a/src/amber/cli/commands/new.cr
+++ b/src/amber/cli/commands/new.cr
@@ -37,7 +37,7 @@ module Amber::CLI
           info "#{full_path_name} should be #{full_path_name.gsub(/\s+/, "_")}"
           exit! error: true
         end
-        if (options.r? != nil)
+        if options.r? != nil
           generator = Amber::Recipes::Recipe.new(name, full_path_name, "#{options.r}")
         else
           generator = Generators.new(name, full_path_name)

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -36,7 +36,7 @@ module Sentry
 
       @includes.each do |task, includes|
         excluded_files = Array(String).new
-        if (excludes = @excludes[task]?)
+        if excludes = @excludes[task]?
           excludes.each { |glob| excluded_files += Dir.glob(glob) }
         end
         includes.each do |glob|
@@ -105,7 +105,7 @@ module Sentry
           log task, "Terminating process..."
         end
         procs.each do |process|
-            process.signal(:term) unless process.terminated?
+          process.signal(:term) unless process.terminated?
         end
         procs.clear
       end

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -54,4 +54,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.4
+    version: ~> 1.3.0

--- a/src/amber/controller/filters.cr
+++ b/src/amber/controller/filters.cr
@@ -72,7 +72,7 @@ module Amber::Controller
 
     property filters = {} of Symbol => Array(Filter)
 
-    def register(precedence : Symbol) : Nil
+    def register(precedence : Symbol, &) : Nil
       with FilterBuilder.new(self, precedence) yield
     end
 
@@ -81,7 +81,7 @@ module Amber::Controller
       filters[filter.precedence] << filter
     end
 
-    def each(&block : {Symbol, Array(Filter)} -> _)
+    def each(& : {Symbol, Array(Filter)} -> _)
       filters.each do |key, filter|
         yield({key, filter})
       end

--- a/src/amber/controller/helpers/redirect.cr
+++ b/src/amber/controller/helpers/redirect.cr
@@ -66,7 +66,7 @@ module Amber::Controller::Helpers
     end
 
     private def raise_redirect_error(location)
-      if (!location.url? || !location.chars.first == '/')
+      if !location.url? || !location.chars.first == '/'
         raise Exceptions::Controller::Redirect.new(location)
       end
     end

--- a/src/amber/pipes/pipeline.cr
+++ b/src/amber/pipes/pipeline.cr
@@ -25,7 +25,7 @@ module Amber
       end
 
       # Connects pipes to a pipeline to process requests
-      def build(valve : Symbol, &block)
+      def build(valve : Symbol, &)
         @valve = valve
         @pipeline[valve] = [] of HTTP::Handler unless pipeline.has_key? valve
         with DSL::Pipeline.new(self) yield

--- a/src/amber/router/cookies/store.cr
+++ b/src/amber/router/cookies/store.cr
@@ -68,7 +68,7 @@ module Amber::Router::Cookies
       end
     end
 
-    def each(&block : T -> _)
+    def each(& : T -> _)
       @cookies.values.each do |cookie|
         yield cookie
       end

--- a/src/amber/router/flash.cr
+++ b/src/amber/router/flash.cr
@@ -62,7 +62,7 @@ module Amber
           fetch(key)
         end
 
-        def each
+        def each(&)
           @store.each do |key, value|
             yield({key, value})
             @read << key

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -24,11 +24,11 @@ module Amber
       end
 
       # This registers all the routes for the application
-      def draw(valve : Symbol)
+      def draw(valve : Symbol, &)
         with DSL::Router.new(self, valve, scope) yield
       end
 
-      def draw(valve : Symbol, namespace : String)
+      def draw(valve : Symbol, namespace : String, &)
         scope.push(namespace)
         with DSL::Router.new(self, valve, scope) yield
         scope.pop

--- a/src/amber/server/server.cr
+++ b/src/amber/server/server.cr
@@ -19,7 +19,7 @@ module Amber
     end
 
     # Configure should probably be deprecated in favor of settings.
-    def self.configure
+    def self.configure(&)
       with self yield instance.settings
     end
 

--- a/src/amber/validators/params.cr
+++ b/src/amber/validators/params.cr
@@ -34,7 +34,7 @@ module Amber::Validators
       @value = params[@field]
       @present = params.has_key?(@field)
 
-      return true if (params[@field].blank? && @allow_blank)
+      return true if params[@field].blank? && @allow_blank
 
       @predicate.call params[@field] unless @predicate.nil?
     end
@@ -99,7 +99,7 @@ module Amber::Validators
     #   required(:age, UInt32)
     # end
     # ```
-    def validation
+    def validation(&)
       with ValidationBuilder.new(self) yield
       self
     end


### PR DESCRIPTION
### Description of the Change

Bumps ameba dependency.

### Benefits

It allows newly created apps to be runnable out-of-the-box (ameba < 1.3 doesn't work with recent Crystal versions).

### Possible Drawbacks

None
