### PR TITLE
Document machine-readable responses and repair job scheduling

### DIFF
--- a/docs/guides/action-helpers.md
+++ b/docs/guides/action-helpers.md
@@ -4,6 +4,47 @@ Amber V2 includes a comprehensive set of view helpers that are available in all 
 
 All helpers are included automatically via `Amber::Controller::Base`.
 
+## Content negotiation with `respond_with`
+
+**File: `src/controllers/articles_controller.cr` — put the response block in
+the controller action that owns the resource.**
+
+```crystal
+class ArticlesController < ApplicationController
+  def show
+    article = Article.find!(params[:id])
+
+    respond_with do
+      html render("show.ecr")
+      json article.to_json
+      markdown "# #{article.title}\n\n#{article.body}"
+    end
+  end
+end
+```
+
+**File: `src/views/articles/show.ecr` — put only the HTML representation in
+the ECR template.**
+
+```ecr
+<article>
+  <h1><%= article.title %></h1>
+  <%= article.body %>
+</article>
+```
+
+Register `/articles/:id` in `config/routes.cr`. Amber chooses a declared
+representation from the URL extension (`.json` or `.md`) or the request's
+`Accept` header. `markdown` and its short alias `md` return
+`text/markdown; charset=utf-8`; `json` returns
+`application/json; charset=utf-8`. A requested format that the action did not
+declare receives `406 Response Not Acceptable`.
+
+Keep format-specific rendering close to its normal source: ECR in `src/views/`,
+short JSON or Markdown serialization in the controller, and reusable document
+builders in `src/services/`. Do not copy an entire ECR page into a controller
+string.
+
 ## FormHelpers
 
 Generate HTML form elements with automatic CSRF token inclusion and method override support.

--- a/docs/guides/background-jobs.md
+++ b/docs/guides/background-jobs.md
@@ -4,6 +4,11 @@ Amber::Jobs provides in-process background job processing for tasks that should 
 
 ## Quick Start
 
+The paths below are relative to the application root—the directory containing
+`shard.yml`.
+
+**File: `src/jobs/send_welcome_email.cr` — create this file.**
+
 ```crystal
 # Define a job
 class SendWelcomeEmail < Amber::Jobs::Job
@@ -25,7 +30,20 @@ end
 
 # Register the job class (required for deserialization)
 Amber::Jobs.register(SendWelcomeEmail)
+```
 
+**File: `src/my_app.cr` — require all jobs before `config/routes`. Replace
+`my_app` with the generated application filename.**
+
+```crystal
+require "./jobs/**"
+require "../config/routes"
+```
+
+**File: `src/controllers/users_controller.cr` — enqueue after the user has
+been validated and saved.**
+
+```crystal
 # Enqueue a job
 SendWelcomeEmail.new(user_id: 42_i64).enqueue
 ```
@@ -60,6 +78,9 @@ Amber::Jobs.register(SendWelcomeEmail)
 ```
 
 Registration is typically done at application startup, before any jobs are enqueued or workers are started.
+The `require "./jobs/**"` entry in `src/my_app.cr` is the normal application
+placement; the registration line stays beside the job class so it cannot be
+loaded without registering its deserializer and retry policy.
 
 ### Customizing Queue and Retry Behavior
 
@@ -209,7 +230,16 @@ Amber::Jobs.configure do |config|
 end
 ```
 
-The work-stealing worker monitors `Worker.pending_request_count` (a class-level atomic counter) and only dequeues jobs when this count is zero.
+The work-stealing worker monitors `Worker.pending_request_count` behind a mutex
+and only dequeues jobs when this count is zero. Ordinary HTTP requests are
+counted by Amber's outer request pipeline and decremented in an `ensure` block.
+Upgraded WebSocket connections are excluded after the handshake, so persistent
+connections do not leave the server permanently non-idle.
+
+This signal means “no request handler is active”; it is not CPU or memory
+telemetry. A job that has started is not preempted if a request arrives. Measure
+job duration and request tail latency before enabling this on a production web
+process.
 
 ## Scheduler
 
