### PR TITLE
Fix controller-relative ECR paths on Windows

### DIFF
--- a/spec/amber/controller/render_spec.cr
+++ b/spec/amber/controller/render_spec.cr
@@ -13,6 +13,10 @@ module Amber::Controller
         RenderController.new(context).render_template_page.should eq page_template
       end
 
+      it "renders a controller-relative template from a Windows source path" do
+        RenderController.new(context).render_template_from_windows_controller_path.should eq page_template
+      end
+
       it "renders partial without layout" do
         RenderController.new(context).render_partial.should eq partial_only
       end

--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -89,6 +89,15 @@ class RenderController < Amber::Controller::Base
     render(path: "spec/support/sample/views", template: "test/test.ecr", layout: false)
   end
 
+  def render_template_from_windows_controller_path
+    render(
+      path: "spec/support/sample/views",
+      template: "test.ecr",
+      layout: false,
+      folder: "C:\\app\\src\\controllers\\test_controller.cr"
+    )
+  end
+
   def render_partial
     render(path: "spec/support/sample/views", partial: "test/_test.ecr")
   end

--- a/src/amber/controller/helpers/render.cr
+++ b/src/amber/controller/helpers/render.cr
@@ -13,7 +13,10 @@ module Amber::Controller::Helpers
       {% if filename.id.split("/").size > 1 %}
         %content = render_template("#{{{filename}}}", {{path}})
       {% else %}
-        {{ short_path = folder.gsub(/^.+?(?:controllers|views)\//, "") }}
+        # Compiler paths use the host platform's separator. Normalize before
+        # deriving a view folder so generated controllers compile on Windows.
+        {{ normalized_folder = folder.gsub(/\\/, "/") }}
+        {{ short_path = normalized_folder.gsub(/^.+?(?:controllers|views)\//, "") }}
         {% if folder.id.ends_with?(".ecr") %}
           %content = render_template("#{{{short_path.gsub(/\/[^\.\/]+\.ecr/, "")}}}/#{{{filename}}}", {{path}})
         {% else %}


### PR DESCRIPTION
## Summary

- normalize compiler source paths before deriving controller-relative view folders
- add a regression fixture using a Windows controller path
- keep Unix view resolution unchanged

## Evidence

- `crystal spec spec/amber/controller/render_spec.cr`: 7 examples, 0 failures
- full `crystal spec`: 2,321 examples, 0 failures
- discovered by the Amber CLI generated-web-app Windows CI job after Crystal, the CLI, generation, dependency installation, and request specs succeeded
- Amber CLI Windows x86_64 job now passes end to end with this exact commit, including the native application compile: https://github.com/amberframework/amber_cli/actions/runs/31490420518/job/93775339629

## Release boundary

Windows is not a beta release gate. The candidate fix is proven in CI, but Amber 2.0.0-beta.2 does not contain it; released Windows support should be claimed only after a later framework beta ships and passes the same generated-app job.
