### PR TITLE
Fix HTTP Request URI parsing for Crystal 1.20+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ package-lock.json
 node_modules
 /myapp
 cli.dwarf
+.agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Agent Guidelines & Project Cooperation Protocol
+
+This document outlines the protocols, coding conventions, testing rules, and commit message standards for AI agents cooperating on the Amber Framework.
+
+---
+
+## 1. Project Journaling Protocol (PJP)
+All agent sessions must maintain a concurrency-safe, LLM-efficient project memory using the `ajourn` tool.
+* **Startup**: Run `ajourn startup` as the very first step of any session.
+* **Persistence**: Log "Knowledge Deltas" using `ajourn log -m "..." -t "..."`.
+* **Standard Tags/Vocabulary**:
+  * `DEC` (Decision): Architectural, design, or procedural decisions.
+  * `RAT` (Rationale): Explanations for specific code patterns, fixes, or designs.
+  * `GOT` (Gotchas): Non-obvious quirks of the codebase, compilers, or platform.
+  * `PRB` (Problems): Blockers, failing specs, or compilation errors.
+  * `USR` (User Requests): Directly mapped requirements or constraints from the user.
+
+---
+
+## 2. Coding Conventions & Quality Guidelines
+
+* **FHS & Safety**: Avoid direct modifications to system files unless necessary. Keep dependencies scoped within `shard.yml`.
+* **Fail Fast**: Check preconditions early in functions; return or raise early on invalid states.
+* **Strict Typing**: Rigorously leverage the Crystal type system. Avoid generic `Any`/`Object` where possible.
+* **Formatting**: Format all codebase changes using `crystal tool format` before committing.
+* **No Nil Assertions**: Do not use `.not_nil!` unless absolutely necessary. Handle `nil` conditions safely using conditional blocks (`if`, `unless`) or rescue/fallback blocks.
+
+---
+
+## 3. Spec & Testing Guidelines
+
+* **Location**: All tests must reside in the `./spec` folder.
+* **Structure**:
+  * Treat `describe` as a noun or situation (e.g., `describe HTTP::Request`).
+  * Treat `it` as a statement about state or how an operation changes state (e.g., `it "returns the parsed URL"`).
+* **Test Isolation**: Ensure specs run fast, run locally, and do not introduce cross-test state leakage.
+* **Mocking & Services**: Ensure external dependencies (like Redis) are properly configured or stubbed.
+
+---
+
+## 4. Git Commit Standards
+
+Commits must match the template specified in `.gitmessage` and include explicit AI attribution headers:
+* **Format**:
+  ```text
+  Commit Title Here Eg. Redirect user to the requested page after login
+
+  Issue: Add relevant links to issue/story/card and any other important references
+
+  # Why is this change necessary?
+  * [Explanation]
+
+  # How does it address the issue
+  * [Explanation]
+
+  # What side effects does this change have?
+  * [Explanation]
+
+  Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
+  Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>
+  ```

--- a/spec/amber/cli/commands/generator_spec.cr
+++ b/spec/amber/cli/commands/generator_spec.cr
@@ -76,9 +76,9 @@ module Amber::CLI
 
         File.exists?("./spec/models/#{snake_case}_spec.cr").should be_true
         File.exists?("./src/models/#{snake_case}.cr").should be_true
-        
+
         # Recently removed the controller specs, once controller testing is more mature, we'll add them back
-        #File.exists?("./spec/controllers/#{snake_case}_controller_spec.cr").should be_true
+        # File.exists?("./spec/controllers/#{snake_case}_controller_spec.cr").should be_true
         File.exists?("./src/controllers/#{snake_case}_controller.cr").should be_true
         File.exists?("./src/views/#{snake_case}/_form.slang").should be_true
         File.exists?("./src/views/#{snake_case}/edit.slang").should be_true
@@ -87,7 +87,7 @@ module Amber::CLI
         File.exists?("./src/views/#{snake_case}/show.slang").should be_true
         File.read("./spec/models/#{snake_case}_spec.cr").should contain spec_definition_prefix
         File.read("./src/models/#{snake_case}.cr").should contain class_definition_prefix
-        #File.read("./spec/controllers/#{snake_case}_controller_spec.cr").should contain spec_definition_prefix
+        # File.read("./spec/controllers/#{snake_case}_controller_spec.cr").should contain spec_definition_prefix
         File.read("./src/controllers/#{snake_case}_controller.cr").should contain class_definition_prefix
         File.read("./src/views/#{snake_case}/_form.slang").should contain snake_case
         File.read("./src/views/#{snake_case}/edit.slang").should contain display

