### PR TITLE
Prepare Amber 2.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.0-beta.3 (2026-08-11)
+
+This release completes the framework side of the database-backed default web
+application introduced by Amber CLI 2.0.4.
+
+- Parse URL-encoded and multipart form bodies in schema controllers, including
+  requests whose bodies were already read by routing or CSRF protection.
+- Repair background-job work stealing so idle workers can claim queued work
+  without corrupting the request activity count.
+- Normalize rendered view paths on Windows.
+- Document `respond_with` HTML and JSON negotiation with executable examples.
+
 ## 2.0.0-beta.2 (2026-07-31)
 
 This release supersedes beta.1 for the supported Amber CLI web-app path.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _Amber makes building web applications fast, simple, and enjoyable - with fewer 
 
 # Welcome! Introducing Amber
 
-**Amber 2.0.0-beta.2 is available for testing.** It is a pre-release: use it
+**Amber 2.0.0-beta.3 is available for testing.** It is a pre-release: use it
 for evaluation and new projects that can tolerate breaking changes, not for
 production workloads. The supported beta path is an ECR web application
 created by the standalone [Amber CLI](https://github.com/amberframework/amber_cli).
@@ -40,11 +40,13 @@ The goal for V2 is to cover every aspect of a modern web application. Here is wh
 **In the wider V2 ecosystem:**
 
 6. CLI with generators, dev workflow, and an LSP server - [amberframework/amber_cli](https://github.com/amberframework/amber_cli)
-7. Persistence, authentication, and native-app generators are preview surfaces. They are not part of the supported beta web-app path yet.
+7. Database-backed web applications use Grant, SQLite, and Micrate through the
+   standalone CLI's supported default template and resource generators.
+8. Authentication and native-app generators remain preview surfaces.
 
 **On the roadmap (not built yet):**
 
-8. Cloud file storage, users & authentication, audit logging, API documentation generation, reactive views, MCP, and SBOM tooling
+9. Cloud file storage, users & authentication, audit logging, API documentation generation, reactive views, MCP, and SBOM tooling
 
 
 ## How Amber Is Embracing AI
@@ -110,6 +112,8 @@ Create and verify a web application:
 amber new my_app --type web
 cd my_app
 shards install
+amber generate scaffold Pet name:string:required species:string:required
+amber database migrate
 crystal spec
 amber watch
 ```
@@ -120,7 +124,7 @@ The generated `shard.yml` pins this framework beta:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.2
+    version: 2.0.0-beta.3
 ```
 
 [Read the complete beta installation guide](docs/beta-installation.md),

--- a/RELEASE_NOTES_V2_BETA3.md
+++ b/RELEASE_NOTES_V2_BETA3.md
@@ -1,0 +1,45 @@
+# Amber 2.0.0-beta.3
+
+Amber 2.0.0-beta.3 is the framework release for the database-backed web
+application that Amber CLI 2.0.4 generates by default. The supported path now
+includes Grant models, SQLite, Micrate migrations, and complete HTML resource
+scaffolds instead of stopping at a database-free homepage.
+
+## What changed
+
+- Schema controllers parse browser form bodies, including bodies already read
+  by routing or CSRF protection.
+- Background-job workers can steal queued work without corrupting request
+  activity accounting.
+- ECR view paths are normalized on Windows.
+- The HTML/JSON `respond_with` behavior is documented with executable examples.
+
+## Install and exercise persistence
+
+Install Amber CLI 2.0.4, then generate and migrate a real resource:
+
+```bash
+brew install amberframework/amber_cli/amber_cli
+amber new pet_tracker --type web
+cd pet_tracker
+shards install
+amber generate scaffold Pet name:string:required species:string:required adopted:bool
+amber database migrate
+crystal spec
+amber watch
+```
+
+Open <http://localhost:3000/pets>. The generated model lives at
+`src/models/pet.cr`, its SQL migration is under `db/migrations/`, and its ECR
+form partial is `src/views/pet/_form.ecr`.
+
+Apple Silicon macOS and x86_64 Linux have CLI release archives. Linux ARM64 and
+Windows x86_64 generated web applications are compile-gated in CI; their CLI
+binaries are built from source for this beta.
+
+See the [beta installation guide](https://github.com/amberframework/amber/blob/v2.0.0-beta.3/docs/beta-installation.md)
+and [V1 to V2 migration guide](https://github.com/amberframework/amber/blob/v2.0.0-beta.3/docs/migration-guide.md).
+
+Please report framework issues at
+<https://github.com/amberframework/amber/issues> and CLI/template/install issues
+at <https://github.com/amberframework/amber_cli/issues>.

--- a/docs/beta-installation.md
+++ b/docs/beta-installation.md
@@ -1,6 +1,6 @@
 # Amber V2 Beta Installation and Support
 
-This is the release contract for Amber `2.0.0-beta.2` and Amber CLI `2.0.2`.
+This is the release contract for Amber `2.0.0-beta.3` and Amber CLI `2.0.4`.
 The goal is a repeatable first run, not a promise that every experimental
 generator is production-ready.
 
@@ -10,13 +10,16 @@ generator is production-ready.
 |---|---|
 | macOS on Apple Silicon | Supported and release-gated |
 | Linux on x86_64 | Supported and release-gated |
-| Homebrew installation on those platforms | Supported |
-| Direct release archive on those platforms | Supported |
+| Linux on ARM64 | Generated web app is compile-gated in CI |
+| Windows on x86_64 | Generated web app, migrations, specs, and build are release-gated in CI |
+| Homebrew on Apple Silicon macOS and x86_64 Linux | Supported |
+| Release archives for Apple Silicon macOS and x86_64 Linux | Supported |
 | `amber new APP --type web` with ECR | Supported |
-| Build, specs, server launch, homepage, and static assets | Release-gated |
-| Intel macOS, Linux ARM64, and Windows | Not release-gated in this beta |
+| Grant models, SQLite, Micrate migrations, and resource scaffolds | Supported |
+| Build, specs, server launch, homepage, static assets, and database CRUD | Release-gated |
+| Intel macOS | Not release-gated in this beta |
 | Native application template | Preview |
-| Persistence, auth, and resource generators | Preview |
+| Authentication generators | Preview |
 
 ## Prerequisites
 
@@ -42,7 +45,7 @@ amber --version
 The fully qualified command follows Homebrew's tap-trust model and trusts only
 the `amber_cli` formula. The installed executables are `amber` and `amber-lsp`.
 
-The expected CLI version is `2.0.2` or newer. If another executable is found,
+The expected CLI version is `2.0.4` or newer. If another executable is found,
 run `command -v amber` and use the troubleshooting section below.
 
 ## Install a release archive
@@ -52,11 +55,11 @@ Choose the archive that matches the supported machine:
 - Apple Silicon macOS: `amber_cli-darwin-arm64.tar.gz`
 - x86_64 Linux: `amber_cli-linux-x86_64.tar.gz`
 
-The following example installs CLI `v2.0.2`. On Linux, replace the two
+The following example installs CLI `v2.0.4`. On Linux, replace the two
 `darwin-arm64` occurrences with `linux-x86_64`.
 
 ```bash
-version=v2.0.2
+version=v2.0.4
 asset=amber_cli-darwin-arm64.tar.gz
 curl -fLO "https://github.com/amberframework/amber_cli/releases/download/${version}/${asset}"
 curl -fLO "https://github.com/amberframework/amber_cli/releases/download/${version}/${asset}.sha256"
@@ -70,6 +73,35 @@ Linux users may use `sha256sum -c` instead of `shasum -a 256 -c`. If
 `/usr/local/bin` requires elevated privileges, prefix only the `install`
 command with `sudo`.
 
+## Build the CLI on Linux ARM64 or Windows
+
+Linux ARM64 and Windows web applications are compile-gated even though CLI
+release archives are not published for them yet. Clone the CLI and install its
+exact dependencies:
+
+```bash
+git clone https://github.com/amberframework/amber_cli.git
+cd amber_cli
+git checkout v2.0.4
+shards install
+```
+
+On Linux ARM64, build both executables:
+
+```bash
+crystal build src/amber_cli.cr -o amber --release
+crystal build src/amber_lsp.cr -o amber-lsp --release
+./amber --version
+```
+
+In PowerShell on Windows, build the CLI and verify it before adding its
+directory to `PATH`:
+
+```powershell
+crystal build src/amber_cli.cr -o amber.exe --release
+.\amber.exe --version
+```
+
 ## Verify the complete web-app path
 
 Use a new directory name, then run every command below:
@@ -78,6 +110,8 @@ Use a new directory name, then run every command below:
 amber new amber_beta_smoke --type web
 cd amber_beta_smoke
 shards install
+amber generate scaffold Pet name:string:required species:string:required adopted:bool
+amber database migrate
 crystal spec
 crystal build src/amber_beta_smoke.cr -o bin/amber_beta_smoke
 amber watch
@@ -91,7 +125,7 @@ curl --fail http://127.0.0.1:3000/css/app.css
 ```
 
 Both requests must succeed. The generated `shard.yml` must reference
-`amberframework/amber` at `2.0.0-beta.2`; it should not point at a personal
+`amberframework/amber` at `2.0.0-beta.3`; it should not point at a personal
 fork or a moving branch.
 
 ## Update or remove
@@ -138,16 +172,18 @@ libraries and must not require `openssl@1.1`. Include the output of
 
 ### The requested platform has no archive
 
-Only the two platforms in the support table are release-gated. Building from
-source can help contributors evaluate other platforms, but it is not an
-installation guarantee for this beta.
+Release archives are published for Apple Silicon macOS and x86_64 Linux.
+Linux ARM64 and Windows are application compile gates in CI, but do not yet
+have standalone CLI archives. Build the CLI from source on those systems while
+the packaging work is completed.
 
-### A preview generator needs another shard
+### An authentication or native preview needs another shard
 
-The minimal web template intentionally has no ORM, database driver, attachment
-library, or authentication shard. Do not add an unofficial or personal-fork
-dependency merely to make a preview generator compile. Follow that component's
-own release documentation or use the core web template until it is published.
+The default web template includes Grant and SQLite, while `amber database`
+provides Micrate migrations. Authentication, attachments, and native-app
+features are separate preview surfaces. Follow each component's release
+documentation instead of adding an unofficial dependency to make a preview
+generator compile.
 
 ## Report a beta problem
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,10 +5,10 @@ web app using ECR templates and the standalone Amber CLI.
 
 ## Prerequisites
 
-- macOS on Apple Silicon or Linux on x86_64
+- A platform and installation method listed in the beta support guide
 - Crystal 1.20 or newer (but earlier than Crystal 2.0)
 - Git and `shards`
-- Amber CLI 2.0.2 or newer
+- Amber CLI 2.0.4 or newer
 
 Follow the [beta installation guide](beta-installation.md) if `amber --version`
 does not work yet.
@@ -24,14 +24,16 @@ shards install
 `--type web` is explicit so the command remains reproducible as more app types
 are added. The generated application uses:
 
-- Amber `2.0.0-beta.2` from `amberframework/amber`
+- Amber `2.0.0-beta.3` from `amberframework/amber`
 - ECR templates
 - typed, sectioned environment configuration
 - a static-file pipeline for the generated CSS and JavaScript
-- no database or ORM dependency by default
+- Grant models with SQLite as the zero-configuration development database
+- Micrate-powered migrations through `amber database`
 
-Database selection records generator metadata; it does not add an ORM or a
-database driver to this minimal web template.
+Choose `--database pg` or `--database mysql` when creating the app if you need
+a server database. The generator writes the matching driver, connection, and
+environment configuration into the new project.
 
 ## Verify before you edit
 
@@ -73,6 +75,20 @@ get "/health", HomeController, :health
 
 Restart `amber watch` if needed and visit <http://localhost:3000/health>.
 
+## Add a database-backed resource
+
+Generate the model, migration, controller, schema, views, route, and specs:
+
+```bash
+amber generate scaffold Pet name:string:required species:string:required adopted:bool
+amber database migrate
+crystal spec
+```
+
+The model is written to `src/models/pet.cr`, its SQL migration to
+`db/migrations/`, and its form partial to `src/views/pet/_form.ecr`. Start the
+app and open <http://localhost:3000/pets>.
+
 ## Configuration
 
 Generated environment files use V2's typed structure:
@@ -109,7 +125,7 @@ branch:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.2
+    version: 2.0.0-beta.3
 
 crystal: ">= 1.20.0, < 2.0"
 ```
@@ -120,12 +136,10 @@ guides.
 
 ## Generator support during the beta
 
-The web application template itself is the release-gated path. Generators that
-depend only on Amber core can be evaluated inside it. Persistence,
-authentication, API-resource, and native-app generators are preview surfaces
-until their external dependencies and platform matrices are released and
-documented. See the CLI's generator support table before relying on one in a
-project.
+The web application template, Grant models, SQLite migrations, and resource
+scaffolds are release-gated together. Authentication, API-only resource, and
+native-app generators remain preview surfaces. See the CLI's generator support
+table before relying on a preview surface in a project.
 
 ## Next steps
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -501,10 +501,12 @@ dependencies:
   pg:
     github: will/crystal-pg
 
-  # ORM used by the Amber V2 default web template
-  grant:
-    github: crimson-knight/grant
 ```
+
+Do not copy a moving Grant branch into an existing application. Amber CLI
+2.0.4 writes the tested, immutable Grant revision into new web applications;
+use that generated manifest as the reference until Grant's coordinated release
+is published.
 
 ## Migration Checklist
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -44,11 +44,11 @@ crystal spec
 amber watch
 ```
 
-The generated project pins Amber `2.0.0-beta.2` and uses ECR. See the
+The generated project pins Amber `2.0.0-beta.3` and uses ECR. See the
 [beta installation guide](beta-installation.md) for direct binary installation,
-supported platforms, and the exact verification procedure. Persistence and
-authentication generators remain preview surfaces during this beta, so migrate
-those dependencies explicitly instead of assuming they are bundled.
+supported platforms, and the exact verification procedure. New web apps use
+Grant with SQLite and Micrate migrations by default. Authentication generators
+remain preview surfaces during this beta.
 
 ## 2. Redis No Longer a Direct Dependency
 
@@ -72,7 +72,7 @@ dependencies:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.2
+    version: 2.0.0-beta.3
   # No redis dependency needed for default configuration
 ```
 
@@ -321,6 +321,10 @@ The V1 `params["key"]` interface continues to work unchanged. The Schema API is 
 
 Amber V1 bundled `pg`, `mysql`, and `sqlite3` as direct dependencies. V2 does not. Add only the database driver you need to your application's shard.yml.
 
+Existing V1 applications can keep their current ORM while upgrading the
+framework. The example below keeps Granite deliberately; new CLI-generated V2
+applications use Grant instead.
+
 **Before (V1) -- shard.yml:**
 
 ```yaml
@@ -336,7 +340,7 @@ dependencies:
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.2
+    version: 2.0.0-beta.3
   pg:
     github: will/crystal-pg
   granite:
@@ -487,7 +491,7 @@ Review your session configuration and update as needed.
 dependencies:
   amber:
     github: amberframework/amber
-    version: 2.0.0-beta.2
+    version: 2.0.0-beta.3
 ```
 
 ### Add to shard.yml (as needed)
@@ -497,15 +501,15 @@ dependencies:
   pg:
     github: will/crystal-pg
 
-  # ORM - pick one
-  granite:
-    github: amberframework/granite
+  # ORM used by the Amber V2 default web template
+  grant:
+    github: crimson-knight/grant
 ```
 
 ## Migration Checklist
 
-- [ ] Install Amber CLI 2.0.2 or newer from `amberframework/amber_cli`
-- [ ] Update `shard.yml` to point to `amberframework/amber` at `2.0.0-beta.2` and remove bundled dependencies
+- [ ] Install Amber CLI 2.0.4 or newer from `amberframework/amber_cli`
+- [ ] Update `shard.yml` to point to `amberframework/amber` at `2.0.0-beta.3` and remove bundled dependencies
 - [ ] Run `shards install`
 - [ ] Replace `YAML.mapping` with `YAML::Serializable` in all custom types
 - [ ] Rename all `.slang` templates to `.ecr` and convert syntax

--- a/scripts/check_beta_contract.sh
+++ b/scripts/check_beta_contract.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 shard_version="$(awk '/^version:/ { print $2; exit }' shard.yml)"
 source_version="$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' src/amber/version.cr)"
-test "$shard_version" = "2.0.0-beta.2"
+test "$shard_version" = "2.0.0-beta.3"
 test "$source_version" = "$shard_version"
 
-files=(README.md docs/README.md docs/getting-started.md docs/beta-installation.md docs/migration-guide.md RELEASE_NOTES_V2_BETA2.md)
+files=(README.md docs/README.md docs/getting-started.md docs/beta-installation.md docs/migration-guide.md RELEASE_NOTES_V2_BETA3.md)
 grep -F 'brew install amberframework/amber_cli/amber_cli' docs/beta-installation.md
-grep -F 'version: 2.0.0-beta.2' docs/getting-started.md
+grep -F 'version: 2.0.0-beta.3' docs/getting-started.md
 if grep -R -F 'Process.fork' src; then
   echo "Amber V2 must compile with Crystal's default multithreaded runtime" >&2
   exit 1

--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: amber
 
-version: 2.0.0-beta.2
+version: 2.0.0-beta.3
 
 authors:
   - Amber Team and Contributors <amberframework.org>

--- a/src/amber/version.cr
+++ b/src/amber/version.cr
@@ -1,3 +1,3 @@
 module Amber
-  VERSION = "2.0.0-beta.2"
+  VERSION = "2.0.0-beta.3"
 end


### PR DESCRIPTION
Promotes the tested V2 framework state to beta.3, adds the release changelog, and aligns framework installation and migration documentation with Amber CLI 2.0.4 persistence defaults.\n\nValidation: 2,326 framework examples pass on Crystal 1.21; source formatting and version consistency checks pass.