@@ -234,6 +264,13 @@ The built-in `MemoryQueueAdapter` stores jobs in memory using Mutex-protected da
 Suitable for: development, testing, and single-instance applications.
 
 Limitations: job data is lost when the application restarts.
+
+The memory adapter is process-local and unbounded: Amber does not impose queue,
+payload, completed-history, or dead-history memory caps. It cannot share work
+between application processes. Use it for development, tests, and deliberately
+small single-process deployments where lost jobs and application-memory growth
+are acceptable. A durable adapter must define its own payload-size, queue-size,
+retention, timeout, and retry limits.
 
 ### Writing a Custom Adapter
 

--- a/spec/amber/controller/respond_with_spec.cr
+++ b/spec/amber/controller/respond_with_spec.cr
@@ -79,6 +79,23 @@ module Amber::Controller
           context.response.status_code.should eq 200
         end
 
+        it "responds with markdown from the Accept header" do
+          context.response.status_code = 200
+          context.request.headers["Accept"] = "text/markdown"
+          expected_result = "# Amber\n"
+          ResponsesController.new(context).markdown_response.should eq expected_result
+          context.response.headers["Content-Type"].should eq "text/markdown; charset=utf-8"
+        end
+
+        it "responds with markdown for a .md path" do
+          context.response.status_code = 200
+          context.request.headers["Accept"] = ""
+          context.request.path = "/response/1.md"
+          expected_result = "# Amber\n"
+          ResponsesController.new(context).markdown_response.should eq expected_result
+          context.response.headers["Content-Type"].should eq "text/markdown; charset=utf-8"
+        end
+
         it "responds with json for path.json" do
           expected_result = %({"type":"json","name":"Amberator"})
           context.request.path = "/response/1.json"

--- a/spec/amber/jobs/worker_spec.cr
+++ b/spec/amber/jobs/worker_spec.cr
@@ -48,6 +48,10 @@ class FailingTestJob < Amber::Jobs::Job
   def self.max_retries : Int32
     2
   end
+
+  def self.retry_backoff(attempt : Int32) : Time::Span
+    (attempt * 17).seconds
+  end
 end
 
 Amber::Jobs.register(WorkerTestJob)
@@ -143,6 +147,20 @@ describe Amber::Jobs::Worker do
       adapter.scheduled_size.should eq(1)
     end
 
+    it "uses the registered job class's custom retry backoff" do
+      adapter = Amber::Jobs::MemoryQueueAdapter.new
+      Amber::Jobs.adapter = adapter
+      worker = Amber::Jobs::Worker.new(adapter: adapter)
+
+      before = Time.utc
+      FailingTestJob.new(error_message: "custom backoff").enqueue
+      worker.process_next_job
+
+      scheduled = adapter.all_jobs.first
+      scheduled.attempts.should eq(1)
+      scheduled.scheduled_at.should be_close(before + 17.seconds, 1.second)
+    end
+
     it "marks jobs as dead when max retries are exceeded" do
       adapter = Amber::Jobs::MemoryQueueAdapter.new
       Amber::Jobs.adapter = adapter
@@ -169,6 +187,19 @@ describe Amber::Jobs::Worker do
   end
 
   describe "work stealing mode" do
+    it "tracks active requests without allowing the count to go negative" do
+      Amber::Jobs::Worker.pending_request_count = 0_i64
+
+      Amber::Jobs::Worker.begin_request
+      Amber::Jobs::Worker.server_idle?.should be_false
+      Amber::Jobs::Worker.pending_request_count.should eq(1_i64)
+
+      Amber::Jobs::Worker.end_request
+      Amber::Jobs::Worker.server_idle?.should be_true
+      Amber::Jobs::Worker.end_request
+      Amber::Jobs::Worker.pending_request_count.should eq(0_i64)
+    end
+
     it "skips processing when idle_only is true and requests are pending" do
       adapter = Amber::Jobs::MemoryQueueAdapter.new
       Amber::Jobs.adapter = adapter

--- a/spec/support/fixtures/controller_fixtures.cr
+++ b/spec/support/fixtures/controller_fixtures.cr
@@ -137,6 +137,13 @@ class ResponsesController < Amber::Controller::Base
     end
   end
 
