### PR TITLE
Link the released Amber v2 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ Our Philosophy? [Read Amber Philosophy H.R.T.](.github/AMBER_PHILOSOPHY.md)
 
 ## Documentation
 
-Read Amber documentation on https://docs.amberframework.org/amber
+Read the [Amber V2 beta documentation](https://amberframework.org/docs/v2),
+including the published installation, CLI, support-matrix, and migration guides.
+The [Amber 1.4.1 documentation](https://amberframework.org/docs/v1.4.1) remains
+available for the stable V1 release.
 
 ## Benchmarks
 

--- a/scripts/check_beta_contract.sh
+++ b/scripts/check_beta_contract.sh
@@ -18,7 +18,7 @@ fi
 # runtime condition keeps the call reachable to the compiler.
 crystal eval 'require "./src/amber"; Amber::Server.start if ENV["AMBER_COMPILE_SERVER"]?'
 
-if grep -Ein 'crimson-knight/(amber|grant|gemma)|amberframework/amber-cli|brew tap amberframework/amber_cli|brew install amber-cli|brew install amber_cli|branch: v2-dev' "${files[@]}"; then
+if grep -Ein 'crimson-knight/(amber|grant|gemma)|amberframework/amber-cli|brew tap amberframework/amber_cli|brew install amber-cli|brew install amber_cli|branch: v2-dev|docs\.amberframework\.org/amber' "${files[@]}"; then
   echo "Amber beta docs contain a stale install or dependency instruction" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Point the v2-dev README at the published Amber v2 beta documentation.
- Keep the stable Amber 1.4.1 documentation explicitly available.
- Extend the beta contract check so the retired docs host cannot return to release-facing files.

## Validation

- `CRYSTAL_CACHE_DIR=/tmp/amber_beta_framework_cache bash scripts/check_beta_contract.sh`
- `git diff --check`

## Release impact

This makes the repository landing page consistent with the already published `2.0.0-beta.2` documentation and support matrix.
