### PR TITLE
ux: add accessible labels to generated scaffold views

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-13 - Added missing labels to scaffolded form templates
+**Learning:** In Amber framework templates, using string literal interpolation for labels in ECR (like `<%= label(":#{field.name}") %>`) instead of evaluating the field name (like `<%= label(<%=":#{field.name}"%>) %>`) causes a runtime compilation error 'undefined local variable or method "field"' because the string literal passes the literal ruby interpolation into the generated file rather than interpreting it during scaffolding.
+**Action:** Always ensure that when generating variables in scaffold templates, the values are correctly interpolated inside `<%=` tags so that they are evaluated by the generator, not output literally into the resulting file.

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.ecr.ecr
@@ -17,6 +17,7 @@
   <div class="form-group">
 <% case field.type
    when "text" -%>
+    <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10") -%>
 <% when "boolean" -%>
   <%="<"%>%= label(<%=":#{field.name}"%>) do
@@ -27,6 +28,7 @@
     <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= select_field(name: "<%= field.name %>_id", collection: <% if config.model == "crecto" %>Repo.all(<%= field.class_name %>)<% else %><%= field.class_name %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control") -%>
 <% else -%>
+    <%="<"%>%= label(<%=":#{field.name}"%>) -%>
     <%="<"%>%= text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control") -%>
 <% end -%>
   </div>

--- a/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
+++ b/src/amber/cli/templates/scaffold/view/src/views/{{name}}/_form.slang.ecr
@@ -9,6 +9,7 @@
   .form-group
   <%- case field.type
      when "text" -%>
+    == label(<%=":#{field.name}"%>)
     == text_area(name: "<%= field.name -%>", content: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control", size: "30x10")
   <%- when "boolean" -%>
       == label(<%=":#{field.name}"%>) do
@@ -17,6 +18,7 @@
     == label(<%=":#{field.name}"%>)
     == select_field(name: "<%= field.name %>_id", collection: <% if config.model == "crecto" %>Repo.all(<%= field.class_name %>)<% else %><%= field.class_name %>.all<% end %>.map{|<%= field.name %>| [<%= field.name %>.id, <%= field.name %>.id]}, selected: <%= @name %>.<%= field.name %>_id, class: "form-control")
   <%- else -%>
+    == label(<%=":#{field.name}"%>)
     == text_field(name: "<%= field.name %>", value: <%= @name %>.<%= field.name %>, placeholder: "<%= field.name.capitalize %>", class: "form-control")
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Adds proper label elements to default text and textarea inputs in ECR and Slang scaffold view templates.

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>