### PR TITLE
Correctly parse and match HTTP Accept header parameters

### DIFF
--- a/spec/amber/controller/respond_with_spec.cr
+++ b/spec/amber/controller/respond_with_spec.cr
@@ -152,6 +152,16 @@ module Amber::Controller
           context.response.headers["Content-Type"].should eq "application/json; charset=utf-8"
           context.response.status_code.should eq 403
         end
+
+        it "responds with json for complex Accept header with parameters" do
+          context.response.status_code = 200
+          expected_result = %({"type":"json","name":"Amberator"})
+          context.request.headers["Accept"] = "application/json; charset=utf-8, text/javascript, */*; q=0.0"
+          context.request.path = "/response/1"
+          ResponsesController.new(context).index.should eq expected_result
+          context.response.headers["Content-Type"].should eq "application/json; charset=utf-8"
+          context.response.status_code.should eq 200
+        end
       end
 
       describe "#proc input" do

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -65,7 +65,7 @@ module Amber::Controller::Helpers
         if @requested_responses.size != 1 || @requested_responses.includes?("*/*")
           @requested_responses << @available_responses.keys.first
         end
-        
+
         result = @requested_responses.find do |resp|
           @available_responses.keys.find { |r| r.includes?(resp) }
         end
@@ -96,8 +96,10 @@ module Amber::Controller::Helpers
     private def accepts_request_type
       accept = context.request.headers["Accept"]?
       if accept && !accept.empty?
-        accepts = accept.split(";").first?.try(&.split(Content::ACCEPT_SEPARATOR_REGEX))
-        return accepts if !accepts.nil? && !accepts.empty?
+        accepts = accept.split(Content::ACCEPT_SEPARATOR_REGEX).map do |part|
+          part.split(";").first.strip
+        end.reject(&.empty?)
+        return accepts unless accepts.empty?
       end
     end
 


### PR DESCRIPTION
### Description of the Change

Fixes a bug where semicolon-delimited options/parameters in individual Accept header types (such as quality values `q=...` or charsets like `charset=utf-8`) cause parsing failures. 

Previously, the Accept header parser split the entire header value on `;` first, taking only the first segment. This resulted in:
1. Ignoring all media types listed after the first semicolon.
2. Inability to match media types if the client requested them with parameters (like `application/json; charset=utf-8` from Dart/Flutter clients), returning the fallback type instead (usually HTML) even when JSON was available.

To address this:
* We split the Accept header on commas first to isolate individual media types.
* We then split each media type on semicolons to remove quality/charset parameters and extract the raw MIME type (e.g. `application/json`).
* Added a spec case to verify that complex Accept headers with parameters match correctly.

### Alternate Designs

None. This follows standard RFC 7231 content negotiation rules.

### Benefits

* Semicolons in media type list options no longer drop subsequent media types.
* Clients sending `application/json; charset=utf-8` are correctly matched to the controller's `json` block rather than receiving the default format (e.g., HTML).

### Possible Drawbacks

None.

---

*Note: This PR was co-developed with the assistance of Gemini AI. The user (Rénich Bon Ćirić) has directed, reviewed, tested, and takes full responsibility for the code.*