### PR TITLE
Document formula-scoped Homebrew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ Read Amber documentation on https://docs.amberframework.org/amber
 Install the standalone CLI with Homebrew on macOS or Linux:
 
 ```bash
-brew tap amberframework/amber_cli
-brew install amber_cli
+brew install amberframework/amber_cli/amber_cli
 amber --version
 ```
 

--- a/RELEASE_NOTES_V2_BETA1.md
+++ b/RELEASE_NOTES_V2_BETA1.md
@@ -11,8 +11,7 @@ it for production workloads that cannot tolerate them.
 Install Amber CLI 2.0.2 or newer:
 
 ```bash
-brew tap amberframework/amber_cli
-brew install amber_cli
+brew install amberframework/amber_cli/amber_cli
 amber new my_app --type web
 cd my_app
 crystal spec

--- a/RELEASE_NOTES_V2_BETA2.md
+++ b/RELEASE_NOTES_V2_BETA2.md
@@ -17,8 +17,7 @@ It keeps the same public beta surface and fixes application startup on Crystal
 Install Amber CLI 2.0.2 or newer:
 
 ```bash
-brew tap amberframework/amber_cli
-brew install amber_cli
+brew install amberframework/amber_cli/amber_cli
 amber new my_app --type web
 cd my_app
 crystal spec

--- a/docs/beta-installation.md
+++ b/docs/beta-installation.md
@@ -35,10 +35,12 @@ git --version
 The tap name contains an underscore:
 
 ```bash
-brew tap amberframework/amber_cli
-brew install amber_cli
+brew install amberframework/amber_cli/amber_cli
 amber --version
 ```
+
+The fully qualified command follows Homebrew's tap-trust model and trusts only
+the `amber_cli` formula. The installed executables are `amber` and `amber-lsp`.
 
 The expected CLI version is `2.0.2` or newer. If another executable is found,
 run `command -v amber` and use the troubleshooting section below.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -36,8 +36,7 @@ amber routes
 **After (V2 beta):**
 
 ```bash
-brew tap amberframework/amber_cli
-brew install amber_cli
+brew install amberframework/amber_cli/amber_cli
 amber new my_app --type web
 cd my_app
 shards install

--- a/scripts/check_beta_contract.sh
+++ b/scripts/check_beta_contract.sh
@@ -7,8 +7,7 @@ test "$shard_version" = "2.0.0-beta.2"
 test "$source_version" = "$shard_version"
 
 files=(README.md docs/README.md docs/getting-started.md docs/beta-installation.md docs/migration-guide.md RELEASE_NOTES_V2_BETA2.md)
-grep -F 'brew tap amberframework/amber_cli' docs/beta-installation.md
-grep -F 'brew install amber_cli' docs/beta-installation.md
+grep -F 'brew install amberframework/amber_cli/amber_cli' docs/beta-installation.md
 grep -F 'version: 2.0.0-beta.2' docs/getting-started.md
 if grep -R -F 'Process.fork' src; then
   echo "Amber V2 must compile with Crystal's default multithreaded runtime" >&2
@@ -19,7 +18,7 @@ fi
 # runtime condition keeps the call reachable to the compiler.
 crystal eval 'require "./src/amber"; Amber::Server.start if ENV["AMBER_COMPILE_SERVER"]?'
 
-if grep -Ein 'crimson-knight/(amber|grant|gemma)|amberframework/amber-cli|brew install amber-cli|branch: v2-dev' "${files[@]}"; then
+if grep -Ein 'crimson-knight/(amber|grant|gemma)|amberframework/amber-cli|brew tap amberframework/amber_cli|brew install amber-cli|brew install amber_cli|branch: v2-dev' "${files[@]}"; then
   echo "Amber beta docs contain a stale install or dependency instruction" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- use `brew install amberframework/amber_cli/amber_cli` throughout beta onboarding and release notes
- explain that the fully qualified command trusts only the Amber CLI formula
- harden the beta docs contract against incomplete untrusted-tap instructions

## Why
Current Homebrew requires explicit trust for third-party taps. The fully qualified install is Homebrew’s documented narrow-trust path and was validated by the 2.0.2 release install gate.

## Validation
- framework beta contract passes, including server-entry compile smoke
- documentation contract rejects the former two-command path