### PR TITLE
Fix Crystal 1.21 server startup for 2.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.0-beta.2 (2026-07-31)
+
+This release supersedes beta.1 for the supported Amber CLI web-app path.
+
+- Replaced `Process.fork` in the HTTP server cluster launcher with portable
+  process spawning. This restores application compilation and launch with
+  Crystal 1.21's default multithreaded runtime on macOS and Linux.
+- Kept the beta.1 framework API and release-gated surface unchanged.
+
 ## 2.0.0-beta.1 (2026-07-31)
 
 This release represents a major architectural revision of the Amber framework.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Amber makes building web applications fast, simple, and enjoyable - with fewer 
 
 # Welcome! Introducing Amber
 
-**Amber 2.0.0-beta.1 is available for testing.** It is a pre-release: use it
+**Amber 2.0.0-beta.2 is available for testing.** It is a pre-release: use it
 for evaluation and new projects that can tolerate breaking changes, not for
 production workloads. The supported beta path is an ECR web application
 created by the standalone [Amber CLI](https://github.com/amberframework/amber_cli).
@@ -118,7 +118,7 @@ The generated `shard.yml` pins this framework beta:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.1
+    version: 2.0.0-beta.2
 ```
 
 [Read the complete beta installation guide](docs/beta-installation.md),

--- a/RELEASE_NOTES_V2_BETA2.md
+++ b/RELEASE_NOTES_V2_BETA2.md
@@ -1,0 +1,38 @@
+# Amber 2.0.0-beta.2
+
+Amber 2.0.0-beta.2 supersedes beta.1 for new Amber CLI web applications.
+It keeps the same public beta surface and fixes application startup on Crystal
+1.21's default multithreaded runtime.
+
+## Compatibility fix
+
+- Replaced the server cluster launcher's `Process.fork` reference with portable
+  process spawning.
+- Release-gated on Apple Silicon macOS and x86_64 Linux with Crystal 1.21.
+- Fresh ECR web apps are tested through dependency installation, specs, core
+  generators, build, server launch, homepage delivery, and static CSS.
+
+## Install and create a web app
+
+Install Amber CLI 2.0.2 or newer:
+
+```bash
+brew tap amberframework/amber_cli
+brew install amber_cli
+amber new my_app --type web
+cd my_app
+crystal spec
+amber watch
+```
+
+The generated application pins `amberframework/amber` at `2.0.0-beta.2` and
+uses ECR. Database drivers, persistence, auth, Grant, Gemma, Asset Pipeline,
+and native application generation remain opt-in preview surfaces rather than
+part of the core beta release gate.
+
+See the [beta installation guide](https://github.com/amberframework/amber/blob/v2.0.0-beta.2/docs/beta-installation.md)
+and [V1 to V2 migration guide](https://github.com/amberframework/amber/blob/v2.0.0-beta.2/docs/migration-guide.md).
+
+Please report framework issues at
+<https://github.com/amberframework/amber/issues> and CLI/template/install issues
+at <https://github.com/amberframework/amber_cli/issues>.

--- a/docs/beta-installation.md
+++ b/docs/beta-installation.md
@@ -1,6 +1,6 @@
 # Amber V2 Beta Installation and Support
 
-This is the release contract for Amber `2.0.0-beta.1` and Amber CLI `2.0.2`.
+This is the release contract for Amber `2.0.0-beta.2` and Amber CLI `2.0.2`.
 The goal is a repeatable first run, not a promise that every experimental
 generator is production-ready.
 
@@ -89,7 +89,7 @@ curl --fail http://127.0.0.1:3000/css/app.css
 ```
 
 Both requests must succeed. The generated `shard.yml` must reference
-`amberframework/amber` at `2.0.0-beta.1`; it should not point at a personal
+`amberframework/amber` at `2.0.0-beta.2`; it should not point at a personal
 fork or a moving branch.
 
 ## Update or remove

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ shards install
 `--type web` is explicit so the command remains reproducible as more app types
 are added. The generated application uses:
 
-- Amber `2.0.0-beta.1` from `amberframework/amber`
+- Amber `2.0.0-beta.2` from `amberframework/amber`
 - ECR templates
 - typed, sectioned environment configuration
 - a static-file pipeline for the generated CSS and JavaScript
@@ -109,7 +109,7 @@ branch:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.1
+    version: 2.0.0-beta.2
 
 crystal: ">= 1.20.0, < 2.0"
 ```

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -45,7 +45,7 @@ crystal spec
 amber watch
 ```
 
-The generated project pins Amber `2.0.0-beta.1` and uses ECR. See the
+The generated project pins Amber `2.0.0-beta.2` and uses ECR. See the
 [beta installation guide](beta-installation.md) for direct binary installation,
 supported platforms, and the exact verification procedure. Persistence and
 authentication generators remain preview surfaces during this beta, so migrate
@@ -73,7 +73,7 @@ dependencies:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.1
+    version: 2.0.0-beta.2
   # No redis dependency needed for default configuration
 ```
 
@@ -337,7 +337,7 @@ dependencies:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.1
+    version: 2.0.0-beta.2
   pg:
     github: will/crystal-pg
   granite:
@@ -488,7 +488,7 @@ Review your session configuration and update as needed.
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.1
+    version: 2.0.0-beta.2
 ```
 
 ### Add to shard.yml (as needed)
@@ -506,7 +506,7 @@ dependencies:
 ## Migration Checklist
 
 - [ ] Install Amber CLI 2.0.2 or newer from `amberframework/amber_cli`
-- [ ] Update `shard.yml` to point to `amberframework/amber` at `2.0.0-beta.1` and remove bundled dependencies
+- [ ] Update `shard.yml` to point to `amberframework/amber` at `2.0.0-beta.2` and remove bundled dependencies
 - [ ] Run `shards install`
 - [ ] Replace `YAML.mapping` with `YAML::Serializable` in all custom types
 - [ ] Rename all `.slang` templates to `.ecr` and convert syntax

--- a/scripts/check_beta_contract.sh
+++ b/scripts/check_beta_contract.sh
@@ -3,13 +3,21 @@ set -euo pipefail
 
 shard_version="$(awk '/^version:/ { print $2; exit }' shard.yml)"
 source_version="$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' src/amber/version.cr)"
-test "$shard_version" = "2.0.0-beta.1"
+test "$shard_version" = "2.0.0-beta.2"
 test "$source_version" = "$shard_version"
 
-files=(README.md docs/README.md docs/getting-started.md docs/beta-installation.md docs/migration-guide.md RELEASE_NOTES_V2_BETA1.md)
+files=(README.md docs/README.md docs/getting-started.md docs/beta-installation.md docs/migration-guide.md RELEASE_NOTES_V2_BETA2.md)
 grep -F 'brew tap amberframework/amber_cli' docs/beta-installation.md
 grep -F 'brew install amber_cli' docs/beta-installation.md
-grep -F 'version: 2.0.0-beta.1' docs/getting-started.md
+grep -F 'version: 2.0.0-beta.2' docs/getting-started.md
+if grep -R -F 'Process.fork' src; then
+  echo "Amber V2 must compile with Crystal's default multithreaded runtime" >&2
+  exit 1
+fi
+
+# Type-check the public server entry point without starting a listener. The
+# runtime condition keeps the call reachable to the compiler.
+crystal eval 'require "./src/amber"; Amber::Server.start if ENV["AMBER_COMPILE_SERVER"]?'
 
 if grep -Ein 'crimson-knight/(amber|grant|gemma)|amberframework/amber-cli|brew install amber-cli|branch: v2-dev' "${files[@]}"; then
   echo "Amber beta docs contain a stale install or dependency instruction" >&2

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: amber
 
-version: 2.0.0-beta.1
+version: 2.0.0-beta.2
 
 authors:
   - Amber Team and Contributors <amberframework.org>

--- a/src/amber/server/cluster.cr
+++ b/src/amber/server/cluster.cr
@@ -12,7 +12,13 @@ module Amber
     end
 
     def self.fork
-      Process.fork { Process.run(PROGRAM_NAME, nil, env_hash, true, false, input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit) }
+      Process.new(
+        PROGRAM_NAME,
+        env: env_hash,
+        input: Process::Redirect::Inherit,
+        output: Process::Redirect::Inherit,
+        error: Process::Redirect::Inherit
+      )
     end
 
     def self.master?

--- a/src/amber/version.cr
+++ b/src/amber/version.cr
@@ -1,3 +1,3 @@
 module Amber
-  VERSION = "2.0.0-beta.1"
+  VERSION = "2.0.0-beta.2"
 end


### PR DESCRIPTION
## Summary
- replace the cluster launcher Process.fork reference with portable process spawning
- bump the framework prerelease to 2.0.0-beta.2 and update the public beta docs
- add a CI contract that type-checks Amber::Server.start under the default runtime

## Why
Crystal 1.21 enables multithreading by default and rejects Process.fork at compile time. The CLI release smoke caught this after beta.1 became resolvable. beta.1 remains immutable; beta.2 supersedes it for new applications.

## Validation
- Crystal 1.21: Amber::Server.start compile smoke
- Crystal 1.21: 2,320 specs, 0 failures
- Crystal 1.21 formatting check
- Crystal 1.20 compile contract
- beta documentation contract