### PR TITLE
Fix compiler deprecation warnings for Crystal 1.20+

### DIFF
--- a/src/amber/cli/commands/exec.cr
+++ b/src/amber/cli/commands/exec.cr
@@ -53,7 +53,7 @@ module Amber::CLI
         spawn show
         process = Process.run(code, shell: true, output: file, error: file)
         sleep 1.millisecond
-        process.exit_status
+        process.exit_code
       end
 
       private def wrap(code)

--- a/src/amber/cli/helpers/process_runner.cr
+++ b/src/amber/cli/helpers/process_runner.cr
@@ -13,7 +13,7 @@ module Sentry
       @build_commands = Hash(String, String).new,  # { "task1" => [ ... ], "task2" => [ ... ] }
       @run_commands = Hash(String, String).new,    # { "task1" => [ ... ], "task2" => [ ... ] }
       @includes = Hash(String, Array(String)).new, # { "task1" => [ ... ], "task2" => [ ... ] }
-      @excludes = Hash(String, Array(String)).new  # { "task1" => [ ... ], "task2" => [ ... ] }
+      @excludes = Hash(String, Array(String)).new, # { "task1" => [ ... ], "task2" => [ ... ] }
     )
       @app_running = false
     end
@@ -25,7 +25,7 @@ module Sentry
       loop do
         scan_files
         check_processes
-        sleep 1
+        sleep 1.second
       end
     end
 
@@ -120,11 +120,11 @@ module Sentry
             ok_to_run = true
           else
             log :run, "Building..."
-            time = Time.monotonic
+            time = Time.instant
             build_result = Amber::CLI::Helpers.run(build_command_run)
             exit 1 unless build_result.is_a? Process::Status
             if build_result.success?
-              log :run, "Compiled in #{(Time.monotonic - time)}"
+              log :run, "Compiled in #{(Time.instant - time)}"
               stop_processes("run") if @app_running
               ok_to_run = true
             elsif !@app_running # first run

--- a/src/amber/dsl/router.cr
+++ b/src/amber/dsl/router.cr
@@ -33,12 +33,12 @@ module Amber::DSL
 
     {% for verb in RESOURCES %}
       macro {{verb.id}}(*args)
-        route {{verb}}, \{{*args}}
+        route {{verb}}, \{{args.splat}}
         {% if verb == :get %}
-        route :head, \{{*args}}
+        route :head, \{{args.splat}}
         {% end %}
         {% if ![:trace, :connect, :options, :head].includes? verb %}
-        route :options, \{{*args}}
+        route :options, \{{args.splat}}
         {% end %}
       end
     {% end %}


### PR DESCRIPTION
### Description of the Change

When compiling the Amber framework under modern Crystal versions (e.g. 1.20+), several deprecation warnings are emitted. This Pull Request updates the deprecated methods to their modern equivalents:
* Updated `Process::Status#exit_status` to `Process::Status#exit_code` in `src/amber/cli/commands/exec.cr`.
* Replaced `Time.monotonic` with `Time.instant` in `src/amber/cli/helpers/process_runner.cr`.
* Replaced `sleep 1` with the modern `sleep 1.second` span-based signature in `src/amber/cli/helpers/process_runner.cr`.
* Replaced the deprecated double-brace macro splat syntax `{{*args}}` with `{{args.splat}}` in `src/amber/dsl/router.cr`.

### Alternate Designs

None. These changes follow standard deprecation warnings emitted during compilation.

### Benefits

* Clean compilation of the `amber` CLI binary under modern Crystal versions with 0 deprecation warnings.

### Possible Drawbacks

None.

---

*Note: This PR was co-developed with the assistance of Gemini AI. The user (Rénich Bon Ćirić) has directed, reviewed, tested, and takes full responsibility for the code.*