### PR TITLE
Prepare Amber 2.0.0-beta.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,186 +1,36 @@
 version: 2.1
 
-parameters:
-  pre_release_test_trigger:
-    type: string
-    default: ""
-
 jobs:
-  ameba-test:
+  v2-beta:
     resource_class: medium
     docker:
       - image: crystallang/crystal:latest
-
     working_directory: ~/amber
-    steps:
-      - run:
-          name: Install missing dependencies
-          command: |
-            apt-get update -qq && apt-get install -y libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev curl 
-      - checkout
-      - restore_cache:
-          name: Restore Shards Cache
-          keys: 
-            - shards-cache
-      - run:
-          name: shards install
-          command: shards install
-      - save_cache:
-          key: shards-cache
-          paths:
-            - lib
-      - run:
-          name: Running Ameba
-          command: bin/ameba
-  
-  granite-test:
-    resource_class: medium
-    docker:
-      - image: crystallang/crystal:1.9.2
-      - image: postgres:15.4
-        environment:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: granite_test
-
-    working_directory: ~/amber
-    steps:
-      - run:
-          name: Install missing dependencies
-          command: |
-            apt-get update -qq && apt-get install -y libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev curl 
-      - checkout
-      - run:
-          name: Create test results folder
-          command: |
-            mkdir ~/amber/test-results
-      - restore_cache:
-          name: Restore Shards Cache
-          keys: 
-            - shards-cache
-      - run:
-          name: shards install
-          command: shards install
-      - save_cache:
-          key: shards-cache
-          paths:
-            - lib
-      - run:
-          name: Running Granite Build Spec1
-          command: crystal spec spec/build_spec_granite.cr --junit_output ~/amber/test-results/granite-build-spec.xml
-
-      - store_test_results:
-          path: ~/amber/test-results
-  
-  amber-specs:
-    resource_class: medium
-    docker:
-      - image: crystallang/crystal:1.9.2
-
-    working_directory: ~/amber
-    steps:
-      - run:
-          name: Install missing dependencies
-          command: |
-            apt-get update -qq && apt-get install -y libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev curl 
-      - checkout
-      - run:
-          name: Create test results folder
-          command: |
-            mkdir ~/amber/test-results
-      - restore_cache:
-          name: Restore Shards Cache
-          keys: 
-            - shards-cache
-      - run:
-          name: shards install
-          command: shards install
-      - save_cache:
-          key: shards-cache
-          paths:
-            - lib
-      - run:
-          name: Running Amber specs
-          command: crystal spec --junit_output ~/amber/test-results/amber-specs.xml
-
-      - store_test_results:
-          path: ~/amber/test-results
-
-  osx_tests:
-    resource_class: macos.m1.medium.gen1
-    macos: 
-      # This is arbitrary, but necessary to get the latest version of macOS
-      xcode: 15.0.0 # v15 is a beta release, but it's also the latest version of macOS
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - checkout
       - restore_cache:
           keys:
-            - lib-cache
-      - restore_cache:
-          keys:
-            - bin-cache
+            - v2-shards-{{ checksum "shard.yml" }}
+            - v2-shards-
       - run:
-          name: Make directory for test output
-          command: mkdir -p test_output
-      - run:
-          name: Install Crystal & Dependencies
-          command: brew install openssl@3 postgresql@15 sqlite crystal && brew link postgresql@15
-      - run:
-          name: Build the Amber binary & symlink to it
-          command: shards install && crystal build src/amber/cli.cr -o bin/amber && sudo ln -s $PWD/bin/amber /usr/local/bin/amber
+          name: Install dependencies
+          command: shards install
       - save_cache:
-          key: lib-cache
+          key: v2-shards-{{ checksum "shard.yml" }}
           paths:
             - lib
-      - save_cache:
-          key: bin-cache
-          paths:
             - bin
       - run:
-          name: Create A New Amber App with Postgres
-          command: amber new new_pg_app && cd new_pg_app
+          name: Check beta contract
+          command: scripts/check_beta_contract.sh
       - run:
-          name: Create a database object
-          command: amber db create && amber scaffold user name:string email:string
+          name: Run framework specs
+          command: crystal spec
       - run:
