### PR TITLE
Support Crystal 1.21: replace Process.fork with process spawn, bump ameba

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -81,4 +81,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5.0
+    version: 1.7.0-dev

--- a/src/amber/cli/templates/app/shard.yml.ecr
+++ b/src/amber/cli/templates/app/shard.yml.ecr
@@ -54,4 +54,4 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.5.0
+    version: 1.7.0-dev

--- a/src/amber/server/cluster.cr
+++ b/src/amber/server/cluster.cr
@@ -12,7 +12,13 @@ module Amber
     end
 
     def self.fork
-      Process.fork { Process.run(PROGRAM_NAME, nil, env_hash, true, false, input: Process::Redirect::Inherit, output: Process::Redirect::Inherit, error: Process::Redirect::Inherit) }
+      Process.new(
+        PROGRAM_NAME,
+        env: env_hash,
+        input: Process::Redirect::Inherit,
+        output: Process::Redirect::Inherit,
+        error: Process::Redirect::Inherit
+      )
     end
 
     def self.master?


### PR DESCRIPTION
### Description of the Change

Crystal 1.21 is multithreaded by default, and `Process.fork` now fails at **compile time** (`Error: Process fork is unsupported with multithreaded mode`). Because `Cluster.fork` is reachable from `Amber::Server#run`, this broke compilation of **every** Amber v1 app on Crystal 1.21.0+.

This PR:
- Replaces the `Process.fork { Process.run(...) }` pattern in `Amber::Cluster.fork` with a direct `Process.new` spawn of the current binary — the same approach already used on `v2-dev`. Master/worker semantics are preserved via the `FORKED` env var.
- Pins ameba to `1.7.0-dev` (the first tag containing crystal-ameba/ameba#823, the Crystal 1.21 support fix) in both the framework's dev dependencies and the generated app template. ameba <= 1.6.4 fails its postinstall build on 1.21, which broke `shards install` for new apps. Supersedes the unpinned-`master` approach of #1394.

### Verification (Crystal 1.21.0, macOS arm64)

- `crystal spec`: **466 examples, 0 failures**
- `amber new testapp -d sqlite -t ecr` → `shards install` → `crystal build`: succeeds
- Generated app boots and serves HTTP 200
- Cluster mode (`process_count: 2`): master + 2 workers spawn, serve, and shut down cleanly

### Possible Drawbacks

`1.7.0-dev` is a prerelease tag; once ameba tags a stable 1.7.0 the pin should move to `~> 1.7.0`.

### References

- crystal-ameba/ameba#823
- #1394