### PR TITLE
Fix unsafe shell invocation in amber exec

### DIFF
--- a/spec/amber/cli/commands/exec_spec.cr
+++ b/spec/amber/cli/commands/exec_spec.cr
@@ -44,10 +44,30 @@ module Amber::CLI
         File.delete("amber_exec_spec_test.cr")
       end
 
-      it "opens editor and executes .cr file on close" do
-        MainCommand.run(["exec", "-e", "echo 'puts 1000' > "])
-        logs = `ls tmp/*_console_result.log`.strip.split(/\s/).sort
-        File.read(logs.last?.to_s).should eq "1000\n"
+      it "does not execute shell metacharacters in the editor option" do
+        marker = "amber_exec_editor_pwned"
+        File.delete(marker) if File.exists?(marker)
+
+        expect_raises(Exception) do
+          MainCommand.run(["exec", "-e", "sh -c 'touch #{marker}' #"])
+        end
+
+        File.exists?(marker).should be_false
+      end
+
+      it "does not execute shell metacharacters in copied filenames" do
+        filename = "amber_exec_spec_test; touch amber_exec_copy_pwned #.cr"
+        marker = "amber_exec_copy_pwned"
+        File.delete(marker) if File.exists?(marker)
+        File.write filename, "puts([:safe])"
+
+        begin
+          MainCommand.run(["exec", filename, "-e", "tail"])
+        ensure
+          File.delete(filename) if File.exists?(filename)
+        end
+
+        File.exists?(marker).should be_false
       end
 
       it "copies previous run into new file for editing and runs it returning results" do

--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -35,7 +35,7 @@ module Amber::CLI
                       Dir.glob("./tmp/*_console.cr").sort.reverse![options.back.to_i(strict: false) - 1]?
                     end
 
-        system("cp #{_filename} #{@filename}") if _filename
+        Process.run("cp", [_filename, @filename]) if _filename
       end
 
       private def show
@@ -72,7 +72,7 @@ module Amber::CLI
 
         if args.code.blank? || File.exists?(args.code)
           prepare_file
-          system("#{options.editor} #{@filename}")
+          Process.run(options.editor, [@filename], output: Process::Redirect::Inherit, error: Process::Redirect::Inherit)
         else
           File.write(@filename, wrap(args.code))
         end


### PR DESCRIPTION
## Summary
Backport the amber exec shell-invocation fix to stable.

## Changes
- replace shell-based editor launch with direct process execution
- replace shell-based file copy with direct process execution
- add regression coverage for shell metacharacters in --editor and copied filenames

## Verification
I could not run the Crystal spec suite in this environment because the host does not have crystal or shards installed. This PR includes regression specs for the affected code paths for maintainers/CI to exercise.