-          name: Run the Amber App in the background
-          command: amber watch & echo $! > amber.pid
-      - run:
-          name: Wait for server to start
-          command: sleep 15
-      - run:
-          name: Does the homepage return a 200?
-          command: curl http://localhost:3000/ | grep "Thank you for trying out the Amber Framework."
-      - run:
-          name: Stop the Amber App test for Postgres
-          command: kill -9 $(cat amber.pid)
-      - run:
-          name: Create A New Amber App with SQLite
-          command: cd .. && amber new new_app_sqlite --database sqlite && cd new_app_sqlite
-      - run:
-          name: Create the database
-          command: amber db create && amber db scaffold user name:string email:string && amber db migrate
-      - run:
-          name: Run the Amber App in the background
-          command: amber watch & echo $! > amber.pid
-      - run:
-          name: Wait for server to start
-          command: sleep 15
-      - run:
-          name: The home page is accessible and returns a 200
-          command: curl http://localhost:3000/ | grep "Thank you for trying out the Amber Framework."
-      
+          name: Check Crystal formatting
+          command: crystal tool format --check src spec
 
 workflows:
-  new_changes:
+  v2-beta:
     jobs:
-      - ameba-test
-      - amber-specs
-      - granite-test
-  pre_release_tests:
-    when: << pipeline.parameters.pre_release_test_trigger >>
-    jobs:
-      - osx_tests
-
+      - v2-beta

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,13 @@ jobs:
       - image: crystallang/crystal:latest
     working_directory: ~/amber
     steps:
