### PR TITLE
security: escape exception messages in default HTML error response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-11 - [XSS in Default Error Handler]
+**Vulnerability:** Reflected Cross-Site Scripting (XSS) in default HTML error response.
+**Learning:** The default error controller generated raw HTML incorporating the unescaped Exception message. In Crystal, `Exception#message` can be `nil` (`String?`), so safely interpolating it into HTML requires `HTML.escape(@ex.message || "")` and explicitly requiring the `"html"` module.
+**Prevention:** Always escape user-controllable or dynamic string data, including exception messages, before interpolating it into an HTML template or string.

--- a/spec/amber/pipes/error_spec.cr
+++ b/spec/amber/pipes/error_spec.cr
@@ -25,6 +25,19 @@ module Amber
 
         response.status_code.should eq 500
       end
+
+      it "escapes exception messages in the HTML response body" do
+        error = Error.new
+        error.next = ->(_context : HTTP::Server::Context) { raise "<script>alert('xss')</script>" }
+        request = HTTP::Request.new("GET", "/")
+        request.headers["Accept"] = "text/html"
+
+        response = create_request_and_return_io(error, request)
+
+        response.status_code.should eq 500
+        response.body.should contain("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;")
+        response.body.should_not contain("<script>")
+      end
     end
   end
 end

--- a/src/amber/controller/error.cr
+++ b/src/amber/controller/error.cr
@@ -1,5 +1,6 @@
 require "./base"
 require "../exceptions/page"
+require "html"
 
 module Amber::Controller
   class Error < Base
@@ -48,7 +49,7 @@ module Amber::Controller
         if Amber.env.development?
           Amber::Exceptions::Page.new(context, @ex)
         else
-          "<html><body><pre>#{@ex.message}</pre></body></html>"
+          "<html><body><pre>#{HTML.escape(@ex.message || "")}</pre></body></html>"
         end
       end
     end


### PR DESCRIPTION
Escapes raw HTML exception messages in the default error controller to prevent reflected XSS.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>