### PR TITLE
fix: support multiple architecture docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:latest
+FROM 84codes/crystal:latest-ubuntu-jammy
 
 # Install Dependencies
 ARG DEBIAN_FRONTEND=noninteractive
@@ -8,7 +8,14 @@ WORKDIR /opt/amber
 
 # Build Amber
 ENV PATH /opt/amber/bin:$PATH
-COPY . /opt/amber
+
+COPY shard.yml /opt/amber
+COPY shard.lock /opt/amber
+RUN shards install
+
+COPY src /opt/amber/src
+COPY spec /opt/amber/spec
+COPY bin /opt/amber/bin
 RUN shards build amber
 
-CMD ["crystal", "spec"]
+ENTRYPOINT []

--- a/bin/amber_spec
+++ b/bin/amber_spec
@@ -9,6 +9,5 @@ crystal tool format --check
 echo "\nRunning 'crystal spec':"
 crystal spec
 
-# Temporarily disabling due to some dependency challenges happening with granite
-#echo "\nRunning 'crystal spec ./spec/build_spec_granite.cr':"
-#crystal spec ./spec/build_spec_granite.cr
+echo "\nRunning 'crystal spec ./spec/build_spec_granite.cr':"
+crystal spec ./spec/build_spec_granite.cr


### PR DESCRIPTION
### Description of the Change

This replaces the crystallang base image with 84codes to add support for arm64 chips.

### Alternate Designs

Continue to use the crystallang base image

### Benefits

Support for systems like apple silicon, windows for arm64, raspberry pi, AWS Graviton instances

### Possible Drawbacks

Creates a dependency on 84codes repositories