-      - checkout
+      # The legacy CircleCI project SSH key is no longer accepted by GitHub.
+      # This is a public repository, so check out the exact build SHA over HTTPS.
+      - run:
+          name: Checkout code over HTTPS
+          command: |
+            git clone https://github.com/amberframework/amber.git .
+            git checkout "$CIRCLE_SHA1"
       - restore_cache:
           keys:
             - v2-shards-{{ checksum "shard.yml" }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - v2-dev
+    tags:
+      - "v2.*"
   pull_request:
     branches:
       - master
@@ -30,6 +33,9 @@ jobs:
 
       - name: Install dependencies
         run: shards install
+
+      - name: Check Amber V2 beta contract
+        run: scripts/check_beta_contract.sh
 
       - name: Run specs
         # Defined order for now: the suite has pre-existing order-dependent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0-dev (unreleased)
+## 2.0.0-beta.1 (2026-07-31)
 
 This release represents a major architectural revision of the Amber framework.
 The primary goals were to remove all runtime dependencies, modernize the
@@ -60,8 +60,9 @@ configuration structs. Sections: `server`, `database`, `session`, `logging`,
 using the `AMBER_{SECTION}_{KEY}` naming convention (e.g.,
 `AMBER_SERVER_PORT=8080`, `AMBER_DATABASE_URL=postgres://...`).
 
-The `Amber::Server.configure` block no longer accepts a block parameter;
-properties are set directly inside the block.
+`Amber::Server.configure` supports both the V1 block-parameter form and the V2
+DSL form. New applications use the DSL form, while existing applications can
+migrate incrementally without changing every configuration assignment at once.
 
 #### Session defaults changed
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ _Amber makes building web applications fast, simple, and enjoyable - with fewer 
 
 # Welcome! Introducing Amber
 
-**Amber V2 is in active development (pre-release beta).** The `v2-dev` branch is stable enough for experimentation and early adoption but is not yet recommended for production. See [docs/migration-guide.md](docs/migration-guide.md) for a complete list of breaking changes from V1, and [amberframework/amber_cli](https://github.com/amberframework/amber_cli) for the standalone CLI tool that replaces the built-in generator commands.
+**Amber 2.0.0-beta.1 is available for testing.** It is a pre-release: use it
+for evaluation and new projects that can tolerate breaking changes, not for
+production workloads. The supported beta path is an ECR web application
+created by the standalone [Amber CLI](https://github.com/amberframework/amber_cli).
+See the [beta installation guide](docs/beta-installation.md) for supported
+platforms and an end-to-end verification procedure, or the
+[migration guide](docs/migration-guide.md) when upgrading an Amber 1.x app.
 
 **Amber** is a web application framework written in [Crystal](https://crystal-lang.org/) inspired by Kemal, Rails, Phoenix, Flutter and other popular application frameworks.
 
@@ -31,10 +37,10 @@ The goal for V2 is to cover every aspect of a modern web application. Here is wh
 4. Transactional emails - built-in mailer with SMTP and memory adapters
 5. WebSockets - channels with presence tracking, message decoders, and connection recovery
 
-**In the wider V2 ecosystem (separate shards):**
+**In the wider V2 ecosystem:**
 
 6. CLI with generators, dev workflow, and an LSP server - [amberframework/amber_cli](https://github.com/amberframework/amber_cli)
-7. ActiveRecord-style ORM (Grant) and file attachments - in active development, publishing to the amberframework org soon
+7. Persistence, authentication, and native-app generators are preview surfaces. They are not part of the supported beta web-app path yet.
 
 **On the roadmap (not built yet):**
 
@@ -88,16 +94,35 @@ Read Amber documentation on https://docs.amberframework.org/amber
 
 ## Installation & Usage
 
-Add this to your application's `shard.yml`:
+Install the standalone CLI with Homebrew on macOS or Linux:
+
+```bash
+brew tap amberframework/amber_cli
+brew install amber_cli
+amber --version
+```
+
+Create and verify a web application:
+
+```bash
+amber new my_app --type web
+cd my_app
+shards install
+crystal spec
+amber watch
+```
+
+The generated `shard.yml` pins this framework beta:
 
 ```yaml
 dependencies:
   amber:
     github: amberframework/amber
-    branch: v2-dev
+    version: 2.0.0-beta.1
 ```
 
-[Read Amber quick start guide](https://docs.amberframework.org/amber/getting-started)
+[Read the complete beta installation guide](docs/beta-installation.md),
+including direct-binary installation and troubleshooting.
 
 ## Have an Amber-based Project?
 
@@ -122,7 +147,7 @@ Amber is a community effort and we want You to be part of it. [Join Amber Commun
 
 1. Fork it https://github.com/amberframework/amber/fork
 2. Create your feature branch `git checkout -b my-new-feature`
-3. Write and execute specs and formatting checks `./bin/amber_spec`
+3. Write and execute specs and formatting checks with `crystal spec` and `crystal tool format --check`
 4. Commit your changes `git commit -am 'Add some feature'`
 5. Push to the branch `git push origin my-new-feature`
 6. Create a new Pull Request

--- a/RELEASE_NOTES_V2_BETA1.md
+++ b/RELEASE_NOTES_V2_BETA1.md
@@ -1,0 +1,56 @@
+# Amber 2.0.0-beta.1
+
+Amber V2's first public beta establishes a tested, documented path for creating
+an ECR web application with the standalone Amber CLI.
+
+This is a prerelease. Expect breaking changes before Amber 2.0.0 and do not use
+it for production workloads that cannot tolerate them.
+
+## Install and create a web app
+
+Install Amber CLI 2.0.2 or newer:
+
+```bash
+brew tap amberframework/amber_cli
+brew install amber_cli
+amber new my_app --type web
+cd my_app
+crystal spec
+amber watch
+```
+
+See the [beta installation guide](https://github.com/amberframework/amber/blob/v2.0.0-beta.1/docs/beta-installation.md)
+for direct archives, checksums, update/uninstall steps, and troubleshooting.
+
+## Release-gated surface
+
+- Apple Silicon macOS and x86_64 Linux
+- Homebrew and matching direct CLI archives
+- ECR web application generation
+- dependency installation, specs, application build, server start, homepage,
+  and static CSS
+- framework core, routing, typed configuration, Schema API, jobs, mailer,
+  WebSockets, adapters, and testing helpers
+
+## Major V2 changes
+
+- CLI and LSP extracted to `amberframework/amber_cli`
+- ECR is the only supported view engine; Kilt and Slang were removed
+- runtime shard dependencies removed from framework core
+- database drivers and ORM are explicit application choices
+- typed, sectioned YAML with environment-variable overrides
+- built-in jobs, mailer, Schema API, and adapter-backed infrastructure
+
+Read the [V1 to V2 migration guide](https://github.com/amberframework/amber/blob/v2.0.0-beta.1/docs/migration-guide.md)
+before upgrading an existing application.
+
+## Preview surfaces
+
+Persistence/auth/API-resource generators, Grant integration, Gemma attachments,
+the separate Asset Pipeline, and native app generation are not part of the
+core beta release gate. Intel macOS, Linux ARM64, and Windows do not have
+release-gated CLI archives in this beta.
+
+Please report framework issues at
+<https://github.com/amberframework/amber/issues> and CLI/template/install issues
+at <https://github.com/amberframework/amber_cli/issues>.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 ## Getting Started
 
-- [Getting Started](getting-started.md) -- Create a minimal Amber V2 application from scratch
+- [Beta Installation and Support](beta-installation.md) -- Supported platforms, install methods, verification, updates, and troubleshooting
+- [Getting Started](getting-started.md) -- Create and run an Amber V2 web application with the standalone CLI
 
 ## Guides
 

--- a/docs/beta-installation.md
+++ b/docs/beta-installation.md
@@ -1,0 +1,159 @@
+# Amber V2 Beta Installation and Support
+
+This is the release contract for Amber `2.0.0-beta.1` and Amber CLI `2.0.2`.
+The goal is a repeatable first run, not a promise that every experimental
+generator is production-ready.
+
+## Supported beta path
+
+| Surface | Beta status |
+|---|---|
+| macOS on Apple Silicon | Supported and release-gated |
+| Linux on x86_64 | Supported and release-gated |
+| Homebrew installation on those platforms | Supported |
+| Direct release archive on those platforms | Supported |
+| `amber new APP --type web` with ECR | Supported |
+| Build, specs, server launch, homepage, and static assets | Release-gated |
+| Intel macOS, Linux ARM64, and Windows | Not release-gated in this beta |
+| Native application template | Preview |
+| Persistence, auth, and resource generators | Preview |
+
+## Prerequisites
+
+Install Crystal 1.20 or newer, but earlier than 2.0, using the
+[official Crystal instructions](https://crystal-lang.org/install/). Verify the
+toolchain:
+
+```bash
+crystal --version
+shards --version
+git --version
+```
+
+## Install with Homebrew
+
+The tap name contains an underscore:
+
+```bash
+brew tap amberframework/amber_cli
+brew install amber_cli
+amber --version
+```
+
+The expected CLI version is `2.0.2` or newer. If another executable is found,
+run `command -v amber` and use the troubleshooting section below.
+
+## Install a release archive
+
+Choose the archive that matches the supported machine:
+
+- Apple Silicon macOS: `amber_cli-darwin-arm64.tar.gz`
+- x86_64 Linux: `amber_cli-linux-x86_64.tar.gz`
+
+The following example installs CLI `v2.0.2`. On Linux, replace the two
+`darwin-arm64` occurrences with `linux-x86_64`.
+
+```bash
+version=v2.0.2
+asset=amber_cli-darwin-arm64.tar.gz
+curl -fLO "https://github.com/amberframework/amber_cli/releases/download/${version}/${asset}"
+curl -fLO "https://github.com/amberframework/amber_cli/releases/download/${version}/${asset}.sha256"
+shasum -a 256 -c "${asset}.sha256"
+tar -xzf "${asset}"
+install -m 0755 amber amber-lsp /usr/local/bin/
+amber --version
+```
+
+Linux users may use `sha256sum -c` instead of `shasum -a 256 -c`. If
+`/usr/local/bin` requires elevated privileges, prefix only the `install`
+command with `sudo`.
+
+## Verify the complete web-app path
+
+Use a new directory name, then run every command below:
+
+```bash
+amber new amber_beta_smoke --type web
+cd amber_beta_smoke
+shards install
+crystal spec
+crystal build src/amber_beta_smoke.cr -o bin/amber_beta_smoke
+amber watch
+```
+
+In another terminal:
+
+```bash
+curl --fail http://127.0.0.1:3000/
+curl --fail http://127.0.0.1:3000/css/app.css
+```
+
+Both requests must succeed. The generated `shard.yml` must reference
+`amberframework/amber` at `2.0.0-beta.1`; it should not point at a personal
+fork or a moving branch.
+
+## Update or remove
+
+Homebrew:
+
+```bash
+brew update
+brew upgrade amber_cli
+# or
+brew uninstall amber_cli
+brew untap amberframework/amber_cli
+```
+
+For a direct installation, replace both installed binaries with the files from
+the newer verified archive. Remove `/usr/local/bin/amber` and
+`/usr/local/bin/amber-lsp` to uninstall.
+
+## Troubleshooting
+
+### The wrong `amber` runs
+
+Amber V1 bundled a CLI, and old source builds may still be earlier in `PATH`:
+
+```bash
+type -a amber
+amber --version
+```
+
+Remove or rename the stale executable, or place the new installation directory
+earlier in `PATH`.
+
+### Homebrew cannot install the binary on macOS
+
+Run `brew update`, then reinstall:
+
+```bash
+brew reinstall amberframework/amber_cli/amber_cli
+```
+
+The beta CLI's macOS release binary must link against supported Homebrew
+libraries and must not require `openssl@1.1`. Include the output of
+`otool -L "$(command -v amber)"` when reporting a failure.
+
+### The requested platform has no archive
+
+Only the two platforms in the support table are release-gated. Building from
+source can help contributors evaluate other platforms, but it is not an
+installation guarantee for this beta.
+
+### A preview generator needs another shard
+
+The minimal web template intentionally has no ORM, database driver, attachment
+library, or authentication shard. Do not add an unofficial or personal-fork
+dependency merely to make a preview generator compile. Follow that component's
+own release documentation or use the core web template until it is published.
+
+## Report a beta problem
+
+Open an issue in the repository that owns the failing step:
+
+- Framework behavior: <https://github.com/amberframework/amber/issues>
+- CLI, template, or binary: <https://github.com/amberframework/amber_cli/issues>
+- Homebrew formula: <https://github.com/amberframework/homebrew-amber_cli/issues>
+
+Include the OS and architecture, `crystal --version`, `amber --version`, the
+install method, the exact command, and the complete error output.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,203 +1,139 @@
 # Getting Started
 
-This guide walks through creating a minimal Amber V2 application from scratch. By the end, you will have a working web server that responds to HTTP requests with a rendered HTML page.
+This guide creates the supported Amber V2 beta application: a server-rendered
+web app using ECR templates and the standalone Amber CLI.
 
 ## Prerequisites
 
-- [Crystal](https://crystal-lang.org/install/) >= 1.0.0
-- A text editor
+- macOS on Apple Silicon or Linux on x86_64
+- Crystal 1.20 or newer (but earlier than Crystal 2.0)
+- Git and `shards`
+- Amber CLI 2.0.2 or newer
 
-## Create a New Project
+Follow the [beta installation guide](beta-installation.md) if `amber --version`
+does not work yet.
 
-Create a new Crystal project using `crystal init`:
+## Create the application
 
 ```bash
-crystal init app my_app
+amber new my_app --type web
 cd my_app
-```
-
-## Add Amber as a Dependency
-
-Edit `shard.yml` to add the Amber framework:
-
-```yaml
-name: my_app
-version: 0.1.0
-
-dependencies:
-  amber:
-    github: amberframework/amber
-    branch: v2-dev
-
-crystal: ">= 1.0.0"
-```
-
-Install dependencies:
-
-```bash
 shards install
 ```
 
-## Project Structure
+`--type web` is explicit so the command remains reproducible as more app types
+are added. The generated application uses:
 
-Create the following directory structure:
+- Amber `2.0.0-beta.1` from `amberframework/amber`
+- ECR templates
+- typed, sectioned environment configuration
+- a static-file pipeline for the generated CSS and JavaScript
+- no database or ORM dependency by default
 
-```
-my_app/
-  src/
-    my_app.cr
-    controllers/
-      home_controller.cr
-    views/
-      home/
-        index.ecr
-      layouts/
-        application.ecr
-```
+Database selection records generator metadata; it does not add an ORM or a
+database driver to this minimal web template.
 
-Create the directories:
+## Verify before you edit
+
+Run the generated specs and build the application:
 
 ```bash
-mkdir -p src/controllers src/views/home src/views/layouts
+crystal spec
+crystal build src/my_app.cr -o bin/my_app
 ```
 
-## Create a Controller
+Start the development watcher:
 
-Create `src/controllers/home_controller.cr`:
+```bash
+amber watch
+```
+
+Open <http://localhost:3000>. Also load
+<http://localhost:3000/css/app.css> to confirm the static-file pipeline is
+working. Stop the watcher with `Ctrl-C`.
+
+## Add a route
+
+The generated app includes `HomeController`. Add this action to
+`src/controllers/home_controller.cr`:
 
 ```crystal
-require "amber/controller/base"
-
-class HomeController < Amber::Controller::Base
-  def index
-    @title = "Welcome"
-    render("index.ecr")
+def health
+  respond_with 200 do
+    json({status: "ok", amber: Amber::VERSION})
   end
 end
 ```
 
-The `render` macro looks for the template at `src/views/home/index.ecr` based on the controller name. It wraps the template in the default layout at `src/views/layouts/application.ecr`.
-
-## Create Views
-
-Create the layout at `src/views/layouts/application.ecr`:
-
-```ecr
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8">
-  <title>My App</title>
-</head>
-<body>
-  <%= content %>
-</body>
-</html>
-```
-
-The `<%= content %>` placeholder is where the action template is inserted.
-
-Create the index template at `src/views/home/index.ecr`:
-
-```ecr
-<h1><%= @title %></h1>
-<p>Hello from Amber V2!</p>
-```
-
-## Configure the Server
-
-Edit `src/my_app.cr` to configure routing and start the server:
+Then add the route inside the generated `routes :web` block:
 
 ```crystal
-require "amber"
-require "./controllers/*"
-
-Amber::Server.configure do
-  pipeline :web do
-    plug Amber::Pipe::Error.new
-    plug Amber::Pipe::Logger.new
-  end
-
-  routes :web do
-    get "/", HomeController, :index
-  end
-end
-
-Amber::Server.start
+get "/health", HomeController, :health
 ```
 
-This configures a `:web` pipeline with error handling and request logging, maps `GET /` to `HomeController#index`, and starts the HTTP server.
-
-## Run the Application
-
-```bash
-crystal run src/my_app.cr
-```
-
-Visit `http://localhost:3000` in your browser to see your page.
+Restart `amber watch` if needed and visit <http://localhost:3000/health>.
 
 ## Configuration
 
-By default, Amber listens on `localhost:3000`. To change the host or port, create a YAML configuration file or use environment variables.
-
-### Environment Variables
-
-```bash
-AMBER_SERVER_HOST=0.0.0.0 AMBER_SERVER_PORT=8080 crystal run src/my_app.cr
-```
-
-### YAML Configuration
-
-Create `config/environments/development.yml`:
+Generated environment files use V2's typed structure:
 
 ```yaml
 name: "my_app"
 
 server:
-  host: "localhost"
+  host: "127.0.0.1"
   port: 3000
-  secret_key_base: "a_random_string_at_least_32_characters_long"
+  secret_key_base: "replace_this_in_production"
 
 logging:
   severity: "debug"
   colorize: true
 ```
 
-See the [Configuration Guide](guides/configuration.md) for all available settings.
+Environment variables override YAML values:
 
-## Adding More Routes
-
-Add additional routes and controllers as your application grows:
-
-```crystal
-Amber::Server.configure do
-  pipeline :web do
-    plug Amber::Pipe::Error.new
-    plug Amber::Pipe::Logger.new
-    plug Amber::Pipe::Session.new
-    plug Amber::Pipe::Flash.new
-    plug Amber::Pipe::CSRF.new
-  end
-
-  routes :web do
-    get "/", HomeController, :index
-    resources "users", UsersController
-    resources "posts", PostsController
-  end
-end
+```bash
+AMBER_SERVER_HOST=0.0.0.0 AMBER_SERVER_PORT=8080 amber watch
 ```
 
-The `resources` macro generates all seven RESTful routes (index, new, create, show, edit, update, destroy) for a given controller.
+See the [configuration guide](guides/configuration.md) for every section and
+override.
 
-## Next Steps
+## Manual framework installation
 
-- [Routing](guides/routing.md) -- Route definitions, resources, namespaces, constraints, and API versioning
-- [Configuration](guides/configuration.md) -- Environment YAML, environment variables, and custom config sections
-- [Action Helpers](guides/action-helpers.md) -- Form helpers, URL helpers, asset tags, and text formatting
-- [Schema API](guides/schema-api.md) -- Type-safe, validated parameter handling
-- [WebSockets](guides/websockets.md) -- Real-time communication with channels and presence tracking
-- [Background Jobs](guides/background-jobs.md) -- Asynchronous job processing
-- [Mailer](guides/mailer.md) -- Email delivery with SMTP and memory adapters
-- [Testing](guides/testing.md) -- Request helpers, assertions, and controller testing
-- [Markdown](guides/markdown.md) -- Markdown rendering with GFM support
-- [Migration Guide](migration-guide.md) -- Migrating from Amber V1 to V2
+The CLI is the supported onboarding path. If you need to add Amber to an
+existing Crystal application, pin the beta rather than the moving development
+branch:
+
+```yaml
+dependencies:
+  amber:
+    github: amberframework/amber
+    version: 2.0.0-beta.1
+
+crystal: ">= 1.20.0, < 2.0"
+```
+
+Then run `shards install` and configure the server as described in the
+[routing](guides/routing.md) and [configuration](guides/configuration.md)
+guides.
+
+## Generator support during the beta
+
+The web application template itself is the release-gated path. Generators that
+depend only on Amber core can be evaluated inside it. Persistence,
+authentication, API-resource, and native-app generators are preview surfaces
+until their external dependencies and platform matrices are released and
+documented. See the CLI's generator support table before relying on one in a
+project.
+
+## Next steps
+
+- [Beta installation and troubleshooting](beta-installation.md)
+- [Routing](guides/routing.md)
+- [Configuration](guides/configuration.md)
+- [Schema API](guides/schema-api.md)
+- [Background jobs](guides/background-jobs.md)
+- [Mailer](guides/mailer.md)
+- [Testing](guides/testing.md)
+- [Migration from Amber V1](migration-guide.md)

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -16,9 +16,12 @@ This guide covers every breaking change between Amber V1 (1.4.x) and Amber V2, w
 | Configuration restructured | YAML config files | Medium |
 | Session security updated | Session configuration | Low |
 
-## 1. CLI Removed
+## 1. CLI Extracted from the Framework
 
-The `amber` CLI tool (generators, scaffolding, database commands, watch, routes, encrypt, exec) has been completely removed from the framework. Amber V2 is a library, not a CLI tool.
+The `amber` executable is no longer compiled from the framework repository.
+Amber V2 is a library shard, while project creation, generators, the
+development watcher, and the LSP ship from the standalone
+[`amber_cli`](https://github.com/amberframework/amber_cli) repository.
 
 **Before (V1):**
 
@@ -30,36 +33,23 @@ amber watch
 amber routes
 ```
 
-**After (V2):**
+**After (V2 beta):**
 
 ```bash
-# Create a project manually
-mkdir my_app && cd my_app
-
-# Create shard.yml with amber dependency
-cat > shard.yml << 'YAML'
-name: my_app
-version: 0.1.0
-
-dependencies:
-  amber:
-    github: amberframework/amber
-    branch: v2-dev
-
-crystal: ">= 1.0.0, < 2.0"
-YAML
-
-# Create the directory structure
-mkdir -p src/controllers src/views/layouts config/environments
-
+brew tap amberframework/amber_cli
+brew install amber_cli
+amber new my_app --type web
+cd my_app
 shards install
-
-# Build and run directly
-crystal build src/my_app.cr -o bin/my_app
-./bin/my_app
+crystal spec
+amber watch
 ```
 
-A separate CLI tool (`amber_cli`) may be developed as an independent shard for project generation, but it is not part of the Amber framework itself.
+The generated project pins Amber `2.0.0-beta.1` and uses ECR. See the
+[beta installation guide](beta-installation.md) for direct binary installation,
+supported platforms, and the exact verification procedure. Persistence and
+authentication generators remain preview surfaces during this beta, so migrate
+those dependencies explicitly instead of assuming they are bundled.
 
 ## 2. Redis No Longer a Direct Dependency
 
@@ -83,7 +73,7 @@ dependencies:
 dependencies:
   amber:
     github: amberframework/amber
-    branch: v2-dev
+    version: 2.0.0-beta.1
   # No redis dependency needed for default configuration
 ```
 
@@ -347,7 +337,7 @@ dependencies:
 dependencies:
   amber:
     github: amberframework/amber
-    branch: v2-dev
+    version: 2.0.0-beta.1
   pg:
     github: will/crystal-pg
   granite:
@@ -467,7 +457,9 @@ Amber::Server.configure do
 end
 ```
 
-The configure block no longer takes a block parameter. Properties are set directly.
+The V2 DSL form is recommended for new code. The V1 block-parameter form is
+still accepted, so this change can be made independently from the rest of the
+migration.
 
 ## 9. Session Security Changes
 
@@ -496,7 +488,7 @@ Review your session configuration and update as needed.
 dependencies:
   amber:
     github: amberframework/amber
-    branch: v2-dev  # or version: ~> 2.0.0 once released
+    version: 2.0.0-beta.1
 ```
 
 ### Add to shard.yml (as needed)
@@ -513,7 +505,8 @@ dependencies:
 
 ## Migration Checklist
 
-- [ ] Update `shard.yml` to point to `amberframework/amber` (branch: v2-dev) and remove bundled dependencies
+- [ ] Install Amber CLI 2.0.2 or newer from `amberframework/amber_cli`
+- [ ] Update `shard.yml` to point to `amberframework/amber` at `2.0.0-beta.1` and remove bundled dependencies
 - [ ] Run `shards install`
 - [ ] Replace `YAML.mapping` with `YAML::Serializable` in all custom types
 - [ ] Rename all `.slang` templates to `.ecr` and convert syntax

--- a/scripts/check_beta_contract.sh
+++ b/scripts/check_beta_contract.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shard_version="$(awk '/^version:/ { print $2; exit }' shard.yml)"
+source_version="$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' src/amber/version.cr)"
+test "$shard_version" = "2.0.0-beta.1"
+test "$source_version" = "$shard_version"
+
+files=(README.md docs/README.md docs/getting-started.md docs/beta-installation.md docs/migration-guide.md RELEASE_NOTES_V2_BETA1.md)
+grep -F 'brew tap amberframework/amber_cli' docs/beta-installation.md
+grep -F 'brew install amber_cli' docs/beta-installation.md
+grep -F 'version: 2.0.0-beta.1' docs/getting-started.md
+
+if grep -Ein 'crimson-knight/(amber|grant|gemma)|amberframework/amber-cli|brew install amber-cli|branch: v2-dev' "${files[@]}"; then
+  echo "Amber beta docs contain a stale install or dependency instruction" >&2
+  exit 1
+fi
+
+echo "Amber framework beta contract checks passed"

--- a/shard.yml
+++ b/shard.yml
@@ -12,7 +12,8 @@ license: MIT
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5.0
+    # Includes upstream Crystal 1.21+ compatibility pending Ameba 1.7.0.
+    commit: cdd58b34b0d8a9c785d67183a7a8f07541549e55
 
 ai_docs:
   include:

--- a/shard.yml
+++ b/shard.yml
@@ -1,11 +1,11 @@
 name: amber
 
-version: 2.0.0-dev
+version: 2.0.0-beta.1
 
 authors:
   - Amber Team and Contributors <amberframework.org>
 
-crystal: ">= 1.0.0, < 2.0"
+crystal: ">= 1.20.0, < 2.0"
 
 license: MIT
 

--- a/src/amber/schema/examples/simple_form_example.cr
+++ b/src/amber/schema/examples/simple_form_example.cr
@@ -119,5 +119,5 @@ module SimpleFormExample
   end
 end
 
-# Run the examples
-SimpleFormExample.run
+# Call `SimpleFormExample.run` explicitly when evaluating this example. Requiring
+# Amber must never execute demonstrations or write to application stdout.

--- a/src/amber/version.cr
+++ b/src/amber/version.cr
@@ -1,3 +1,3 @@
 module Amber
-  VERSION = "1.4.1"
+  VERSION = "2.0.0-beta.1"
 end


### PR DESCRIPTION
## Summary

- prepare Amber 2.0.0-beta.1 with synchronized shard and runtime versions
- publish the supported macOS/Linux installation, verification, and migration guides
- add a beta contract check to CI and remove import-time output from a schema example

## Supported beta contract

The release-gated path is an ECR web application generated by Amber CLI 2.0.2 on Apple Silicon macOS or x86_64 Linux. Persistence/auth and native generation remain preview.

## Validation

- 2,320 framework specs pass
- Crystal formatting passes
- beta documentation/version contract check passes
- fresh generated app passes specs, build, server launch, homepage, and static CSS probes against this worktree
