### PR TITLE
Update ameba dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -81,4 +81,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5.0
+    branch: master

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -54,4 +54,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5.0
+    branch: master


### PR DESCRIPTION
### Description of the Change

With the latest Crystal update to 1.21.0 the project fails to build `ameba` dependency. Here's the error that happens after running `shards install`:
```
Failed postinstall of ameba on shards build -Dpreview_mt:
I: Dependencies are satisfied
I: Building: ameba
E: Error target ameba failed to compile:
The 'preview_mt' flag is deprecated. Resize the default execution context, or start additional contexts instead.

In src/ameba/rule/base.cr:117:34

 117 | source.add_issue(self, {{ *args }}, {{ **kwargs }}) {{ block }}
                                  ^
Warning: Deprecated use of splat operator. Use `#splat` instead

In src/ameba/rule/base.cr:117:48

 117 | source.add_issue(self, {{ *args }}, {{ **kwargs }}) {{ block }}
                                                ^
Warning: Deprecated use of double splat operator. Use `#double_splat` instead

A total of 3 warnings were found.
Showing last frame. Use --error-trace for full trace.

In src/ameba/tokenizer.cr:88:15

 88 | lexer.next_string_array_token
            ^----------------------
Error: undefined method 'next_string_array_token' for Crystal::Lexer (compile-time type is Crystal::Lexer+)
```

This was fixed by the upstream but there's no tagged release with the patch yet, so switching to `master` branch

### Benefits

Latest stable compiler support

### Possible Drawbacks

The dependency is not pinned

### References
- https://github.com/crystal-ameba/ameba/pull/823
- https://github.com/Homebrew/homebrew-core/pull/293531