### PR TITLE
update exception_page to 0.3.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -72,7 +72,7 @@ dependencies:
 
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.2.1
+    version: ~> 0.3.0
 
   yaml_mapping:
     github: crystal-lang/yaml_mapping.cr


### PR DESCRIPTION
### Description of the Change

Update dependency `exception_page` to 0.3.0.

### Alternate Designs

n/a

### Benefits

removal of additional JS no longer needed on exception pages.

### Possible Drawbacks

I am unaware of any
