### PR TITLE
Removes monkey patch that allows HTTP Method Tunneling

### DIFF
--- a/src/amber/router/request.cr
+++ b/src/amber/router/request.cr
@@ -6,49 +6,56 @@ class HTTP::Request
   METHOD          = "_method"
   OVERRIDE_HEADER = "X-HTTP-Method-Override"
 
+  # Required for the `matched_route` method
   @matched_route : Amber::Router::RoutedResult(Amber::Route)?
-  @requested_method : String?
+  
+  # Required for the `params` method
   @params : Amber::Router::Params?
 
-  def method
-    case @method
-    when "POST" then requested_method.to_s.upcase
-    else             @method
-    end
-  end
-
-  def requested_method
-    @requested_method ||= params.override_method?(METHOD) || headers[OVERRIDE_HEADER]? || @method
-  end
-
+  # A necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def params
     @params ||= Amber::Router::Params.new(self)
   end
 
+  # This is a necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def port
     uri.port
   end
 
+  # This is a necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def url
     uri.to_s
   end
 
+  # This is a necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def route
     matched_route.payload.not_nil!
   end
 
+  # This is a necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def valid_route?
     matched_route.payload? || router.socket_route_defined?(self)
   end
 
+  # This is a necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def process_websocket
     router.get_socket_handler(self)
   end
 
+  # This is a necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def matched_route
     @matched_route ||= router.match_by_request(self)
   end
 
+  # This is a necessary method that the rest of the Amber server requires to be present
+  # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   private def router
     Amber::Server.router
   end


### PR DESCRIPTION
The tunneling causes other issues with HTTP requests when using external APIs, but they tend to be weird errors related to the body of the request being empty. They can usually be tracked down and resolved by trying the same API request outside of Amber and everything works, but once put into Amber it stops working as expected.

### Description of the Change

Removed a key methods that trigger the change, now things are mostly the same but HTTP Method Tunneling will not work.

The test coverage remains so that if a refactor happens we can keep it. I'm not entirely convinced it's worth keeping at this point. This was a very helpful approach in the early 2010s before JavaScript was more widely used, but I think HTTP method tunneling is a rather antiquated approach that can be removed entirely at this point.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Probably could have made some kind of pipe or some other modification to the request object. Again, I'm not sure this is worth keeping longterm. It's modeled after the RailsUJS, but is it really worth keeping?

### Benefits

<!-- What benefits will be realized by the code change? -->

More minimalistic reliance on the standard library.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

The AmberUJS is going to stop working. 