+  def markdown_response
+    respond_with do
+      html { "<h1>Amber</h1>" }
+      markdown "# Amber\n"
+    end
+  end
+
   def custom_status_code
     respond_with(403) do
       json type: "json", error: "Unauthorized"

--- a/src/amber/controller/helpers/responders.cr
+++ b/src/amber/controller/helpers/responders.cr
@@ -6,12 +6,14 @@ module Amber::Controller::Helpers
 
     class Content
       TYPE = {
-        html: "text/html",
-        json: "application/json; charset=utf-8",
-        txt:  "text/plain",
-        text: "text/plain",
-        xml:  "application/xml",
-        js:   "text/javascript",
+        html:     "text/html",
+        json:     "application/json; charset=utf-8",
+        txt:      "text/plain",
+        text:     "text/plain",
+        xml:      "application/xml",
+        js:       "text/javascript",
+        md:       "text/markdown; charset=utf-8",
+        markdown: "text/markdown; charset=utf-8",
       }
 
       TYPE_EXT_REGEX         = /\.(#{TYPE.keys.join("|")})$/
@@ -25,7 +27,7 @@ module Amber::Controller::Helpers
       def initialize(@requested_responses)
       end
 
-      {% for type in %w(html xml js json text) %}
+      {% for type in %w(html xml js json text markdown) %}
         def {{type.id}}(value : String | ProcType)
           @available_responses[TYPE[:{{type.id}}]] = value
           self
@@ -35,6 +37,15 @@ module Amber::Controller::Helpers
           {{type.id}}(block)
         end
       {% end %}
+
+      # Short alias for Markdown response blocks.
+      def md(value : String | ProcType)
+        markdown(value)
+      end
+
+      def md(&block : -> _)
+        markdown(block)
+      end
 
       def json(value : Hash(Symbol | String, String))
         json(value.to_json)
@@ -66,15 +77,13 @@ module Amber::Controller::Helpers
           @requested_responses << @available_responses.keys.first
         end
 
-        result = @requested_responses.find do |resp|
-          @available_responses.keys.find { |r| r.includes?(resp) }
+        @requested_responses.each do |requested_type|
+          if available_type = @available_responses.keys.find { |candidate| candidate.includes?(requested_type) }
+            return available_type
+          end
         end
 
-        if result == "application/json"
-          result = "application/json; charset=utf-8"
-        end
-
-        result
+        nil
       end
     end
 

--- a/src/amber/jobs.cr
+++ b/src/amber/jobs.cr
@@ -13,6 +13,10 @@ module Amber::Jobs
   # Jobs register themselves using the `Amber::Jobs.register` macro.
   @@job_registry = Hash(String, Proc(String, Job)).new
 
+  # Retry policies are registered beside deserializers so a worker can honor
+  # the concrete job class's `retry_backoff` after reading an envelope.
+  @@retry_backoff_registry = Hash(String, Proc(Int32, Time::Span)).new
+
   # The singleton queue adapter instance.
   @@adapter : QueueAdapter?
 
@@ -64,12 +68,31 @@ module Amber::Jobs
     Amber::Jobs.register_job({{job_class.stringify}}) do |payload|
       {{job_class}}.from_json(payload).as(Amber::Jobs::Job)
     end
+
+    Amber::Jobs.register_retry_backoff({{job_class.stringify}}) do |attempt|
+      {{job_class}}.retry_backoff(attempt)
+    end
   end
 
   # Registers a job class with a deserialization proc.
   # This is the runtime method called by the `register` macro.
   def self.register_job(class_name : String, &block : String -> Job)
     @@job_registry[class_name] = block
+  end
+
+  # Registers the retry policy for a job class. This is called by `register`.
+  def self.register_retry_backoff(class_name : String, &block : Int32 -> Time::Span)
+    @@retry_backoff_registry[class_name] = block
+  end
+
+  # Returns a registered job's retry delay, or Amber's exponential default
+  # when an older/manual registry entry did not register a policy.
+  def self.retry_backoff(class_name : String, attempt : Int32) : Time::Span
+    if policy = @@retry_backoff_registry[class_name]?
+      policy.call(attempt)
+    else
+      (2 ** attempt).seconds
+    end
   end
 
   # Deserializes a job from its class name and JSON payload.
@@ -143,6 +166,7 @@ module Amber::Jobs
     @@adapter = nil
     @@configuration = nil
     @@job_registry.clear
+    @@retry_backoff_registry.clear
   end
 
   # Creates the appropriate adapter based on the current configuration.

--- a/src/amber/jobs/worker.cr
+++ b/src/amber/jobs/worker.cr
@@ -39,6 +39,29 @@ module Amber::Jobs
     class_property pending_request_count : Int64 = 0_i64
     class_property pending_request_mutex : Mutex = Mutex.new
 
+    # Records one active HTTP request for idle-only workers. WebSocket
+    # connections are intentionally excluded after their HTTP upgrade so a
+    # long-lived socket does not make the server look permanently busy.
+    def self.begin_request : Nil
+      @@pending_request_mutex.synchronize do
+        @@pending_request_count += 1
+      end
+    end
+
+    # Releases one active HTTP request and guards against a negative counter
+    # if an application handler exits through an exception.
+    def self.end_request : Nil
+      @@pending_request_mutex.synchronize do
+        @@pending_request_count = Math.max(0_i64, @@pending_request_count - 1)
+      end
+    end
+
+    def self.server_idle? : Bool
+      @@pending_request_mutex.synchronize do
+        @@pending_request_count == 0
+      end
+    end
+
     def initialize(
       @adapter : QueueAdapter,
       @list_of_queues : Array(String) = ["default"],
@@ -155,15 +178,12 @@ module Amber::Jobs
     # Attempts to use the job class's custom backoff strategy if available,
     # falling back to the default exponential backoff (2^attempts seconds).
     private def calculate_backoff(envelope : JobEnvelope) : Time::Span
-      # Default exponential backoff: 2^attempts seconds
-      (2 ** envelope.attempts).seconds
+      Amber::Jobs.retry_backoff(envelope.job_class, envelope.attempts)
     end
 
     # Returns true if the HTTP server has no pending requests.
     private def is_server_idle? : Bool
-      @@pending_request_mutex.synchronize do
-        @@pending_request_count <= 0
-      end
+      self.class.server_idle?
     end
   end
 end

--- a/src/amber/pipes/pipeline.cr
+++ b/src/amber/pipes/pipeline.cr
@@ -13,6 +13,9 @@ module Amber
       end
 
       def call(context : HTTP::Server::Context)
+        track_pending_request = !context.websocket?
+        Amber::Jobs::Worker.begin_request if track_pending_request
+
         raise Amber::Exceptions::RouteNotFound.new(context.request) unless context.valid_route?
 
         # Check request-level constraint if the matched route has one
@@ -32,6 +35,8 @@ module Amber
         end
       rescue e : Amber::Exceptions::Base
         Amber::Pipe::Error.new.call(context)
+      ensure
+        Amber::Jobs::Worker.end_request if track_pending_request
       end
 
       # Connects pipes to a pipeline to process requests


### PR DESCRIPTION
## What changed

- adds `md` / `markdown` response helpers and keeps the canonical emitted media type during negotiation
- documents exact application file placement for response formats and background jobs
- makes custom job retry backoff policies actually run after deserialization
- connects idle-only job workers to Amber's live HTTP request count while excluding upgraded WebSockets
- documents strict queue ordering, the unbounded process-local memory adapter, work-stealing limits, and channel broadcasts after jobs complete

## Why

The public V2 guides need to describe behavior that the framework actually implements. The retry hook was documented but ignored, and work stealing had a request counter that the request pipeline never updated.

## Developer impact

Applications can return Markdown through `respond_with`, custom retry schedules are honored, and idle-only workers now use a real request-activity signal. Existing queue and response behavior remains the default.

## Validation

- focused responder, worker, and pipeline specs: 46 examples, 0 failures
- complete Amber V2 suite: 2,324 examples, 0 failures
- Crystal 1.21.0
