### PR TITLE
Fixed the STD Lib monkey patch

### DIFF
--- a/spec/amber/router/request_spec.cr
+++ b/spec/amber/router/request_spec.cr
@@ -74,42 +74,5 @@ module Amber::Router
         end
       end
     end
-
-    describe "#method" do
-      %w(PUT PATCH DELETE).each do |method|
-        it "overrides form POST method to PUT, PATCH, DELETE" do
-          headers[HTTP::Request::OVERRIDE_HEADER] = method
-          request = HTTP::Request.new("POST", "/?test=test", headers)
-          request.method.should eq method
-        end
-
-        it "takes form post over header override" do
-          headers[HTTP::Request::OVERRIDE_HEADER] = "PUT"
-          headers["content-type"] = "application/x-www-form-urlencoded"
-          request = HTTP::Request.new("POST", "/?test=test", headers, "_method=PATCH")
-          request.method.should eq "PATCH"
-        end
-      end
-
-      it "overrides form request method only by upper case value" do
-        headers["content-type"] = "application/x-www-form-urlencoded"
-        request = HTTP::Request.new("POST", "/?test=test", headers, "_method=put")
-        request.method.should eq "PUT"
-      end
-    end
-
-    %w(PUT PATCH DELETE).each do |method|
-      it "overrides form POST method to PUT, PATCH, DELETE" do
-        headers["content-type"] = "application/x-www-form-urlencoded"
-        request = HTTP::Request.new("POST", "/?test=test", headers, "_method=#{method}")
-        request.method.should eq method
-      end
-
-      it "does not override other than PUT, PATCH, DELETE" do
-        headers["content-type"] = "application/x-www-form-urlencoded"
-        request = HTTP::Request.new("HEAD", "/?test=test", headers, "_method=#{method}")
-        request.method.should eq "HEAD"
-      end
-    end
   end
 end

--- a/src/amber/router/request.cr
+++ b/src/amber/router/request.cr
@@ -3,23 +3,11 @@ require "./router"
 require "./route"
 
 class HTTP::Request
-  METHOD          = "_method"
-  OVERRIDE_HEADER = "X-HTTP-Method-Override"
-
+  METHOD = "_method"
+  
   @matched_route : Amber::Router::RoutedResult(Amber::Route)?
   @requested_method : String?
   @params : Amber::Router::Params?
-
-  def method
-    case @method
-    when "POST" then requested_method.to_s.upcase
-    else             @method
-    end
-  end
-
-  def requested_method
-    @requested_method ||= params.override_method?(METHOD) || headers[OVERRIDE_HEADER]? || @method
-  end
 
   def params
     @params ||= Amber::Router::Params.new(self)


### PR DESCRIPTION
While trying to create a client to send `POST` requests with type `multipart/form-data`, my requests were being caught and messed up somehow.

This is infuriating to track down because the monkey patch was not at all obvious so I went ahead and removed this.

Overall the behavior is kind of weird. Changing form submissions from `POST` to other request types feels a bit dangerous.

There are a few tests that are failing for `io` reasons now. I'm running this branch in prod on my own project to see what kind of side effects it might have (yolo!)

Anyway, this was a huge blocker. Anyone using or trying to create an HTTP client of any kind would be affected.