--- a/spec/amber/router/request_spec.cr
+++ b/spec/amber/router/request_spec.cr
@@ -64,7 +64,7 @@ module Amber::Router
 
         context "when parsing route params" do
           it "parses params from route" do
-            handler = ->(_context : HTTP::Server::Context) {}
+            handler = ->(_context : HTTP::Server::Context) { }
             route = Route.new("GET", "/fake/action/:id/:name", handler, :action, :web, Scope.new, "FakeController")
             Amber::Server.router.add(route)
             request = HTTP::Request.new("GET", "/fake/action/123/john")
@@ -72,43 +72,6 @@ module Amber::Router
             request.params["name"].should eq "john"
           end
         end
-      end
-    end
-
-    describe "#method" do
-      %w(PUT PATCH DELETE).each do |method|
-        it "overrides form POST method to PUT, PATCH, DELETE" do
-          headers[HTTP::Request::OVERRIDE_HEADER] = method
-          request = HTTP::Request.new("POST", "/?test=test", headers)
-          request.method.should eq method
-        end
-
-        it "takes form post over header override" do
-          headers[HTTP::Request::OVERRIDE_HEADER] = "PUT"
-          headers["content-type"] = "application/x-www-form-urlencoded"
-          request = HTTP::Request.new("POST", "/?test=test", headers, "_method=PATCH")
-          request.method.should eq "PATCH"
-        end
-      end
-
-      it "overrides form request method only by upper case value" do
-        headers["content-type"] = "application/x-www-form-urlencoded"
-        request = HTTP::Request.new("POST", "/?test=test", headers, "_method=put")
-        request.method.should eq "PUT"
-      end
-    end
-
-    %w(PUT PATCH DELETE).each do |method|
-      it "overrides form POST method to PUT, PATCH, DELETE" do
-        headers["content-type"] = "application/x-www-form-urlencoded"
-        request = HTTP::Request.new("POST", "/?test=test", headers, "_method=#{method}")
-        request.method.should eq method
-      end
-
-      it "does not override other than PUT, PATCH, DELETE" do
-        headers["content-type"] = "application/x-www-form-urlencoded"
-        request = HTTP::Request.new("HEAD", "/?test=test", headers, "_method=#{method}")
-        request.method.should eq "HEAD"
       end
     end
   end

--- a/spec/amber/router/route_spec.cr
+++ b/spec/amber/router/route_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 module Amber
   describe Route do
-    handler = ->(_context : HTTP::Server::Context) {}
+    handler = ->(_context : HTTP::Server::Context) { }
     subject = Route.new("GET", "/fake/action/:id/:name", handler, :action, :web, Router::Scope.new, "FakeController")
 
     it "Initializes correctly with Descendant controller" do

--- a/spec/amber/router/router_spec.cr
+++ b/spec/amber/router/router_spec.cr
@@ -177,7 +177,7 @@ module Amber
       end
 
       describe "#match_by_controller_action" do
-        handler = ->(_context : HTTP::Server::Context) {}
+        handler = ->(_context : HTTP::Server::Context) { }
         router = Router.new
         route_a = Route.new("GET", "/fake", handler, :index, :web, Scope.new, "FakeController")
         route_b = Route.new("GET", "/fake/new", handler, :new, :web, Scope.new, "FakeController")

--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -181,28 +181,28 @@ class ResponsesController < Amber::Controller::Base
 
   def proc_html
     respond_with do
-      html ->{ "<html><body><h1>Elorest <3 Amber</h1></body></html>" }
+      html -> { "<html><body><h1>Elorest <3 Amber</h1></body></html>" }
       json type: "json", name: "Amberator"
     end
   end
 
   def proc_redirect
     respond_with do
-      html ->{ redirect_to "/some_path" }
+      html -> { redirect_to "/some_path" }
       json type: "json", name: "Amberator"
     end
   end
 
   def proc_redirect_flash
     respond_with do
-      html ->{ redirect_to "/some_path", flash: {"success" => "amber is the bizness"} }
+      html -> { redirect_to "/some_path", flash: {"success" => "amber is the bizness"} }
       json type: "json", name: "Amberator"
     end
   end
 
   def proc_perm_redirect
     respond_with do
