### PR TITLE
 Updated Ameba to use v1.5

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -81,4 +81,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.3.0
+    version: ~> 1.5.0

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -54,4 +54,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.3.0
+    version: ~> 1.5.0


### PR DESCRIPTION
Resolving an error that arises when trying to install Ameba from a fresh Amber app