### PR TITLE
Fix Static pipe test on newer systems that uses "text/javascript" mime type.

### DIFF
--- a/src/amber/support/mime_types.cr
+++ b/src/amber/support/mime_types.cr
@@ -238,7 +238,7 @@ module Amber
         "jpg"       => "image/jpeg",
         "jpgv"      => "video/jpeg",
         "jpm"       => "video/jpm",
-        "js"        => "application/javascript",
+        "js"        => "text/javascript",
         "json"      => "application/json",
         "karbon"    => "application/vnd.kde.karbon",
         "kfo"       => "application/vnd.kde.kformula",


### PR DESCRIPTION
```
Failures:

  1) Amber::Pipe::Static serves the correct content type for serve file
     Failure/Error: response.headers["content-type"].should eq(Amber::Support::MimeTypes.mime_type(ext))

       Expected: "application/javascript"
            got: "text/javascript"

     # spec/amber/pipes/static_spec.cr:44
```

According to https://datatracker.ietf.org/doc/draft-ietf-dispatch-javascript-mjs/ "application/javascript" is obsolete.

### Possible Drawbacks

This may fail on CI if the system used to test is too old.