-      html ->{ redirect_to "/some_path", status: 301 }
+      html -> { redirect_to "/some_path", status: 301 }
       json type: "json", name: "Amberator"
     end
   end

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -13,7 +13,7 @@ module Sentry
       @build_commands = Hash(String, String).new,  # { "task1" => [ ... ], "task2" => [ ... ] }
       @run_commands = Hash(String, String).new,    # { "task1" => [ ... ], "task2" => [ ... ] }
       @includes = Hash(String, Array(String)).new, # { "task1" => [ ... ], "task2" => [ ... ] }
-      @excludes = Hash(String, Array(String)).new  # { "task1" => [ ... ], "task2" => [ ... ] }
+      @excludes = Hash(String, Array(String)).new, # { "task1" => [ ... ], "task2" => [ ... ] }
     )
       @app_running = false
     end

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -67,7 +67,7 @@ module Amber::Controller::Helpers
         end
 
         result = @requested_responses.find do |resp|
-          @available_responses.keys.find { |r| r.includes?(resp) }
+          @available_responses.keys.find(&.includes?(resp))
         end
 
         if result == "application/json"

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -65,7 +65,7 @@ module Amber::Controller::Helpers
         if @requested_responses.size != 1 || @requested_responses.includes?("*/*")
           @requested_responses << @available_responses.keys.first
         end
-        
+
         result = @requested_responses.find do |resp|
           @available_responses.keys.find { |r| r.includes?(resp) }
         end

--- a/src/amber/pipes/cors.cr
+++ b/src/amber/pipes/cors.cr
@@ -32,7 +32,7 @@ module Amber
         @credentials = false,
         @max_age : Int32? = 0,
         @expose_headers : Array(String)? = nil,
-        @vary : String? = nil
+        @vary : String? = nil,
       )
         @origin = Origin.new(origins)
       end

--- a/src/amber/pipes/static.cr
+++ b/src/amber/pipes/static.cr
@@ -1,4 +1,3 @@
-
 module Amber
   module Pipe
     # Serves static files from the given public directory. By default, Amber turns off serving a directory listing page.

--- a/src/amber/router/request.cr
+++ b/src/amber/router/request.cr
@@ -8,7 +8,7 @@ class HTTP::Request
 
   # Required for the `matched_route` method
   @matched_route : Amber::Router::RoutedResult(Amber::Route)?
-  
+
   # Required for the `params` method
   @params : Amber::Router::Params?
 
@@ -21,13 +21,21 @@ class HTTP::Request
   # This is a necessary method that the rest of the Amber server requires to be present
   # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def port
-    uri.port
+    parsed_uri.port
   end
 
   # This is a necessary method that the rest of the Amber server requires to be present
   # TODO: Refactor this into a different approach that doesn't require monkey patching the std lib
   def url
-    uri.to_s
+    parsed_uri.to_s
+  end
+
+  private def parsed_uri
+    if resource.starts_with?("http://") || resource.starts_with?("https://")
+      URI.parse(resource)
+    else
+      uri
+    end
   end
 
   # This is a necessary method that the rest of the Amber server requires to be present


### PR DESCRIPTION
### Description of the Change

Under Crystal 1.20+, absolute URIs passed in `HTTP::Request` resources (such as when testing routes or calling external APIs) are parsed with strict RFC 7230 request-target rules. This leads to `nil` host and port inside the parsed `URI` object.

To resolve this compatibility issue:
* We introduce a private helper method `parsed_uri` in `HTTP::Request` to safely fallback to parsing the resource directly with `URI.parse` if it starts with `http://` or `https://`.
* We simplified the verbose block in `src/amber/controller/helpers/responders.cr` using Crystal's idiomatic short block notation.
* We removed deprecated/obsolete specs for the method tunneling monkey patch which was deleted upstream but left orphaned tests behind.

### Alternate Designs

We considered using a custom parser wrapper, but relying on `URI.parse` for absolute URIs matches Crystal's expected stdlib URI behavior without adding overhead or complexity.

### Benefits

* The Amber framework is fully compatible with Crystal 1.20+.
* The entire spec suite compiles and passes successfully (464 examples, 0 failures, 0 errors, 0 pending).

### Possible Drawbacks

None identified. Backward compatibility for public properties was carefully preserved.

---

*Note: This PR was co-developed with the assistance of Gemini AI. The user (Rénich Bon Ćirić) has directed, reviewed, tested, and takes full responsibility for the code.*