### PR TITLE
feat: use multi-architecture image from 84codes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:latest
+FROM 84codes/crystal:latest-ubuntu-jammy
 
 # Install Dependencies
 ARG DEBIAN_FRONTEND=noninteractive
@@ -8,7 +8,14 @@ WORKDIR /opt/amber
 
 # Build Amber
 ENV PATH /opt/amber/bin:$PATH
-COPY . /opt/amber
+
+COPY shard.yml /opt/amber
+COPY shard.lock /opt/amber
+RUN shards install
+
+COPY src /opt/amber/src
+COPY spec /opt/amber/spec
+COPY bin /opt/amber/bin
 RUN shards build amber
 
-CMD ["crystal", "spec"]
+ENTRYPOINT []

--- a/bin/amber_spec
+++ b/bin/amber_spec
@@ -9,6 +9,5 @@ crystal tool format --check
 echo "\nRunning 'crystal spec':"
 crystal spec
 
-# Temporarily disabling due to some dependency challenges happening with granite
-#echo "\nRunning 'crystal spec ./spec/build_spec_granite.cr':"
-#crystal spec ./spec/build_spec_granite.cr
+echo "\nRunning 'crystal spec ./spec/build_spec_granite.cr':"
+crystal spec ./spec/build_spec_granite.cr


### PR DESCRIPTION
### Description of the Change

This replaces the base image of Docker to use the 84codes multi-architecture image.  This adds support for arm64 architecture for use on Apple Silicon, Raspberry PI, AWS Graviton and other flavors of arm based chips.

`docker-compose run spec`

### Alternate Designs

There is no official multi-architecture image supported by crystallang at this time.

### Benefits

Support for arm64 based systems

### Possible Drawbacks

This adds a dependency on 84codes and their available repos and docker images.
