### PR TITLE
Remove use of YAML.mapping from amber/cli/plugins/settings.cr.

### DIFF
--- a/src/amber/cli/plugins/settings.cr
+++ b/src/amber/cli/plugins/settings.cr
@@ -1,22 +1,13 @@
 require "yaml"
-require "yaml_mapping"
 
 module Amber::Plugins
   class Settings
+    include YAML::Serializable
+
     alias RouteType = Hash(String, Hash(String, Array(String)))
 
-    YAML.mapping(
-      routes: {
-        type:    RouteType,
-        default: {
-          "pipelines" => Hash(String, Array(String)).new,
-          "plugs"     => Hash(String, Array(String)).new,
-        },
-      },
-      args: {
-        type:    Array(String),
-        default: [] of String,
-      }
-    )
+    property routes = RouteType{"pipelines" => Hash(String, Array(String)).new,
+                                "plugs"     => Hash(String, Array(String)).new}
+    property args = [] of String
   end
 end


### PR DESCRIPTION
### Description of the Change

Remove use of `YAML.mapping` on amber/cli/plugins/settings.cr

My original objective was to fully remove `YAML.mapping` from Amber, but without time to complete the whole removal I though that submit the initial work would be a good start.

