### PR TITLE
perf: optimize socket route checking to avoid array allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-11-20 - Array Allocation on Every Request in Socket Route Checking
+**Learning:** Checking for websocket routes using `@socket_routes.map(&.[:path]).includes?(request.path)` creates an array allocation (`.map`) and iterates through it on every single incoming HTTP request. This is particularly wasteful when socket route counts are small or non-existent, impacting baseline performance for all requests. `any?` significantly reduces processing time for these operations.
+**Action:** Always prefer early-exit enumeration methods like `any?`, `find`, or `includes?` directly on the collection instead of mapping to a temporary array first, especially in hot paths like request routing.

--- a/src/amber/router/router.cr
+++ b/src/amber/router/router.cr
@@ -49,7 +49,8 @@ module Amber
       end
 
       def socket_route_defined?(request)
-        @socket_routes.map(&.[:path]).includes?(request.path)
+        # ⚡ Bolt: Using any? avoids the allocation of an intermediate array and allows early exit
+        @socket_routes.any? { |route| route[:path] == request.path }
       end
 
       def match_by_request(request)


### PR DESCRIPTION
Replaces array mapping with a direct .any? check to avoid allocating a new array on every incoming HTTP request.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>